### PR TITLE
feat: add OpenAI Responses API provider

### DIFF
--- a/cubepi/providers/__init__.py
+++ b/cubepi/providers/__init__.py
@@ -39,6 +39,12 @@ def get_openai_provider():
     return OpenAIProvider
 
 
+def get_openai_responses_provider():
+    from cubepi.providers.openai_responses import OpenAIResponsesProvider
+
+    return OpenAIResponsesProvider
+
+
 __all__ = [
     "AssistantMessage",
     "Content",

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    MessageStream,
+    Model,
+    StreamEvent,
+    TextContent,
+    ThinkingContent,
+    ThinkingLevel,
+    ToolCall,
+    ToolDefinition,
+    ToolResultMessage,
+    Usage,
+    UserMessage,
+)
+
+# Map cubepi ThinkingLevel to OpenAI reasoning.effort values.
+# "off" means no reasoning parameter is sent.
+# "minimal" is not a valid OpenAI effort level, so we map it to "low".
+_THINKING_TO_EFFORT: dict[ThinkingLevel, str | None] = {
+    "off": None,
+    "minimal": "low",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "high",
+}
+
+
+class OpenAIResponsesProvider:
+    """Provider that uses the OpenAI Responses API.
+
+    The Responses API supports reasoning models (o-series) with streaming,
+    tool use, and reasoning effort control.
+    """
+
+    def __init__(
+        self, *, api_key: str | None = None, base_url: str | None = None
+    ) -> None:
+        import openai
+
+        kwargs: dict[str, Any] = {}
+        if api_key:
+            kwargs["api_key"] = api_key
+        if base_url:
+            kwargs["base_url"] = base_url
+        self._client = openai.AsyncOpenAI(**kwargs)
+
+    async def stream(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        thinking: ThinkingLevel = "off",
+        signal: asyncio.Event | None = None,
+    ) -> MessageStream:
+        ms = MessageStream()
+
+        api_input = self._build_input(messages)
+
+        kwargs: dict[str, Any] = {
+            "model": model.id,
+            "input": api_input,
+            "stream": True,
+            "store": False,
+        }
+
+        if system_prompt:
+            role = "developer" if model.reasoning else "system"
+            kwargs["instructions"] = system_prompt
+            # The instructions param uses system/developer role implicitly.
+            # For explicit role control, prepend to input instead.
+            kwargs["input"] = [{"role": role, "content": system_prompt}] + api_input
+
+            # Remove instructions since we use input-based system prompt
+            del kwargs["instructions"]
+
+        if tools:
+            kwargs["tools"] = [self._convert_tool(t) for t in tools]
+
+        # Configure reasoning effort for reasoning models
+        effort = _THINKING_TO_EFFORT.get(thinking)
+        if model.reasoning and effort is not None:
+            kwargs["reasoning"] = {
+                "effort": effort,
+                "summary": "auto",
+            }
+            kwargs["include"] = ["reasoning.encrypted_content"]
+
+        if model.max_tokens:
+            kwargs["max_output_tokens"] = model.max_tokens
+
+        async def _produce() -> None:
+            try:
+                response = await self._client.responses.create(**kwargs)
+                partial = AssistantMessage(
+                    content=[], usage=Usage(), timestamp=time.time()
+                )
+                ms.push(
+                    StreamEvent(type="start", partial=partial.model_copy(deep=True))
+                )
+
+                # Track current streaming state
+                current_thinking = ""
+                current_text = ""
+                current_tool_json = ""
+                current_item_type: str | None = None
+                current_tool_call_id = ""
+                current_tool_item_id = ""
+                current_tool_name = ""
+
+                async for event in response:
+                    if signal and signal.is_set():
+                        aborted = partial.model_copy(
+                            update={
+                                "stop_reason": "aborted",
+                                "error_message": "Request was aborted",
+                            }
+                        )
+                        ms.push(
+                            StreamEvent(
+                                type="error",
+                                error_message="Request was aborted",
+                            )
+                        )
+                        ms.set_result(aborted)
+                        return
+
+                    etype = event.type
+
+                    # --- Output item lifecycle ---
+                    if etype == "response.output_item.added":
+                        item = event.item
+                        if item.type == "reasoning":
+                            current_item_type = "reasoning"
+                            current_thinking = ""
+                            partial.content.append(ThinkingContent(thinking=""))
+                            ms.push(
+                                StreamEvent(
+                                    type="thinking_start",
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+                        elif item.type == "message":
+                            current_item_type = "message"
+                            current_text = ""
+                            partial.content.append(TextContent(text=""))
+                            ms.push(
+                                StreamEvent(
+                                    type="text_start",
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+                        elif item.type == "function_call":
+                            current_item_type = "function_call"
+                            current_tool_json = ""
+                            current_tool_call_id = item.call_id
+                            current_tool_item_id = item.id
+                            current_tool_name = item.name
+                            partial.content.append(
+                                ToolCall(
+                                    id=f"{item.call_id}|{item.id}",
+                                    name=item.name,
+                                    arguments={},
+                                )
+                            )
+                            ms.push(
+                                StreamEvent(
+                                    type="toolcall_start",
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+
+                    # --- Reasoning (thinking) deltas ---
+                    elif etype == "response.reasoning_summary_text.delta":
+                        if current_item_type == "reasoning":
+                            current_thinking += event.delta
+                            if partial.content and isinstance(
+                                partial.content[-1], ThinkingContent
+                            ):
+                                partial.content[-1] = ThinkingContent(
+                                    thinking=current_thinking
+                                )
+                            ms.push(
+                                StreamEvent(
+                                    type="thinking_delta",
+                                    delta=event.delta,
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+
+                    elif etype == "response.reasoning_text.delta":
+                        if current_item_type == "reasoning":
+                            current_thinking += event.delta
+                            if partial.content and isinstance(
+                                partial.content[-1], ThinkingContent
+                            ):
+                                partial.content[-1] = ThinkingContent(
+                                    thinking=current_thinking
+                                )
+                            ms.push(
+                                StreamEvent(
+                                    type="thinking_delta",
+                                    delta=event.delta,
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+
+                    elif etype == "response.reasoning_summary_part.done":
+                        # Append separator between summary parts
+                        if current_item_type == "reasoning":
+                            current_thinking += "\n\n"
+                            if partial.content and isinstance(
+                                partial.content[-1], ThinkingContent
+                            ):
+                                partial.content[-1] = ThinkingContent(
+                                    thinking=current_thinking
+                                )
+                            ms.push(
+                                StreamEvent(
+                                    type="thinking_delta",
+                                    delta="\n\n",
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+
+                    # --- Text deltas ---
+                    elif etype == "response.output_text.delta":
+                        if current_item_type == "message":
+                            current_text += event.delta
+                            if partial.content and isinstance(
+                                partial.content[-1], TextContent
+                            ):
+                                partial.content[-1] = TextContent(text=current_text)
+                            ms.push(
+                                StreamEvent(
+                                    type="text_delta",
+                                    delta=event.delta,
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+
+                    elif etype == "response.refusal.delta":
+                        if current_item_type == "message":
+                            current_text += event.delta
+                            if partial.content and isinstance(
+                                partial.content[-1], TextContent
+                            ):
+                                partial.content[-1] = TextContent(text=current_text)
+                            ms.push(
+                                StreamEvent(
+                                    type="text_delta",
+                                    delta=event.delta,
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+
+                    # --- Tool call argument deltas ---
+                    elif etype == "response.function_call_arguments.delta":
+                        if current_item_type == "function_call":
+                            current_tool_json += event.delta
+                            ms.push(
+                                StreamEvent(
+                                    type="toolcall_delta",
+                                    delta=event.delta,
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+
+                    elif etype == "response.function_call_arguments.done":
+                        if current_item_type == "function_call":
+                            current_tool_json = event.arguments
+
+                    # --- Output item done ---
+                    elif etype == "response.output_item.done":
+                        item = event.item
+                        if item.type == "reasoning":
+                            # Finalize thinking content from item summary
+                            summary_text = ""
+                            if hasattr(item, "summary") and item.summary:
+                                summary_text = "\n\n".join(
+                                    s.text for s in item.summary if hasattr(s, "text")
+                                )
+                            final_thinking = summary_text or current_thinking
+                            if partial.content and isinstance(
+                                partial.content[-1], ThinkingContent
+                            ):
+                                partial.content[-1] = ThinkingContent(
+                                    thinking=final_thinking
+                                )
+                            ms.push(
+                                StreamEvent(
+                                    type="thinking_end",
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+                            current_item_type = None
+
+                        elif item.type == "message":
+                            # Finalize text from item content
+                            final_text = ""
+                            if hasattr(item, "content") and item.content:
+                                parts = []
+                                for c in item.content:
+                                    if hasattr(c, "text"):
+                                        parts.append(c.text)
+                                    elif hasattr(c, "refusal"):
+                                        parts.append(c.refusal)
+                                final_text = "".join(parts)
+                            if (
+                                final_text
+                                and partial.content
+                                and isinstance(partial.content[-1], TextContent)
+                            ):
+                                partial.content[-1] = TextContent(text=final_text)
+                            ms.push(
+                                StreamEvent(
+                                    type="text_end",
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+                            current_item_type = None
+
+                        elif item.type == "function_call":
+                            try:
+                                args = (
+                                    json.loads(current_tool_json)
+                                    if current_tool_json
+                                    else {}
+                                )
+                            except json.JSONDecodeError:
+                                args = {}
+                            tc_id = f"{current_tool_call_id}|{current_tool_item_id}"
+                            # Update the tool call in partial with final args
+                            for i, c in enumerate(partial.content):
+                                if isinstance(c, ToolCall) and c.id == tc_id:
+                                    partial.content[i] = ToolCall(
+                                        id=tc_id,
+                                        name=current_tool_name,
+                                        arguments=args,
+                                    )
+                            ms.push(
+                                StreamEvent(
+                                    type="toolcall_end",
+                                    partial=partial.model_copy(deep=True),
+                                )
+                            )
+                            current_item_type = None
+
+                    # --- Response completed ---
+                    elif etype == "response.completed":
+                        resp = event.response
+                        usage = Usage()
+                        if resp and resp.usage:
+                            cached = 0
+                            if hasattr(resp.usage, "input_tokens_details"):
+                                details = resp.usage.input_tokens_details
+                                if details and hasattr(details, "cached_tokens"):
+                                    cached = details.cached_tokens or 0
+                            usage = Usage(
+                                input_tokens=(resp.usage.input_tokens or 0) - cached,
+                                output_tokens=resp.usage.output_tokens or 0,
+                                cache_read_tokens=cached,
+                            )
+
+                        stop_reason = self._map_stop_reason(
+                            resp.status if resp else None, partial
+                        )
+                        partial = partial.model_copy(
+                            update={
+                                "usage": usage,
+                                "stop_reason": stop_reason,
+                            }
+                        )
+                        ms.push(StreamEvent(type="done"))
+                        ms.set_result(partial)
+                        return
+
+                    # --- Errors ---
+                    elif etype == "error":
+                        error_msg_text = ""
+                        if hasattr(event, "message"):
+                            error_msg_text = event.message
+                        elif hasattr(event, "code"):
+                            error_msg_text = f"Error code {event.code}"
+                        raise RuntimeError(error_msg_text or "Unknown error")
+
+                    elif etype == "response.failed":
+                        resp = event.response
+                        error_detail = ""
+                        if resp and hasattr(resp, "error") and resp.error:
+                            code = getattr(resp.error, "code", "unknown")
+                            msg = getattr(resp.error, "message", "no message")
+                            error_detail = f"{code}: {msg}"
+                        elif (
+                            resp
+                            and hasattr(resp, "incomplete_details")
+                            and resp.incomplete_details
+                        ):
+                            reason = getattr(
+                                resp.incomplete_details, "reason", "unknown"
+                            )
+                            error_detail = f"incomplete: {reason}"
+                        raise RuntimeError(error_detail or "Unknown error (no details)")
+
+                # If we get here without response.completed, finalize
+                ms.push(StreamEvent(type="done"))
+                ms.set_result(partial)
+
+            except BaseException as exc:
+                error_msg = AssistantMessage(
+                    content=[],
+                    stop_reason="error",
+                    error_message=str(exc),
+                    usage=Usage(),
+                    timestamp=time.time(),
+                )
+                ms.push(StreamEvent(type="error", error_message=str(exc)))
+                ms.set_result(error_msg)
+                if not isinstance(exc, Exception):
+                    raise
+
+        asyncio.create_task(_produce())
+        return ms
+
+    @staticmethod
+    def _map_stop_reason(status: str | None, partial: AssistantMessage) -> str:
+        """Map OpenAI response status to cubepi stop reason."""
+        has_tool_calls = any(isinstance(c, ToolCall) for c in partial.content)
+        reason_map = {
+            "completed": "stop",
+            "incomplete": "length",
+            "failed": "error",
+            "cancelled": "error",
+            "in_progress": "stop",
+            "queued": "stop",
+        }
+        reason = reason_map.get(status or "completed", "stop")
+        if has_tool_calls and reason == "stop":
+            reason = "tool_use"
+        return reason
+
+    @staticmethod
+    def _build_input(messages: list[Message]) -> list[dict[str, Any]]:
+        """Convert cubepi messages to OpenAI Responses API input format."""
+        api_input: list[dict[str, Any]] = []
+
+        for msg in messages:
+            if isinstance(msg, UserMessage):
+                content: list[dict[str, Any]] = []
+                for c in msg.content:
+                    if isinstance(c, TextContent):
+                        content.append({"type": "input_text", "text": c.text})
+                if content:
+                    api_input.append({"role": "user", "content": content})
+
+            elif isinstance(msg, AssistantMessage):
+                for c in msg.content:
+                    if isinstance(c, ThinkingContent):
+                        # Reasoning items cannot be replayed without
+                        # encrypted_content, so we skip them for now.
+                        pass
+                    elif isinstance(c, TextContent):
+                        api_input.append(
+                            {
+                                "type": "message",
+                                "role": "assistant",
+                                "content": [
+                                    {
+                                        "type": "output_text",
+                                        "text": c.text,
+                                        "annotations": [],
+                                    }
+                                ],
+                                "status": "completed",
+                            }
+                        )
+                    elif isinstance(c, ToolCall):
+                        # Parse compound id format "call_id|item_id"
+                        parts = c.id.split("|", 1)
+                        call_id = parts[0]
+                        item_id = parts[1] if len(parts) > 1 else None
+                        fc: dict[str, Any] = {
+                            "type": "function_call",
+                            "call_id": call_id,
+                            "name": c.name,
+                            "arguments": json.dumps(c.arguments),
+                        }
+                        if item_id:
+                            fc["id"] = item_id
+                        api_input.append(fc)
+
+            elif isinstance(msg, ToolResultMessage):
+                parts = msg.tool_call_id.split("|", 1)
+                call_id = parts[0]
+                text_parts = [c.text for c in msg.content if isinstance(c, TextContent)]
+                api_input.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": "\n".join(text_parts),
+                    }
+                )
+
+        return api_input
+
+    @staticmethod
+    def _convert_tool(td: ToolDefinition) -> dict[str, Any]:
+        """Convert a cubepi ToolDefinition to OpenAI Responses API tool format."""
+        return {
+            "type": "function",
+            "name": td.name,
+            "description": td.description,
+            "parameters": td.parameters,
+        }

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -50,9 +50,7 @@ class TestBuildInput:
         assert result[0]["content"] == [{"type": "input_text", "text": "hello"}]
 
     def test_assistant_text_message(self):
-        msgs = [
-            AssistantMessage(content=[TextContent(text="hi there")])
-        ]
+        msgs = [AssistantMessage(content=[TextContent(text="hi there")])]
         result = OpenAIResponsesProvider._build_input(msgs)
         assert len(result) == 1
         assert result[0]["type"] == "message"
@@ -86,9 +84,7 @@ class TestBuildInput:
         """Tool call id without pipe separator should omit item id."""
         msgs = [
             AssistantMessage(
-                content=[
-                    ToolCall(id="call_123", name="search", arguments={"q": "x"})
-                ],
+                content=[ToolCall(id="call_123", name="search", arguments={"q": "x"})],
             )
         ]
         result = OpenAIResponsesProvider._build_input(msgs)
@@ -129,9 +125,7 @@ class TestBuildInput:
             AssistantMessage(
                 content=[
                     TextContent(text="hi"),
-                    ToolCall(
-                        id="c1|fc_1", name="search", arguments={"q": "test"}
-                    ),
+                    ToolCall(id="c1|fc_1", name="search", arguments={"q": "test"}),
                 ],
                 stop_reason="tool_use",
             ),
@@ -173,16 +167,16 @@ class TestMapStopReason:
         assert OpenAIResponsesProvider._map_stop_reason("completed", partial) == "stop"
 
     def test_completed_with_tools(self):
-        partial = AssistantMessage(
-            content=[ToolCall(id="x", name="y", arguments={})]
-        )
+        partial = AssistantMessage(content=[ToolCall(id="x", name="y", arguments={})])
         assert (
             OpenAIResponsesProvider._map_stop_reason("completed", partial) == "tool_use"
         )
 
     def test_incomplete(self):
         partial = AssistantMessage(content=[])
-        assert OpenAIResponsesProvider._map_stop_reason("incomplete", partial) == "length"
+        assert (
+            OpenAIResponsesProvider._map_stop_reason("incomplete", partial) == "length"
+        )
 
     def test_failed(self):
         partial = AssistantMessage(content=[])
@@ -306,9 +300,7 @@ class TestStreamThinking:
                 "response.output_item.added",
                 item=_make_output_item("reasoning", id="rs_1", summary=[]),
             ),
-            _make_event(
-                "response.reasoning_summary_text.delta", delta="Thinking..."
-            ),
+            _make_event("response.reasoning_summary_text.delta", delta="Thinking..."),
             _make_event(
                 "response.output_item.done",
                 item=_make_output_item(
@@ -407,12 +399,8 @@ class TestStreamToolUse:
                     arguments="",
                 ),
             ),
-            _make_event(
-                "response.function_call_arguments.delta", delta='{"q": '
-            ),
-            _make_event(
-                "response.function_call_arguments.delta", delta='"test"}'
-            ),
+            _make_event("response.function_call_arguments.delta", delta='{"q": '),
+            _make_event("response.function_call_arguments.delta", delta='"test"}'),
             _make_event(
                 "response.function_call_arguments.done",
                 arguments='{"q": "test"}',
@@ -702,11 +690,14 @@ class TestReasoningParams:
             provider._client = mock_client
 
             model = _model(reasoning=True)
-            await provider.stream(
+            ms = await provider.stream(
                 model,
                 [UserMessage(content=[TextContent(text="hi")])],
                 thinking="off",
             )
+            async for _ in ms:
+                pass
+            await ms.result()
 
             call_kwargs = mock_client.responses.create.call_args[1]
             assert "reasoning" not in call_kwargs
@@ -741,11 +732,14 @@ class TestReasoningParams:
             provider._client = mock_client
 
             model = _model(reasoning=True)
-            await provider.stream(
+            ms = await provider.stream(
                 model,
                 [UserMessage(content=[TextContent(text="hi")])],
                 system_prompt="You are helpful.",
             )
+            async for _ in ms:
+                pass
+            await ms.result()
 
             call_kwargs = mock_client.responses.create.call_args[1]
             api_input = call_kwargs["input"]
@@ -783,11 +777,14 @@ class TestReasoningParams:
             provider._client = mock_client
 
             model = _model(reasoning=False)
-            await provider.stream(
+            ms = await provider.stream(
                 model,
                 [UserMessage(content=[TextContent(text="hi")])],
                 system_prompt="You are helpful.",
             )
+            async for _ in ms:
+                pass
+            await ms.result()
 
             call_kwargs = mock_client.responses.create.call_args[1]
             api_input = call_kwargs["input"]


### PR DESCRIPTION
Closes #2

## Summary
- Add `OpenAIResponsesProvider` in `cubepi/providers/openai_responses.py` supporting the newer OpenAI Responses API (`client.responses.create()` with streaming)
- Map cubepi `ThinkingLevel` to OpenAI `reasoning.effort` parameter for reasoning models (o-series)
- Handle Responses API streaming format: reasoning items, text output, function calls, refusals, and completion events
- Use compound tool call IDs (`call_id|item_id`) matching the Responses API format
- Export via lazy `get_openai_responses_provider()` in providers `__init__.py`
- Fix three pre-existing tests that checked mock `call_args` without consuming the background stream

## Test plan
- [x] All 147 existing + new tests pass (`uv run pytest tests/ -x -q`)
- [x] 25 new tests cover: message conversion, tool conversion, stop reason mapping, text streaming, reasoning/thinking streaming, tool call streaming, abort handling, API errors, stream error events, response.failed events, reasoning params, system prompt role, and refusal handling
- [x] `ruff check` and `ruff format` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)