### PR TITLE
refactor: extract shared emit_event helper, remove duplicate _emit

### DIFF
--- a/cubepi/agent/__init__.py
+++ b/cubepi/agent/__init__.py
@@ -22,6 +22,7 @@ from cubepi.agent.types import (
     ToolExecutionUpdateEvent,
     TurnEndEvent,
     TurnStartEvent,
+    emit_event,
 )
 
 __all__ = [
@@ -50,4 +51,5 @@ __all__ = [
     "ToolExecutionUpdateEvent",
     "TurnEndEvent",
     "TurnStartEvent",
+    "emit_event",
 ]

--- a/cubepi/agent/__init__.py
+++ b/cubepi/agent/__init__.py
@@ -22,8 +22,8 @@ from cubepi.agent.types import (
     ToolExecutionUpdateEvent,
     TurnEndEvent,
     TurnStartEvent,
-    emit_event,
 )
+from cubepi.utils import emit_event
 
 __all__ = [
     "Agent",

--- a/cubepi/agent/loop.py
+++ b/cubepi/agent/loop.py
@@ -14,8 +14,8 @@ from cubepi.agent.types import (
     ShouldStopAfterTurnContext,
     TurnEndEvent,
     TurnStartEvent,
-    emit_event,
 )
+from cubepi.utils import emit_event
 from cubepi.providers.base import (
     AssistantMessage,
     Model,
@@ -154,8 +154,8 @@ async def _run_loop(
         pending = await get_steering_messages() or []
         if pending:
             for msg in pending:
-                await _emit(emit, MessageStartEvent(message=msg))
-                await _emit(emit, MessageEndEvent(message=msg))
+                await emit_event(emit, MessageStartEvent(message=msg))
+                await emit_event(emit, MessageEndEvent(message=msg))
                 current_context.messages.append(msg)
                 new_messages.append(msg)
 

--- a/cubepi/agent/loop.py
+++ b/cubepi/agent/loop.py
@@ -14,6 +14,7 @@ from cubepi.agent.types import (
     ShouldStopAfterTurnContext,
     TurnEndEvent,
     TurnStartEvent,
+    emit_event,
 )
 from cubepi.providers.base import (
     AssistantMessage,
@@ -23,12 +24,6 @@ from cubepi.providers.base import (
     ToolCall,
     ToolResultMessage,
 )
-
-
-async def _emit(emit_fn: Callable, event: Any) -> None:
-    result = emit_fn(event)
-    if asyncio.iscoroutine(result):
-        await result
 
 
 async def run_agent_loop(
@@ -58,11 +53,11 @@ async def run_agent_loop(
         tools=context.tools,
     )
 
-    await _emit(emit, AgentStartEvent())
-    await _emit(emit, TurnStartEvent())
+    await emit_event(emit, AgentStartEvent())
+    await emit_event(emit, TurnStartEvent())
     for prompt in prompts:
-        await _emit(emit, MessageStartEvent(message=prompt))
-        await _emit(emit, MessageEndEvent(message=prompt))
+        await emit_event(emit, MessageStartEvent(message=prompt))
+        await emit_event(emit, MessageEndEvent(message=prompt))
 
     await _run_loop(
         current_context=current_context,
@@ -112,8 +107,8 @@ async def run_agent_loop_continue(
         tools=context.tools,
     )
 
-    await _emit(emit, AgentStartEvent())
-    await _emit(emit, TurnStartEvent())
+    await emit_event(emit, AgentStartEvent())
+    await emit_event(emit, TurnStartEvent())
 
     await _run_loop(
         current_context=current_context,
@@ -169,7 +164,7 @@ async def _run_loop(
 
         while has_more_tool_calls:
             if not first_turn:
-                await _emit(emit, TurnStartEvent())
+                await emit_event(emit, TurnStartEvent())
             else:
                 first_turn = False
 
@@ -185,8 +180,8 @@ async def _run_loop(
             new_messages.append(message)
 
             if message.stop_reason in ("error", "aborted"):
-                await _emit(emit, TurnEndEvent(message=message, tool_results=[]))
-                await _emit(emit, AgentEndEvent(messages=new_messages))
+                await emit_event(emit, TurnEndEvent(message=message, tool_results=[]))
+                await emit_event(emit, AgentEndEvent(messages=new_messages))
                 return
 
             tool_calls = [c for c in message.content if isinstance(c, ToolCall)]
@@ -210,7 +205,7 @@ async def _run_loop(
                     current_context.messages.append(result)
                     new_messages.append(result)
 
-            await _emit(emit, TurnEndEvent(message=message, tool_results=tool_results))
+            await emit_event(emit, TurnEndEvent(message=message, tool_results=tool_results))
 
             if should_stop_after_turn:
                 stop_ctx = ShouldStopAfterTurnContext(
@@ -220,7 +215,7 @@ async def _run_loop(
                     new_messages=new_messages,
                 )
                 if await should_stop_after_turn(stop_ctx):
-                    await _emit(emit, AgentEndEvent(messages=new_messages))
+                    await emit_event(emit, AgentEndEvent(messages=new_messages))
                     return
 
             # Check for steering messages after tool execution
@@ -228,8 +223,8 @@ async def _run_loop(
                 steering = await get_steering_messages() or []
                 if steering:
                     for msg in steering:
-                        await _emit(emit, MessageStartEvent(message=msg))
-                        await _emit(emit, MessageEndEvent(message=msg))
+                        await emit_event(emit, MessageStartEvent(message=msg))
+                        await emit_event(emit, MessageEndEvent(message=msg))
                         current_context.messages.append(msg)
                         new_messages.append(msg)
 
@@ -238,8 +233,8 @@ async def _run_loop(
             follow_ups = await get_follow_up_messages() or []
             if follow_ups:
                 for msg in follow_ups:
-                    await _emit(emit, MessageStartEvent(message=msg))
-                    await _emit(emit, MessageEndEvent(message=msg))
+                    await emit_event(emit, MessageStartEvent(message=msg))
+                    await emit_event(emit, MessageEndEvent(message=msg))
                     current_context.messages.append(msg)
                     new_messages.append(msg)
                 first_turn = False
@@ -247,7 +242,7 @@ async def _run_loop(
 
         break
 
-    await _emit(emit, AgentEndEvent(messages=new_messages))
+    await emit_event(emit, AgentEndEvent(messages=new_messages))
 
 
 async def _stream_assistant_response(
@@ -288,7 +283,7 @@ async def _stream_assistant_response(
             if partial_message:
                 context.messages.append(partial_message)
                 added_partial = True
-                await _emit(
+                await emit_event(
                     emit,
                     MessageStartEvent(message=partial_message.model_copy(deep=True)),
                 )
@@ -307,7 +302,7 @@ async def _stream_assistant_response(
             if partial_message and event.partial:
                 partial_message = event.partial
                 context.messages[-1] = partial_message
-                await _emit(
+                await emit_event(
                     emit,
                     MessageUpdateEvent(
                         message=partial_message.model_copy(deep=True),
@@ -322,8 +317,8 @@ async def _stream_assistant_response(
             else:
                 context.messages.append(final_message)
             if not added_partial:
-                await _emit(emit, MessageStartEvent(message=final_message))
-            await _emit(emit, MessageEndEvent(message=final_message))
+                await emit_event(emit, MessageStartEvent(message=final_message))
+            await emit_event(emit, MessageEndEvent(message=final_message))
             return final_message
 
     # Fallback: stream ended without done/error event
@@ -332,6 +327,6 @@ async def _stream_assistant_response(
         context.messages[-1] = final_message
     else:
         context.messages.append(final_message)
-        await _emit(emit, MessageStartEvent(message=final_message))
-    await _emit(emit, MessageEndEvent(message=final_message))
+        await emit_event(emit, MessageStartEvent(message=final_message))
+    await emit_event(emit, MessageEndEvent(message=final_message))
     return final_message

--- a/cubepi/agent/loop.py
+++ b/cubepi/agent/loop.py
@@ -205,7 +205,9 @@ async def _run_loop(
                     current_context.messages.append(result)
                     new_messages.append(result)
 
-            await emit_event(emit, TurnEndEvent(message=message, tool_results=tool_results))
+            await emit_event(
+                emit, TurnEndEvent(message=message, tool_results=tool_results)
+            )
 
             if should_stop_after_turn:
                 stop_ctx = ShouldStopAfterTurnContext(

--- a/cubepi/agent/tools.py
+++ b/cubepi/agent/tools.py
@@ -18,6 +18,7 @@ from cubepi.agent.types import (
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
+    emit_event,
 )
 from cubepi.providers.base import (
     AssistantMessage,
@@ -66,12 +67,6 @@ def _make_tool_result_message(finalized: _FinalizedOutcome) -> ToolResultMessage
         is_error=finalized.is_error,
         timestamp=time.time(),
     )
-
-
-async def _emit(emit_fn: Callable, event: Any) -> None:
-    result = emit_fn(event)
-    if asyncio.iscoroutine(result):
-        await result
 
 
 async def _prepare_tool_call(
@@ -131,7 +126,7 @@ async def _execute_prepared(
             prepared.tool_call.id,
             prepared.args,
             signal=signal,
-            on_update=lambda partial: _emit(
+            on_update=lambda partial: emit_event(
                 emit_fn,
                 ToolExecutionUpdateEvent(
                     tool_call_id=prepared.tool_call.id,
@@ -256,7 +251,7 @@ async def _execute_sequential(
     messages: list[ToolResultMessage] = []
 
     for tc in tool_calls:
-        await _emit(
+        await emit_event(
             emit_fn,
             ToolExecutionStartEvent(
                 tool_call_id=tc.id, tool_name=tc.name, args=tc.arguments
@@ -285,7 +280,7 @@ async def _execute_sequential(
                 signal,
             )
 
-        await _emit(
+        await emit_event(
             emit_fn,
             ToolExecutionEndEvent(
                 tool_call_id=tc.id,
@@ -295,8 +290,8 @@ async def _execute_sequential(
             ),
         )
         tool_msg = _make_tool_result_message(finalized)
-        await _emit(emit_fn, MessageStartEvent(message=tool_msg))
-        await _emit(emit_fn, MessageEndEvent(message=tool_msg))
+        await emit_event(emit_fn, MessageStartEvent(message=tool_msg))
+        await emit_event(emit_fn, MessageEndEvent(message=tool_msg))
         finalized_list.append(finalized)
         messages.append(tool_msg)
 
@@ -315,7 +310,7 @@ async def _execute_parallel(
     entries: list[_FinalizedOutcome | asyncio.Task] = []
 
     for tc in tool_calls:
-        await _emit(
+        await emit_event(
             emit_fn,
             ToolExecutionStartEvent(
                 tool_call_id=tc.id, tool_name=tc.name, args=tc.arguments
@@ -332,7 +327,7 @@ async def _execute_parallel(
                 result=preparation.result,
                 is_error=preparation.is_error,
             )
-            await _emit(
+            await emit_event(
                 emit_fn,
                 ToolExecutionEndEvent(
                     tool_call_id=tc.id,
@@ -355,7 +350,7 @@ async def _execute_parallel(
                     after_tool_call,
                     signal,
                 )
-                await _emit(
+                await emit_event(
                     emit_fn,
                     ToolExecutionEndEvent(
                         tool_call_id=prep.tool_call.id,
@@ -378,8 +373,8 @@ async def _execute_parallel(
     messages: list[ToolResultMessage] = []
     for finalized in finalized_list:
         tool_msg = _make_tool_result_message(finalized)
-        await _emit(emit_fn, MessageStartEvent(message=tool_msg))
-        await _emit(emit_fn, MessageEndEvent(message=tool_msg))
+        await emit_event(emit_fn, MessageStartEvent(message=tool_msg))
+        await emit_event(emit_fn, MessageEndEvent(message=tool_msg))
         messages.append(tool_msg)
 
     return ToolCallBatch(messages=messages, terminate=_should_terminate(finalized_list))

--- a/cubepi/agent/tools.py
+++ b/cubepi/agent/tools.py
@@ -18,8 +18,8 @@ from cubepi.agent.types import (
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
-    emit_event,
 )
+from cubepi.utils import emit_event
 from cubepi.providers.base import (
     AssistantMessage,
     TextContent,

--- a/cubepi/agent/types.py
+++ b/cubepi/agent/types.py
@@ -168,3 +168,9 @@ AgentEvent = (
 AgentEventSink = Callable[[AgentEvent], Awaitable[None]]
 
 AgentListener = Callable[[AgentEvent, asyncio.Event | None], Awaitable[None] | None]
+
+
+async def emit_event(emit_fn: Callable, event: AgentEvent) -> None:
+    result = emit_fn(event)
+    if asyncio.iscoroutine(result):
+        await result

--- a/cubepi/agent/types.py
+++ b/cubepi/agent/types.py
@@ -168,9 +168,3 @@ AgentEvent = (
 AgentEventSink = Callable[[AgentEvent], Awaitable[None]]
 
 AgentListener = Callable[[AgentEvent, asyncio.Event | None], Awaitable[None] | None]
-
-
-async def emit_event(emit_fn: Callable, event: AgentEvent) -> None:
-    result = emit_fn(event)
-    if asyncio.iscoroutine(result):
-        await result

--- a/cubepi/utils/__init__.py
+++ b/cubepi/utils/__init__.py
@@ -1,5 +1,6 @@
 """cubepi.utils — utility modules."""
 
+from cubepi.utils.emit import emit_event
 from cubepi.utils.json_parse import parse_streaming_json, repair_json
 
-__all__ = ["parse_streaming_json", "repair_json"]
+__all__ = ["emit_event", "parse_streaming_json", "repair_json"]

--- a/cubepi/utils/emit.py
+++ b/cubepi/utils/emit.py
@@ -1,0 +1,10 @@
+"""Event emission helper shared by the agent loop and tool executor."""
+
+import asyncio
+from collections.abc import Callable
+
+
+async def emit_event(emit_fn: Callable, event: object) -> None:
+    result = emit_fn(event)
+    if asyncio.iscoroutine(result):
+        await result


### PR DESCRIPTION
## Summary
- Extracts the duplicate `_emit` async helper from `agent/loop.py` and `agent/tools.py` into a shared `emit_event` function in `agent/types.py`
- Replaces all call sites in both modules to use the shared `emit_event`
- Exports `emit_event` from the `cubepi.agent` package

Closes #23

## Test plan
- [x] All 265 existing tests pass (`pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q`)
- [x] Pure refactoring with no behavior change