### PR TITLE
fix: poll steering messages at loop start before first assistant turn

### DIFF
--- a/cubepi/agent/loop.py
+++ b/cubepi/agent/loop.py
@@ -154,6 +154,16 @@ async def _run_loop(
     opts = stream_options or StreamOptions()
     first_turn = True
 
+    # Poll for steering messages at start (user may have typed while waiting)
+    if get_steering_messages:
+        pending = await get_steering_messages() or []
+        if pending:
+            for msg in pending:
+                await _emit(emit, MessageStartEvent(message=msg))
+                await _emit(emit, MessageEndEvent(message=msg))
+                current_context.messages.append(msg)
+                new_messages.append(msg)
+
     while True:
         has_more_tool_calls = True
 

--- a/tests/agent/test_loop.py
+++ b/tests/agent/test_loop.py
@@ -304,6 +304,43 @@ class TestAgentLoop:
         roles = [m.role for m in messages]
         assert roles == ["user", "assistant", "tool_result"]
 
+    async def test_steering_messages_polled_before_first_turn(self):
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("Got it")])
+
+        context = AgentContext(system_prompt="", messages=[], tools=[])
+        call_count = 0
+
+        async def get_steering():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [make_user_message("steering hint")]
+            return []
+
+        events: list[AgentEvent] = []
+        messages = await run_agent_loop(
+            prompts=[make_user_message("Hello")],
+            context=context,
+            provider=provider,
+            model=make_model(),
+            convert_to_llm=identity_converter,
+            get_steering_messages=get_steering,
+            emit=lambda e: events.append(e),
+        )
+
+        # Messages should be: initial prompt, steering message, assistant response
+        roles = [m.role for m in messages]
+        assert roles == ["user", "user", "assistant"]
+
+        # Verify event ordering: message_end events should reflect
+        # initial prompt -> steering message -> assistant response
+        message_ends = [e for e in events if e.type == "message_end"]
+        assert len(message_ends) == 3
+        assert message_ends[0].message.role == "user"  # initial prompt
+        assert message_ends[1].message.role == "user"  # steering message
+        assert message_ends[2].message.role == "assistant"  # response
+
     async def test_error_stop_reason_ends_loop(self):
         provider = FauxProvider()
         provider.set_responses(


### PR DESCRIPTION
## Summary

- Adds an initial steering message poll at the start of `_run_loop()`, before the first LLM call, so that messages typed by the user while waiting are included in context before the first assistant turn
- Adds a test verifying that steering messages polled at start appear in the correct order: initial prompt, steering message, then assistant response

Closes #20

## Test plan

- [x] New test `test_steering_messages_polled_before_first_turn` validates event ordering
- [x] All 266 tests pass (`pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q`)