### PR TITLE
feat: add provider metadata fields to AssistantMessage

### DIFF
--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -109,7 +109,11 @@ class AnthropicProvider:
                         )
 
                     partial = AssistantMessage(
-                        content=[], usage=Usage(), timestamp=time.time()
+                        content=[],
+                        usage=Usage(),
+                        timestamp=time.time(),
+                        provider_id=model.provider,
+                        model_id=model.id,
                     )
                     ms.push(
                         StreamEvent(type="start", partial=partial.model_copy(deep=True))
@@ -135,7 +139,7 @@ class AnthropicProvider:
                         self._handle_event(event, partial, ms)
 
                     final_msg = stream.get_final_message()
-                    result = self._convert_response(final_msg)
+                    result = self._convert_response(final_msg, model)
                     ms.push(StreamEvent(type="done"))
                     ms.set_result(result)
 
@@ -360,7 +364,7 @@ class AnthropicProvider:
                     )
 
     @staticmethod
-    def _convert_response(response: Any) -> AssistantMessage:
+    def _convert_response(response: Any, model: Model) -> AssistantMessage:
         content: list[Any] = []
         for block in response.content:
             if block.type == "text":
@@ -392,4 +396,7 @@ class AnthropicProvider:
                 or 0,
             ),
             timestamp=time.time(),
+            provider_id=model.provider,
+            model_id=model.id,
+            response_id=getattr(response, "id", None),
         )

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -125,6 +125,9 @@ class AssistantMessage(BaseModel):
     error_message: str | None = None
     usage: Usage | None = None
     timestamp: float | None = None
+    provider_id: str = ""
+    model_id: str = ""
+    response_id: str | None = None
 
 
 class ToolResultMessage(BaseModel):

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -85,7 +85,11 @@ class OpenAIProvider:
                     )
 
                 partial = AssistantMessage(
-                    content=[], usage=Usage(), timestamp=time.time()
+                    content=[],
+                    usage=Usage(),
+                    timestamp=time.time(),
+                    provider_id=model.provider,
+                    model_id=model.id,
                 )
                 ms.push(
                     StreamEvent(type="start", partial=partial.model_copy(deep=True))
@@ -95,8 +99,12 @@ class OpenAIProvider:
                 tool_calls_in_progress: dict[int, dict[str, Any]] = {}
                 text_started = False
                 text_content_index = 0
+                response_id: str | None = None
 
                 async for chunk in response:
+                    if response_id is None and getattr(chunk, "id", None):
+                        response_id = chunk.id
+                        partial.response_id = response_id
                     if opts.signal and opts.signal.is_set():
                         aborted = partial.model_copy(
                             update={

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -105,7 +105,11 @@ class OpenAIResponsesProvider:
             try:
                 response = await self._client.responses.create(**kwargs)
                 partial = AssistantMessage(
-                    content=[], usage=Usage(), timestamp=time.time()
+                    content=[],
+                    usage=Usage(),
+                    timestamp=time.time(),
+                    provider_id=model.provider,
+                    model_id=model.id,
                 )
                 ms.push(
                     StreamEvent(type="start", partial=partial.model_copy(deep=True))
@@ -407,6 +411,9 @@ class OpenAIResponsesProvider:
                             update={
                                 "usage": usage,
                                 "stop_reason": stop_reason,
+                                "response_id": getattr(resp, "id", None)
+                                if resp
+                                else None,
                             }
                         )
                         ms.push(StreamEvent(type="done"))

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -184,3 +184,22 @@ class TestMessageStreamTaskTracking:
         ms.attach_task(task)
         with pytest.raises(RuntimeError, match="producer died"):
             await ms.result()
+
+
+class TestAssistantMessageMetadata:
+    def test_default_metadata_fields(self):
+        msg = AssistantMessage(content=[])
+        assert msg.provider_id == ""
+        assert msg.model_id == ""
+        assert msg.response_id is None
+
+    def test_metadata_fields_set(self):
+        msg = AssistantMessage(
+            content=[],
+            provider_id="anthropic",
+            model_id="claude-sonnet-4-20250514",
+            response_id="msg_abc123",
+        )
+        assert msg.provider_id == "anthropic"
+        assert msg.model_id == "claude-sonnet-4-20250514"
+        assert msg.response_id == "msg_abc123"


### PR DESCRIPTION
## Summary

- Add `provider_id`, `model_id`, and `response_id` fields to `AssistantMessage` in `cubepi/providers/base.py`
- Fill metadata in `AnthropicProvider`, `OpenAIProvider`, and `OpenAIResponsesProvider` during streaming and final response construction
- Add unit tests verifying default values and explicit field assignment

Closes #17

## Test plan

- [x] `pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q` -- 267 passed
- [x] New `TestAssistantMessageMetadata` class covers default and explicit field values