### PR TITLE
feat: propagate details from AgentToolResult to ToolResultMessage

### DIFF
--- a/cubepi/agent/tools.py
+++ b/cubepi/agent/tools.py
@@ -62,6 +62,7 @@ def _make_tool_result_message(finalized: _FinalizedOutcome) -> ToolResultMessage
         tool_call_id=finalized.tool_call.id,
         tool_name=finalized.tool_call.name,
         content=finalized.result.content,
+        details=finalized.result.details,
         is_error=finalized.is_error,
         timestamp=time.time(),
     )

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -132,6 +132,7 @@ class ToolResultMessage(BaseModel):
     tool_call_id: str
     tool_name: str
     content: list[Content]
+    details: Any = None
     is_error: bool = False
     timestamp: float | None = None
 

--- a/tests/agent/test_tools.py
+++ b/tests/agent/test_tools.py
@@ -279,3 +279,27 @@ class TestToolEvents:
         start_idx = types.index("tool_execution_start")
         end_idx = types.index("tool_execution_end")
         assert start_idx < end_idx
+
+
+class TestToolResultDetails:
+    async def test_details_propagated_to_tool_result_message(self):
+        async def execute_with_details(
+            tool_call_id, params, *, signal=None, on_update=None
+        ):
+            return AgentToolResult(
+                content=[TextContent(text="result")],
+                details={"execution_time": 42},
+            )
+
+        tool = make_echo_tool(execute_fn=execute_with_details)
+        ctx = make_context([tool])
+        msg = make_assistant_msg(
+            [ToolCall(id="t1", name="echo", arguments={"value": "hi"})]
+        )
+
+        batch = await execute_tool_calls(
+            ctx, msg, tool_execution="sequential", emit=lambda e: None
+        )
+
+        assert len(batch.messages) == 1
+        assert batch.messages[0].details == {"execution_time": 42}


### PR DESCRIPTION
## Summary
- Added `details: Any = None` field to `ToolResultMessage` in `cubepi/providers/base.py`
- Updated `_make_tool_result_message()` in `cubepi/agent/tools.py` to pass `details=finalized.result.details` through to the `ToolResultMessage` constructor
- Added test verifying details propagation from `AgentToolResult` to `ToolResultMessage`

Closes #19

## Test plan
- [x] New test `TestToolResultDetails::test_details_propagated_to_tool_result_message` asserts details dict is propagated
- [x] All 266 tests pass (`pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q`)