### PR TITLE
feat: integrate checkpointer into Agent lifecycle

### DIFF
--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -201,6 +201,12 @@ class Agent(Generic[TMessage]):
         else:
             messages = [message]
 
+        # Restore history from checkpointer if this is first prompt
+        if self.checkpointer and self.thread_id and not self._state._messages:
+            data = await self.checkpointer.load(self.thread_id)
+            if data and data.messages:
+                self._state._messages = list(data.messages)
+
         await self._run_prompt(messages)
 
     async def resume(self) -> None:
@@ -334,6 +340,8 @@ class Agent(Generic[TMessage]):
         elif event.type == "message_end":
             self._state.streaming_message = None
             self._state._messages.append(event.message)
+            if self.checkpointer and self.thread_id:
+                await self.checkpointer.append(self.thread_id, [event.message])
         elif event.type == "tool_execution_start":
             self._state._pending_tool_calls = self._state._pending_tool_calls | {
                 event.tool_call_id

--- a/tests/agent/test_checkpointer_integration.py
+++ b/tests/agent/test_checkpointer_integration.py
@@ -1,0 +1,54 @@
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.base import Model
+from cubepi.providers.faux import FauxProvider, faux_assistant_message
+
+
+def make_model() -> Model:
+    return Model(id="faux-1", provider="faux")
+
+
+class TestCheckpointerIntegration:
+    async def test_messages_persisted_on_message_end(self):
+        checkpointer = MemoryCheckpointer()
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("Hello!")])
+        agent = Agent(
+            provider=provider,
+            model=make_model(),
+            checkpointer=checkpointer,
+            thread_id="thread-1",
+        )
+        await agent.prompt("Hi")
+        data = await checkpointer.load("thread-1")
+        assert data is not None
+        assert len(data.messages) == 2  # user + assistant
+
+    async def test_history_restored_on_prompt(self):
+        checkpointer = MemoryCheckpointer()
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("First reply")])
+        agent1 = Agent(
+            provider=provider,
+            model=make_model(),
+            checkpointer=checkpointer,
+            thread_id="thread-1",
+        )
+        await agent1.prompt("First message")
+
+        provider.set_responses([faux_assistant_message("Second reply")])
+        agent2 = Agent(
+            provider=provider,
+            model=make_model(),
+            checkpointer=checkpointer,
+            thread_id="thread-1",
+        )
+        await agent2.prompt("Second message")
+        assert len(agent2.state.messages) == 4  # 2 from first + 2 from second
+
+    async def test_no_checkpointer_works_as_before(self):
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("Hi")])
+        agent = Agent(provider=provider, model=make_model())
+        await agent.prompt("Hello")
+        assert len(agent.state.messages) == 2


### PR DESCRIPTION
## Summary

- Restore conversation history from checkpointer on first `prompt()` call when `self._state._messages` is empty, enabling cross-session message continuity
- Persist every message to checkpointer via `append()` in the `message_end` event handler
- Add integration tests covering persistence, restoration, and backward compatibility (no checkpointer)

Closes #21

## Test plan

- [x] `test_messages_persisted_on_message_end` -- verifies both user and assistant messages are saved to checkpointer after a prompt
- [x] `test_history_restored_on_prompt` -- verifies a new Agent instance with the same thread_id restores prior messages and accumulates correctly
- [x] `test_no_checkpointer_works_as_before` -- verifies agents without a checkpointer behave identically to before
- [x] Full test suite passes: `pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q` (268 passed)