### PR TITLE
feat: enhance FauxProvider with full context access and cache simulation

### DIFF
--- a/cubepi/providers/faux.py
+++ b/cubepi/providers/faux.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import math
 import time
@@ -22,8 +23,10 @@ from cubepi.providers.base import (
 
 FauxContentBlock = TextContent | ThinkingContent | ToolCall
 
+# New extended signature: (messages, model, system_prompt, tools)
+# Old signature (messages, model) is still supported for backward compatibility
 FauxResponseFactory = Callable[
-    [list[Message], Model],
+    ...,
     AssistantMessage | Awaitable[AssistantMessage],
 ]
 
@@ -87,6 +90,62 @@ def _split_by_token_size(text: str, min_size: int, max_size: int) -> list[str]:
     return chunks or [""]
 
 
+def _estimate_tokens(text: str) -> int:
+    """Estimate token count from text (approx 4 chars per token)."""
+    return max(1, math.ceil(len(text) / 4))
+
+
+def _common_prefix_length(a: str, b: str) -> int:
+    """Return the length of the common prefix between two strings."""
+    length = min(len(a), len(b))
+    index = 0
+    while index < length and a[index] == b[index]:
+        index += 1
+    return index
+
+
+def _serialize_prompt_context(
+    system_prompt: str,
+    tools: list[ToolDefinition] | None,
+    messages: list[Message],
+) -> str:
+    """Serialize prompt context for cache comparison (prefix-based)."""
+    parts: list[str] = []
+    if system_prompt:
+        parts.append(f"system:{system_prompt}")
+    if tools:
+        parts.append(
+            f"tools:{json.dumps([t.model_dump() for t in tools], sort_keys=True)}"
+        )
+    for msg in messages:
+        parts.append(f"{msg.role}:{msg.model_dump_json()}")
+    return "\n\n".join(parts)
+
+
+def _can_accept_extended_args(factory: FauxResponseFactory) -> bool:
+    """Check if a factory can accept the extended (messages, model, system_prompt, tools) signature."""
+    try:
+        sig = inspect.signature(factory)
+        params = [
+            p
+            for p in sig.parameters.values()
+            if p.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ]
+        # Check for VAR_POSITIONAL (*args)
+        has_var_positional = any(
+            p.kind == inspect.Parameter.VAR_POSITIONAL for p in sig.parameters.values()
+        )
+        if has_var_positional:
+            return True
+        return len(params) >= 4
+    except (ValueError, TypeError):
+        return False
+
+
 class FauxProvider:
     def __init__(
         self,
@@ -100,6 +159,7 @@ class FauxProvider:
         self._min = max(1, min(token_size_min, token_size_max))
         self._max = max(self._min, token_size_max)
         self.call_count = 0
+        self._prompt_cache: dict[str, str] = {}
 
     def set_responses(self, responses: list[FauxResponseStep]) -> None:
         self._responses = list(responses)
@@ -110,6 +170,48 @@ class FauxProvider:
     @property
     def pending_response_count(self) -> int:
         return len(self._responses)
+
+    def clear_prompt_cache(self) -> None:
+        """Clear the prompt cache, useful between test scenarios."""
+        self._prompt_cache.clear()
+
+    @property
+    def prompt_cache(self) -> dict[str, str]:
+        """Read-only access to the prompt cache for test assertions."""
+        return dict(self._prompt_cache)
+
+    def _compute_cache_usage(
+        self,
+        system_prompt: str,
+        tools: list[ToolDefinition] | None,
+        messages: list[Message],
+        usage: Usage,
+    ) -> Usage:
+        """Compute cache-aware usage based on prompt prefix matching."""
+        prompt_text = _serialize_prompt_context(system_prompt, tools, messages)
+        prompt_tokens = _estimate_tokens(prompt_text)
+        # Use "default" as session key (single-session simulation)
+        session_key = "default"
+        previous_prompt = self._prompt_cache.get(session_key)
+
+        if previous_prompt is not None:
+            cached_chars = _common_prefix_length(previous_prompt, prompt_text)
+            cache_read = _estimate_tokens(previous_prompt[:cached_chars])
+            cache_write = _estimate_tokens(prompt_text[cached_chars:])
+            input_tokens = max(0, prompt_tokens - cache_read)
+        else:
+            cache_read = 0
+            cache_write = prompt_tokens
+            input_tokens = 0
+
+        self._prompt_cache[session_key] = prompt_text
+
+        return Usage(
+            input_tokens=input_tokens,
+            output_tokens=usage.output_tokens,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=cache_write,
+        )
 
     async def stream(
         self,
@@ -133,7 +235,9 @@ class FauxProvider:
                         content=[],
                         stop_reason="error",
                         error_message="No more faux responses queued",
-                        usage=Usage(),
+                        usage=self._compute_cache_usage(
+                            system_prompt, tools, messages, Usage()
+                        ),
                         timestamp=time.time(),
                     )
                     ms.push(
@@ -143,14 +247,27 @@ class FauxProvider:
                     return
 
                 if callable(step):
-                    import inspect
+                    if _can_accept_extended_args(step):
+                        args = (messages, model, system_prompt, tools)
+                    else:
+                        args = (messages, model)
 
                     if inspect.iscoroutinefunction(step):
-                        resolved = await step(messages, model)
+                        resolved = await step(*args)
                     else:
-                        resolved = step(messages, model)
+                        resolved = step(*args)
                 else:
                     resolved = step
+
+                # Compute cache-aware usage
+                output_tokens = _estimate_tokens(
+                    json.dumps([b.model_dump() for b in resolved.content], default=str)
+                )
+                base_usage = Usage(output_tokens=output_tokens)
+                cache_usage = self._compute_cache_usage(
+                    system_prompt, tools, messages, base_usage
+                )
+                resolved = resolved.model_copy(update={"usage": cache_usage})
 
                 await self._stream_with_deltas(ms, resolved, signal)
             except BaseException as exc:

--- a/cubepi/providers/faux.py
+++ b/cubepi/providers/faux.py
@@ -92,6 +92,8 @@ def _split_by_token_size(text: str, min_size: int, max_size: int) -> list[str]:
 
 def _estimate_tokens(text: str) -> int:
     """Estimate token count from text (approx 4 chars per token)."""
+    if not text:
+        return 0
     return max(1, math.ceil(len(text) / 4))
 
 

--- a/cubepi/providers/faux.py
+++ b/cubepi/providers/faux.py
@@ -204,7 +204,7 @@ class FauxProvider:
         else:
             cache_read = 0
             cache_write = prompt_tokens
-            input_tokens = 0
+            input_tokens = prompt_tokens
 
         self._prompt_cache[session_key] = prompt_text
 
@@ -237,9 +237,7 @@ class FauxProvider:
                         content=[],
                         stop_reason="error",
                         error_message="No more faux responses queued",
-                        usage=self._compute_cache_usage(
-                            system_prompt, tools, messages, Usage()
-                        ),
+                        usage=Usage(),
                         timestamp=time.time(),
                     )
                     ms.push(

--- a/tests/providers/test_faux.py
+++ b/tests/providers/test_faux.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from cubepi.providers.base import TextContent, ToolDefinition, UserMessage
 from cubepi.providers.faux import (
     FauxProvider,
     faux_assistant_message,
@@ -284,3 +285,330 @@ class TestFauxProvider:
         s2 = await provider.stream(model, [])
         _ = [e async for e in s2]
         assert provider.call_count == 2
+
+
+class TestFauxProviderExtendedFactory:
+    """Tests for extended factory signature (messages, model, system_prompt, tools)."""
+
+    def _make_model(self):
+        from cubepi.providers.base import Model
+
+        return Model(id="faux-1", provider="faux")
+
+    async def test_extended_sync_factory_receives_all_args(self):
+        """Factory with 4 params receives system_prompt and tools."""
+        received = {}
+
+        def factory(messages, model, system_prompt, tools):
+            received["system_prompt"] = system_prompt
+            received["tools"] = tools
+            received["messages"] = messages
+            received["model"] = model
+            return faux_assistant_message("extended")
+
+        provider = FauxProvider()
+        provider.set_responses([factory])
+        model = self._make_model()
+        tools = [
+            ToolDefinition(
+                name="search",
+                description="Search the web",
+                parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+            )
+        ]
+
+        stream = await provider.stream(
+            model, [], system_prompt="You are helpful.", tools=tools
+        )
+        _ = [e async for e in stream]
+        result = await stream.result()
+
+        assert result.content[0].text == "extended"
+        assert received["system_prompt"] == "You are helpful."
+        assert received["tools"] is not None
+        assert len(received["tools"]) == 1
+        assert received["tools"][0].name == "search"
+
+    async def test_extended_async_factory_receives_all_args(self):
+        """Async factory with 4 params receives system_prompt and tools."""
+        received = {}
+
+        async def factory(messages, model, system_prompt, tools):
+            received["system_prompt"] = system_prompt
+            received["tools"] = tools
+            return faux_assistant_message("async extended")
+
+        provider = FauxProvider()
+        provider.set_responses([factory])
+        model = self._make_model()
+
+        stream = await provider.stream(
+            model, [], system_prompt="Be concise.", tools=None
+        )
+        _ = [e async for e in stream]
+        result = await stream.result()
+
+        assert result.content[0].text == "async extended"
+        assert received["system_prompt"] == "Be concise."
+        assert received["tools"] is None
+
+    async def test_old_factory_still_works(self):
+        """Old-style factory with 2 params still works (backward compat)."""
+
+        def factory(messages, model):
+            return faux_assistant_message(f"old style: {model.id}")
+
+        provider = FauxProvider()
+        provider.set_responses([factory])
+        model = self._make_model()
+
+        stream = await provider.stream(model, [], system_prompt="ignored", tools=None)
+        _ = [e async for e in stream]
+        result = await stream.result()
+
+        assert result.content[0].text == "old style: faux-1"
+
+    async def test_old_async_factory_still_works(self):
+        """Old-style async factory with 2 params still works."""
+
+        async def factory(messages, model):
+            return faux_assistant_message("old async")
+
+        provider = FauxProvider()
+        provider.set_responses([factory])
+        model = self._make_model()
+
+        stream = await provider.stream(model, [], system_prompt="ignored", tools=None)
+        _ = [e async for e in stream]
+        result = await stream.result()
+
+        assert result.content[0].text == "old async"
+
+    async def test_factory_with_var_positional_args(self):
+        """Factory using *args receives all arguments."""
+
+        def factory(*args):
+            assert len(args) == 4
+            return faux_assistant_message(f"got {len(args)} args")
+
+        provider = FauxProvider()
+        provider.set_responses([factory])
+        model = self._make_model()
+
+        stream = await provider.stream(model, [], system_prompt="test")
+        _ = [e async for e in stream]
+        result = await stream.result()
+
+        assert result.content[0].text == "got 4 args"
+
+    async def test_extended_factory_with_tools_content(self):
+        """Extended factory can use tools to decide response."""
+
+        def factory(messages, model, system_prompt, tools):
+            if tools and any(t.name == "calculator" for t in tools):
+                return faux_assistant_message(
+                    [faux_tool_call("calculator", {"expr": "2+2"}, id="t1")],
+                    stop_reason="tool_use",
+                )
+            return faux_assistant_message("no tools available")
+
+        provider = FauxProvider()
+        tools = [
+            ToolDefinition(
+                name="calculator",
+                description="Evaluate math",
+                parameters={
+                    "type": "object",
+                    "properties": {"expr": {"type": "string"}},
+                },
+            )
+        ]
+        provider.set_responses([factory])
+        model = self._make_model()
+
+        stream = await provider.stream(model, [], tools=tools)
+        _ = [e async for e in stream]
+        result = await stream.result()
+
+        assert result.stop_reason == "tool_use"
+        assert result.content[0].name == "calculator"
+
+
+class TestFauxProviderPromptCache:
+    """Tests for prompt cache simulation."""
+
+    def _make_model(self):
+        from cubepi.providers.base import Model
+
+        return Model(id="faux-1", provider="faux")
+
+    async def test_first_call_populates_cache_write(self):
+        """First call should have cache_write > 0 and cache_read == 0."""
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("hello")])
+        model = self._make_model()
+
+        stream = await provider.stream(model, [], system_prompt="You are helpful.")
+        _ = [e async for e in stream]
+        result = await stream.result()
+
+        assert result.usage is not None
+        assert result.usage.cache_write_tokens > 0
+        assert result.usage.cache_read_tokens == 0
+
+    async def test_second_call_same_context_has_cache_read(self):
+        """Second call with same context should have cache_read > 0."""
+        provider = FauxProvider()
+        provider.set_responses(
+            [faux_assistant_message("first"), faux_assistant_message("second")]
+        )
+        model = self._make_model()
+        messages = [UserMessage(content=[TextContent(text="Hello")])]
+
+        # First call
+        s1 = await provider.stream(model, messages, system_prompt="You are helpful.")
+        _ = [e async for e in s1]
+        r1 = await s1.result()
+
+        # Second call with same context
+        s2 = await provider.stream(model, messages, system_prompt="You are helpful.")
+        _ = [e async for e in s2]
+        r2 = await s2.result()
+
+        assert r1.usage is not None
+        assert r2.usage is not None
+        # First call: all cache_write, no cache_read
+        assert r1.usage.cache_write_tokens > 0
+        assert r1.usage.cache_read_tokens == 0
+        # Second call: should have cache_read (prefix match)
+        assert r2.usage.cache_read_tokens > 0
+
+    async def test_different_system_prompt_has_no_cache_read(self):
+        """Changing system_prompt should result in cache miss (no prefix match)."""
+        provider = FauxProvider()
+        provider.set_responses(
+            [faux_assistant_message("first"), faux_assistant_message("second")]
+        )
+        model = self._make_model()
+
+        # First call
+        s1 = await provider.stream(
+            model, [], system_prompt="You are a helpful assistant."
+        )
+        _ = [e async for e in s1]
+        r1 = await s1.result()
+
+        # Second call with different system prompt
+        s2 = await provider.stream(model, [], system_prompt="You are a code reviewer.")
+        _ = [e async for e in s2]
+        r2 = await s2.result()
+
+        assert r1.usage is not None
+        assert r2.usage is not None
+        # Both should have cache_write since prompts differ significantly
+        assert r1.usage.cache_write_tokens > 0
+        assert r2.usage.cache_write_tokens > 0
+        # Second call might have partial prefix match ("system:You are a ")
+        # but should have less cache_read than a full match
+        # The key assertion: cache_write on second call is non-zero
+        # (new content that wasn't in cache)
+        assert r2.usage.cache_write_tokens > 0
+
+    async def test_clear_prompt_cache(self):
+        """Clearing cache causes next call to be a full cache miss."""
+        provider = FauxProvider()
+        provider.set_responses(
+            [
+                faux_assistant_message("a"),
+                faux_assistant_message("b"),
+                faux_assistant_message("c"),
+            ]
+        )
+        model = self._make_model()
+
+        # First call populates cache
+        s1 = await provider.stream(model, [], system_prompt="test")
+        _ = [e async for e in s1]
+
+        # Second call hits cache
+        s2 = await provider.stream(model, [], system_prompt="test")
+        _ = [e async for e in s2]
+        r2 = await s2.result()
+        assert r2.usage is not None
+        assert r2.usage.cache_read_tokens > 0
+
+        # Clear cache
+        provider.clear_prompt_cache()
+        assert provider.prompt_cache == {}
+
+        # Third call after clear: cache miss
+        s3 = await provider.stream(model, [], system_prompt="test")
+        _ = [e async for e in s3]
+        r3 = await s3.result()
+        assert r3.usage is not None
+        assert r3.usage.cache_read_tokens == 0
+        assert r3.usage.cache_write_tokens > 0
+
+    async def test_cache_with_tools_change(self):
+        """Changing tools definition should affect cache behavior."""
+        provider = FauxProvider()
+        provider.set_responses(
+            [faux_assistant_message("first"), faux_assistant_message("second")]
+        )
+        model = self._make_model()
+        tools_v1 = [
+            ToolDefinition(
+                name="search",
+                description="Search",
+                parameters={"type": "object"},
+            )
+        ]
+        tools_v2 = [
+            ToolDefinition(
+                name="search",
+                description="Search",
+                parameters={"type": "object"},
+            ),
+            ToolDefinition(
+                name="calculate",
+                description="Calculate",
+                parameters={"type": "object"},
+            ),
+        ]
+
+        # First call with tools_v1
+        s1 = await provider.stream(model, [], system_prompt="test", tools=tools_v1)
+        _ = [e async for e in s1]
+        r1 = await s1.result()
+
+        # Second call with tools_v2 (different tools)
+        s2 = await provider.stream(model, [], system_prompt="test", tools=tools_v2)
+        _ = [e async for e in s2]
+        r2 = await s2.result()
+
+        assert r1.usage is not None
+        assert r2.usage is not None
+        # Second call should have partial cache read (system_prompt matches)
+        # but also cache_write for the new tool definitions
+        assert r2.usage.cache_write_tokens > 0
+
+    async def test_cache_populates_usage_on_static_response(self):
+        """Static AssistantMessage responses also get cache-aware usage."""
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("static")])
+        model = self._make_model()
+
+        stream = await provider.stream(model, [], system_prompt="You are helpful.")
+        _ = [e async for e in stream]
+        result = await stream.result()
+
+        assert result.usage is not None
+        assert result.usage.cache_write_tokens > 0
+        assert result.usage.output_tokens > 0
+
+    async def test_prompt_cache_property_is_copy(self):
+        """The prompt_cache property returns a copy, not the internal dict."""
+        provider = FauxProvider()
+        cache = provider.prompt_cache
+        cache["injected"] = "value"
+        assert "injected" not in provider.prompt_cache


### PR DESCRIPTION
Closes #7

## Summary
- Extend FauxResponseFactory to receive system_prompt and tools (backward compatible)
- Add prompt cache simulation for testing cache-dependent logic

## Test plan
- [ ] Existing tests pass (backward compatibility)
- [ ] New tests verify extended factory signature
- [ ] New tests verify cache hit/miss simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)