### PR TITLE
fix: track producer task in MessageStream to prevent silent failures

### DIFF
--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -152,7 +152,7 @@ class AnthropicProvider:
                 if not isinstance(exc, Exception):
                     raise
 
-        asyncio.create_task(_produce())
+        ms.attach_task(asyncio.create_task(_produce()))
         return ms
 
     def _get_cache_control(self) -> dict[str, str] | None:

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -171,6 +171,19 @@ class MessageStream:
         self._result_future: asyncio.Future[AssistantMessage] = (
             asyncio.get_running_loop().create_future()
         )
+        self._producer_task: asyncio.Task | None = None
+
+    def attach_task(self, task: asyncio.Task) -> None:
+        self._producer_task = task
+        task.add_done_callback(self._on_task_done)
+
+    def _on_task_done(self, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc and not self._result_future.done():
+            self._result_future.set_exception(exc)
+            self._queue.put_nowait(None)
 
     def push(self, event: StreamEvent) -> None:
         self._queue.put_nowait(event)

--- a/cubepi/providers/faux.py
+++ b/cubepi/providers/faux.py
@@ -283,7 +283,7 @@ class FauxProvider:
                 if not isinstance(exc, Exception):
                     raise
 
-        asyncio.create_task(_produce())
+        ms.attach_task(asyncio.create_task(_produce()))
         return ms
 
     async def _stream_with_deltas(

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -244,7 +244,7 @@ class OpenAIProvider:
                 if not isinstance(exc, Exception):
                     raise
 
-        asyncio.create_task(_produce())
+        ms.attach_task(asyncio.create_task(_produce()))
         return ms
 
     @staticmethod

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -440,7 +440,7 @@ class OpenAIResponsesProvider:
                 if not isinstance(exc, Exception):
                     raise
 
-        asyncio.create_task(_produce())
+        ms.attach_task(asyncio.create_task(_produce()))
         return ms
 
     @staticmethod

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from cubepi.providers.base import (
     AssistantMessage,
     ImageContent,
@@ -147,3 +149,28 @@ class TestMessageStream:
 
         result = await stream.result()
         assert result.stop_reason == "error"
+
+
+class TestMessageStreamTaskTracking:
+    async def test_attach_task_stores_reference(self):
+        ms = MessageStream()
+
+        async def dummy():
+            ms.push(StreamEvent(type="done"))
+            ms.set_result(AssistantMessage(content=[]))
+
+        task = asyncio.create_task(dummy())
+        ms.attach_task(task)
+        assert ms._producer_task is task
+        await task
+
+    async def test_result_propagates_task_exception(self):
+        ms = MessageStream()
+
+        async def failing():
+            raise RuntimeError("producer died before pushing error")
+
+        task = asyncio.create_task(failing())
+        ms.attach_task(task)
+        with pytest.raises(RuntimeError, match="producer died"):
+            await ms.result()


### PR DESCRIPTION
## Summary
- Adds `_producer_task` field, `attach_task()`, and `_on_task_done()` callback to `MessageStream` so the producer task reference is retained and unhandled exceptions propagate to `result()` instead of being silently lost.
- Updates all four providers (`anthropic`, `openai`, `openai_responses`, `faux`) to call `ms.attach_task(asyncio.create_task(...))` instead of bare `asyncio.create_task(...)`.
- Adds two tests verifying task reference storage and exception propagation.

Closes #24

## Test plan
- [x] `pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q` -- 267 passed