### PR TITLE
feat: add image content support to OpenAI providers

### DIFF
--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -9,6 +9,7 @@ from cubepi.utils.json_parse import parse_streaming_json
 
 from cubepi.providers.base import (
     AssistantMessage,
+    ImageContent,
     Message,
     MessageStream,
     Model,
@@ -250,6 +251,22 @@ class OpenAIProvider:
     @staticmethod
     def _convert_message(msg: Message) -> dict[str, Any]:
         if isinstance(msg, UserMessage):
+            has_image = any(isinstance(c, ImageContent) for c in msg.content)
+            if has_image:
+                parts: list[dict[str, Any]] = []
+                for c in msg.content:
+                    if isinstance(c, TextContent):
+                        parts.append({"type": "text", "text": c.text})
+                    elif isinstance(c, ImageContent):
+                        parts.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:{c.media_type};base64,{c.source}"
+                                },
+                            }
+                        )
+                return {"role": "user", "content": parts}
             text_parts = [c.text for c in msg.content if isinstance(c, TextContent)]
             return {"role": "user", "content": "\n".join(text_parts)}
 

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from cubepi.providers.base import (
     AssistantMessage,
+    ImageContent,
     Message,
     MessageStream,
     Model,
@@ -471,6 +472,13 @@ class OpenAIResponsesProvider:
                 for c in msg.content:
                     if isinstance(c, TextContent):
                         content.append({"type": "input_text", "text": c.text})
+                    elif isinstance(c, ImageContent):
+                        content.append(
+                            {
+                                "type": "input_image",
+                                "image_url": f"data:{c.media_type};base64,{c.source}",
+                            }
+                        )
                 if content:
                     api_input.append({"role": "user", "content": content})
 

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -1,6 +1,7 @@
 from cubepi.providers.openai import OpenAIProvider
 from cubepi.providers.base import (
     AssistantMessage,
+    ImageContent,
     TextContent,
     ToolCall,
     ToolDefinition,
@@ -44,6 +45,29 @@ class TestOpenAIMessageConversion:
         assert result["role"] == "tool"
         assert result["tool_call_id"] == "tc-1"
         assert result["content"] == "result"
+
+
+class TestOpenAIImageConversion:
+    def test_user_message_with_image(self):
+        msg = UserMessage(content=[
+            TextContent(text="What's in this image?"),
+            ImageContent(source="base64data", media_type="image/png"),
+        ])
+        result = OpenAIProvider._convert_message(msg)
+        assert result["role"] == "user"
+        assert isinstance(result["content"], list)
+        assert len(result["content"]) == 2
+        assert result["content"][0] == {"type": "text", "text": "What's in this image?"}
+        assert result["content"][1] == {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,base64data"},
+        }
+
+    def test_user_message_text_only_stays_simple(self):
+        msg = UserMessage(content=[TextContent(text="hello")])
+        result = OpenAIProvider._convert_message(msg)
+        assert result["role"] == "user"
+        assert result["content"] == "hello"
 
 
 class TestOpenAIToolConversion:

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -49,10 +49,12 @@ class TestOpenAIMessageConversion:
 
 class TestOpenAIImageConversion:
     def test_user_message_with_image(self):
-        msg = UserMessage(content=[
-            TextContent(text="What's in this image?"),
-            ImageContent(source="base64data", media_type="image/png"),
-        ])
+        msg = UserMessage(
+            content=[
+                TextContent(text="What's in this image?"),
+                ImageContent(source="base64data", media_type="image/png"),
+            ]
+        )
         result = OpenAIProvider._convert_message(msg)
         assert result["role"] == "user"
         assert isinstance(result["content"], list)

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -147,10 +147,12 @@ class TestBuildInput:
 
 class TestOpenAIResponsesImageConversion:
     def test_user_message_with_image(self):
-        msg = UserMessage(content=[
-            TextContent(text="Describe this"),
-            ImageContent(source="imgdata", media_type="image/jpeg"),
-        ])
+        msg = UserMessage(
+            content=[
+                TextContent(text="Describe this"),
+                ImageContent(source="imgdata", media_type="image/jpeg"),
+            ]
+        )
         result = OpenAIResponsesProvider._build_input([msg])
         assert len(result) == 1
         assert result[0]["role"] == "user"

--- a/tests/providers/test_openai_responses.py
+++ b/tests/providers/test_openai_responses.py
@@ -10,6 +10,7 @@ import pytest
 
 from cubepi.providers.base import (
     AssistantMessage,
+    ImageContent,
     Model,
     StreamOptions,
     TextContent,
@@ -142,6 +143,24 @@ class TestBuildInput:
         assert result[1]["type"] == "message"
         assert result[2]["type"] == "function_call"
         assert result[3]["type"] == "function_call_output"
+
+
+class TestOpenAIResponsesImageConversion:
+    def test_user_message_with_image(self):
+        msg = UserMessage(content=[
+            TextContent(text="Describe this"),
+            ImageContent(source="imgdata", media_type="image/jpeg"),
+        ])
+        result = OpenAIResponsesProvider._build_input([msg])
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        content = result[0]["content"]
+        assert len(content) == 2
+        assert content[0] == {"type": "input_text", "text": "Describe this"}
+        assert content[1] == {
+            "type": "input_image",
+            "image_url": "data:image/jpeg;base64,imgdata",
+        }
 
 
 class TestConvertTool:


### PR DESCRIPTION
## Summary
- Handle `ImageContent` in `OpenAIProvider._convert_message` — when images are present, builds a list of content parts (`text` + `image_url`) instead of a plain string; text-only messages retain the existing simple string format
- Handle `ImageContent` in `OpenAIResponsesProvider._build_input` — converts image blocks to `input_image` parts alongside `input_text` parts
- Add tests for both providers covering image conversion and verifying text-only messages remain unchanged

## Test plan
- [x] `TestOpenAIImageConversion.test_user_message_with_image` — verifies mixed text+image produces correct list-of-parts format
- [x] `TestOpenAIImageConversion.test_user_message_text_only_stays_simple` — verifies text-only stays as plain string
- [x] `TestOpenAIResponsesImageConversion.test_user_message_with_image` — verifies Responses API image format
- [x] Full test suite passes (268 tests, 0 failures)

Closes #22