### PR TITLE
feat: add content_index to StreamEvent and populate in all providers

### DIFF
--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -261,12 +261,15 @@ class AnthropicProvider:
     ) -> None:
         etype = getattr(event, "type", "")
         if etype == "content_block_start":
+            idx = getattr(event, "index", len(partial.content))
             block = event.content_block
             if block.type == "text":
                 partial.content.append(TextContent(text=""))
                 ms.push(
                     StreamEvent(
-                        type="text_start", partial=partial.model_copy(deep=True)
+                        type="text_start",
+                        content_index=idx,
+                        partial=partial.model_copy(deep=True),
                     )
                 )
             elif block.type == "thinking":
@@ -274,6 +277,7 @@ class AnthropicProvider:
                 ms.push(
                     StreamEvent(
                         type="thinking_start",
+                        content_index=idx,
                         partial=partial.model_copy(deep=True),
                     )
                 )
@@ -284,10 +288,12 @@ class AnthropicProvider:
                 ms.push(
                     StreamEvent(
                         type="toolcall_start",
+                        content_index=idx,
                         partial=partial.model_copy(deep=True),
                     )
                 )
         elif etype == "content_block_delta":
+            idx = getattr(event, "index", len(partial.content) - 1)
             delta = event.delta
             if hasattr(delta, "text"):
                 if partial.content and isinstance(partial.content[-1], TextContent):
@@ -298,6 +304,7 @@ class AnthropicProvider:
                     StreamEvent(
                         type="text_delta",
                         delta=delta.text,
+                        content_index=idx,
                         partial=partial.model_copy(deep=True),
                     )
                 )
@@ -310,6 +317,7 @@ class AnthropicProvider:
                     StreamEvent(
                         type="thinking_delta",
                         delta=delta.thinking,
+                        content_index=idx,
                         partial=partial.model_copy(deep=True),
                     )
                 )
@@ -318,16 +326,19 @@ class AnthropicProvider:
                     StreamEvent(
                         type="toolcall_delta",
                         delta=delta.partial_json,
+                        content_index=idx,
                         partial=partial.model_copy(deep=True),
                     )
                 )
         elif etype == "content_block_stop":
+            idx = getattr(event, "index", len(partial.content) - 1)
             if partial.content:
                 last = partial.content[-1]
                 if isinstance(last, TextContent):
                     ms.push(
                         StreamEvent(
                             type="text_end",
+                            content_index=idx,
                             partial=partial.model_copy(deep=True),
                         )
                     )
@@ -335,6 +346,7 @@ class AnthropicProvider:
                     ms.push(
                         StreamEvent(
                             type="thinking_end",
+                            content_index=idx,
                             partial=partial.model_copy(deep=True),
                         )
                     )
@@ -342,6 +354,7 @@ class AnthropicProvider:
                     ms.push(
                         StreamEvent(
                             type="toolcall_end",
+                            content_index=idx,
                             partial=partial.model_copy(deep=True),
                         )
                     )

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -160,6 +160,7 @@ class StreamEvent(BaseModel):
         "done",
         "error",
     ]
+    content_index: int | None = None
     delta: str | None = None
     partial: AssistantMessage | None = None
     error_message: str | None = None

--- a/cubepi/providers/faux.py
+++ b/cubepi/providers/faux.py
@@ -318,9 +318,12 @@ class FauxProvider:
 
             if isinstance(block, ThinkingContent):
                 partial.content.append(ThinkingContent(thinking=""))
+                block_idx = len(partial.content) - 1
                 stream.push(
                     StreamEvent(
-                        type="thinking_start", partial=partial.model_copy(deep=True)
+                        type="thinking_start",
+                        content_index=block_idx,
+                        partial=partial.model_copy(deep=True),
                     )
                 )
                 for chunk in _split_by_token_size(block.thinking, self._min, self._max):
@@ -343,20 +346,26 @@ class FauxProvider:
                         StreamEvent(
                             type="thinking_delta",
                             delta=chunk,
+                            content_index=block_idx,
                             partial=partial.model_copy(deep=True),
                         )
                     )
                 stream.push(
                     StreamEvent(
-                        type="thinking_end", partial=partial.model_copy(deep=True)
+                        type="thinking_end",
+                        content_index=block_idx,
+                        partial=partial.model_copy(deep=True),
                     )
                 )
 
             elif isinstance(block, TextContent):
                 partial.content.append(TextContent(text=""))
+                block_idx = len(partial.content) - 1
                 stream.push(
                     StreamEvent(
-                        type="text_start", partial=partial.model_copy(deep=True)
+                        type="text_start",
+                        content_index=block_idx,
+                        partial=partial.model_copy(deep=True),
                     )
                 )
                 for chunk in _split_by_token_size(block.text, self._min, self._max):
@@ -377,20 +386,28 @@ class FauxProvider:
                         StreamEvent(
                             type="text_delta",
                             delta=chunk,
+                            content_index=block_idx,
                             partial=partial.model_copy(deep=True),
                         )
                     )
                 stream.push(
-                    StreamEvent(type="text_end", partial=partial.model_copy(deep=True))
+                    StreamEvent(
+                        type="text_end",
+                        content_index=block_idx,
+                        partial=partial.model_copy(deep=True),
+                    )
                 )
 
             elif isinstance(block, ToolCall):
                 partial.content.append(
                     ToolCall(id=block.id, name=block.name, arguments={})
                 )
+                block_idx = len(partial.content) - 1
                 stream.push(
                     StreamEvent(
-                        type="toolcall_start", partial=partial.model_copy(deep=True)
+                        type="toolcall_start",
+                        content_index=block_idx,
+                        partial=partial.model_copy(deep=True),
                     )
                 )
                 json_str = json.dumps(block.arguments)
@@ -409,6 +426,7 @@ class FauxProvider:
                         StreamEvent(
                             type="toolcall_delta",
                             delta=chunk,
+                            content_index=block_idx,
                             partial=partial.model_copy(deep=True),
                         )
                     )
@@ -419,7 +437,9 @@ class FauxProvider:
                     )
                 stream.push(
                     StreamEvent(
-                        type="toolcall_end", partial=partial.model_copy(deep=True)
+                        type="toolcall_end",
+                        content_index=block_idx,
+                        partial=partial.model_copy(deep=True),
                     )
                 )
 

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -93,6 +93,7 @@ class OpenAIProvider:
                 current_text = ""
                 tool_calls_in_progress: dict[int, dict[str, Any]] = {}
                 text_started = False
+                text_content_index = 0
 
                 async for chunk in response:
                     if opts.signal and opts.signal.is_set():
@@ -118,9 +119,11 @@ class OpenAIProvider:
                     if delta.content:
                         if not text_started:
                             partial.content.append(TextContent(text=""))
+                            text_content_index = len(partial.content) - 1
                             ms.push(
                                 StreamEvent(
                                     type="text_start",
+                                    content_index=text_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -134,6 +137,7 @@ class OpenAIProvider:
                             StreamEvent(
                                 type="text_delta",
                                 delta=delta.content,
+                                content_index=text_content_index,
                                 partial=partial.model_copy(deep=True),
                             )
                         )
@@ -146,6 +150,7 @@ class OpenAIProvider:
                                     ms.push(
                                         StreamEvent(
                                             type="text_end",
+                                            content_index=text_content_index,
                                             partial=partial.model_copy(deep=True),
                                         )
                                     )
@@ -166,9 +171,12 @@ class OpenAIProvider:
                                         arguments={},
                                     )
                                 )
+                                tc_content_index = len(partial.content) - 1
+                                tool_calls_in_progress[idx]["content_index"] = str(tc_content_index)
                                 ms.push(
                                     StreamEvent(
                                         type="toolcall_start",
+                                        content_index=tc_content_index,
                                         partial=partial.model_copy(deep=True),
                                     )
                                 )
@@ -180,6 +188,7 @@ class OpenAIProvider:
                                     StreamEvent(
                                         type="toolcall_delta",
                                         delta=tc_delta.function.arguments,
+                                        content_index=int(tool_calls_in_progress[idx]["content_index"]),
                                         partial=partial.model_copy(deep=True),
                                     )
                                 )
@@ -192,6 +201,7 @@ class OpenAIProvider:
                             ms.push(
                                 StreamEvent(
                                     type="text_end",
+                                    content_index=text_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -208,6 +218,7 @@ class OpenAIProvider:
                             ms.push(
                                 StreamEvent(
                                     type="toolcall_end",
+                                    content_index=int(tc_data["content_index"]),
                                     partial=partial.model_copy(deep=True),
                                 )
                             )

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -172,7 +172,9 @@ class OpenAIProvider:
                                     )
                                 )
                                 tc_content_index = len(partial.content) - 1
-                                tool_calls_in_progress[idx]["content_index"] = str(tc_content_index)
+                                tool_calls_in_progress[idx]["content_index"] = str(
+                                    tc_content_index
+                                )
                                 ms.push(
                                     StreamEvent(
                                         type="toolcall_start",
@@ -188,7 +190,9 @@ class OpenAIProvider:
                                     StreamEvent(
                                         type="toolcall_delta",
                                         delta=tc_delta.function.arguments,
-                                        content_index=int(tool_calls_in_progress[idx]["content_index"]),
+                                        content_index=int(
+                                            tool_calls_in_progress[idx]["content_index"]
+                                        ),
                                         partial=partial.model_copy(deep=True),
                                     )
                                 )

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -114,6 +114,7 @@ class OpenAIResponsesProvider:
                 current_thinking = ""
                 current_text = ""
                 current_item_type: str | None = None
+                current_content_index = 0
                 # Per-item tool call state keyed by item.id
                 tool_state: dict[str, dict[str, str]] = {}
                 active_tool_item_id: str | None = None
@@ -144,9 +145,11 @@ class OpenAIResponsesProvider:
                             current_item_type = "reasoning"
                             current_thinking = ""
                             partial.content.append(ThinkingContent(thinking=""))
+                            current_content_index = len(partial.content) - 1
                             ms.push(
                                 StreamEvent(
                                     type="thinking_start",
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -154,9 +157,11 @@ class OpenAIResponsesProvider:
                             current_item_type = "message"
                             current_text = ""
                             partial.content.append(TextContent(text=""))
+                            current_content_index = len(partial.content) - 1
                             ms.push(
                                 StreamEvent(
                                     type="text_start",
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -181,9 +186,11 @@ class OpenAIResponsesProvider:
                                     arguments={},
                                 )
                             )
+                            current_content_index = len(partial.content) - 1
                             ms.push(
                                 StreamEvent(
                                     type="toolcall_start",
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -202,6 +209,7 @@ class OpenAIResponsesProvider:
                                 StreamEvent(
                                     type="thinking_delta",
                                     delta=event.delta,
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -219,6 +227,7 @@ class OpenAIResponsesProvider:
                                 StreamEvent(
                                     type="thinking_delta",
                                     delta=event.delta,
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -237,6 +246,7 @@ class OpenAIResponsesProvider:
                                 StreamEvent(
                                     type="thinking_delta",
                                     delta="\n\n",
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -253,6 +263,7 @@ class OpenAIResponsesProvider:
                                 StreamEvent(
                                     type="text_delta",
                                     delta=event.delta,
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -268,6 +279,7 @@ class OpenAIResponsesProvider:
                                 StreamEvent(
                                     type="text_delta",
                                     delta=event.delta,
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -280,6 +292,7 @@ class OpenAIResponsesProvider:
                                 StreamEvent(
                                     type="toolcall_delta",
                                     delta=event.delta,
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -308,6 +321,7 @@ class OpenAIResponsesProvider:
                             ms.push(
                                 StreamEvent(
                                     type="thinking_end",
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -333,6 +347,7 @@ class OpenAIResponsesProvider:
                             ms.push(
                                 StreamEvent(
                                     type="text_end",
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )
@@ -362,6 +377,7 @@ class OpenAIResponsesProvider:
                             ms.push(
                                 StreamEvent(
                                     type="toolcall_end",
+                                    content_index=current_content_index,
                                     partial=partial.model_copy(deep=True),
                                 )
                             )

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -102,6 +102,16 @@ class TestMessageTypes:
         assert td.name == "search"
 
 
+class TestStreamEvent:
+    def test_content_index_default_none(self):
+        event = StreamEvent(type="text_delta", delta="hi")
+        assert event.content_index is None
+
+    def test_content_index_set(self):
+        event = StreamEvent(type="text_start", content_index=0)
+        assert event.content_index == 0
+
+
 class TestMessageStream:
     async def test_stream_iteration_and_result(self):
         stream = MessageStream()

--- a/tests/providers/test_content_index.py
+++ b/tests/providers/test_content_index.py
@@ -1,0 +1,107 @@
+from cubepi.providers.base import Model
+from cubepi.providers.faux import (
+    FauxProvider,
+    faux_assistant_message,
+    faux_text,
+    faux_thinking,
+    faux_tool_call,
+)
+
+
+def _make_model() -> Model:
+    return Model(id="faux-1", provider="faux")
+
+
+class TestContentIndexTextOnly:
+    """FauxProvider text-only stream: all text events have content_index=0."""
+
+    async def test_text_only_content_index(self):
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("hello world")])
+
+        stream = await provider.stream(_make_model(), [])
+        events = [e async for e in stream]
+
+        # "start" event should have content_index=None
+        start_events = [e for e in events if e.type == "start"]
+        assert len(start_events) == 1
+        assert start_events[0].content_index is None
+
+        # All text_start, text_delta, text_end events should have content_index=0
+        text_events = [
+            e for e in events if e.type in ("text_start", "text_delta", "text_end")
+        ]
+        assert len(text_events) >= 3  # at least start + 1 delta + end
+        for e in text_events:
+            assert e.content_index == 0, f"{e.type} had content_index={e.content_index}"
+
+
+class TestContentIndexThinkingAndText:
+    """FauxProvider thinking+text: thinking events index 0, text events index 1."""
+
+    async def test_thinking_then_text_content_index(self):
+        provider = FauxProvider()
+        provider.set_responses(
+            [faux_assistant_message([faux_thinking("let me think"), faux_text("answer")])]
+        )
+
+        stream = await provider.stream(_make_model(), [])
+        events = [e async for e in stream]
+
+        thinking_events = [
+            e
+            for e in events
+            if e.type in ("thinking_start", "thinking_delta", "thinking_end")
+        ]
+        assert len(thinking_events) >= 3
+        for e in thinking_events:
+            assert (
+                e.content_index == 0
+            ), f"{e.type} had content_index={e.content_index}"
+
+        text_events = [
+            e for e in events if e.type in ("text_start", "text_delta", "text_end")
+        ]
+        assert len(text_events) >= 3
+        for e in text_events:
+            assert (
+                e.content_index == 1
+            ), f"{e.type} had content_index={e.content_index}"
+
+
+class TestContentIndexTextAndToolCall:
+    """FauxProvider text+tool_call: text events index 0, tool events index 1."""
+
+    async def test_text_then_tool_content_index(self):
+        provider = FauxProvider()
+        provider.set_responses(
+            [
+                faux_assistant_message(
+                    [faux_text("searching"), faux_tool_call("search", {"q": "test"}, id="tc-1")],
+                    stop_reason="tool_use",
+                )
+            ]
+        )
+
+        stream = await provider.stream(_make_model(), [])
+        events = [e async for e in stream]
+
+        text_events = [
+            e for e in events if e.type in ("text_start", "text_delta", "text_end")
+        ]
+        assert len(text_events) >= 3
+        for e in text_events:
+            assert (
+                e.content_index == 0
+            ), f"{e.type} had content_index={e.content_index}"
+
+        tool_events = [
+            e
+            for e in events
+            if e.type in ("toolcall_start", "toolcall_delta", "toolcall_end")
+        ]
+        assert len(tool_events) >= 3
+        for e in tool_events:
+            assert (
+                e.content_index == 1
+            ), f"{e.type} had content_index={e.content_index}"

--- a/tests/providers/test_content_index.py
+++ b/tests/providers/test_content_index.py
@@ -42,7 +42,11 @@ class TestContentIndexThinkingAndText:
     async def test_thinking_then_text_content_index(self):
         provider = FauxProvider()
         provider.set_responses(
-            [faux_assistant_message([faux_thinking("let me think"), faux_text("answer")])]
+            [
+                faux_assistant_message(
+                    [faux_thinking("let me think"), faux_text("answer")]
+                )
+            ]
         )
 
         stream = await provider.stream(_make_model(), [])
@@ -55,18 +59,14 @@ class TestContentIndexThinkingAndText:
         ]
         assert len(thinking_events) >= 3
         for e in thinking_events:
-            assert (
-                e.content_index == 0
-            ), f"{e.type} had content_index={e.content_index}"
+            assert e.content_index == 0, f"{e.type} had content_index={e.content_index}"
 
         text_events = [
             e for e in events if e.type in ("text_start", "text_delta", "text_end")
         ]
         assert len(text_events) >= 3
         for e in text_events:
-            assert (
-                e.content_index == 1
-            ), f"{e.type} had content_index={e.content_index}"
+            assert e.content_index == 1, f"{e.type} had content_index={e.content_index}"
 
 
 class TestContentIndexTextAndToolCall:
@@ -77,7 +77,10 @@ class TestContentIndexTextAndToolCall:
         provider.set_responses(
             [
                 faux_assistant_message(
-                    [faux_text("searching"), faux_tool_call("search", {"q": "test"}, id="tc-1")],
+                    [
+                        faux_text("searching"),
+                        faux_tool_call("search", {"q": "test"}, id="tc-1"),
+                    ],
                     stop_reason="tool_use",
                 )
             ]
@@ -91,9 +94,7 @@ class TestContentIndexTextAndToolCall:
         ]
         assert len(text_events) >= 3
         for e in text_events:
-            assert (
-                e.content_index == 0
-            ), f"{e.type} had content_index={e.content_index}"
+            assert e.content_index == 0, f"{e.type} had content_index={e.content_index}"
 
         tool_events = [
             e
@@ -102,6 +103,4 @@ class TestContentIndexTextAndToolCall:
         ]
         assert len(tool_events) >= 3
         for e in tool_events:
-            assert (
-                e.content_index == 1
-            ), f"{e.type} had content_index={e.content_index}"
+            assert e.content_index == 1, f"{e.type} had content_index={e.content_index}"


### PR DESCRIPTION
## Summary

- Added `content_index: int | None = None` field to `StreamEvent` in `cubepi/providers/base.py`, positioned after `type`
- Populated `content_index` in all four providers (FauxProvider, AnthropicProvider, OpenAIProvider, OpenAIResponsesProvider) so every content-block-level event (`*_start`, `*_delta`, `*_end`) carries the index of its block within `partial.content`
- Message-level events (`start`, `done`, `error`) keep `content_index=None`

Closes #16

## Test plan

- [x] Added `TestStreamEvent` to `tests/providers/test_base.py` verifying default `None` and explicit set
- [x] Created `tests/providers/test_content_index.py` with three test cases:
  - Text-only stream: all text events have `content_index=0`
  - Thinking + text: thinking events index 0, text events index 1
  - Text + tool_call: text events index 0, tool events index 1
- [x] All 270 tests pass (`pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q`)