### PR TITLE
refactor: remove dead code, rename private helpers to public API

### DIFF
--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -21,8 +21,8 @@ from cubepi.providers.base import (
     Usage,
     UserMessage,
     adjust_max_tokens_for_thinking,
-    _invoke_on_payload,
-    _invoke_on_response,
+    invoke_on_payload,
+    invoke_on_response,
 )
 from cubepi.providers.models import clamp_thinking_level
 
@@ -93,13 +93,13 @@ class AnthropicProvider:
         async def _produce() -> None:
             try:
                 nonlocal kwargs
-                kwargs = await _invoke_on_payload(opts.on_payload, kwargs, model)
+                kwargs = await invoke_on_payload(opts.on_payload, kwargs, model)
 
                 async with self._client.messages.stream(**kwargs) as stream:
                     # Invoke on_response with HTTP metadata if available
                     http_response = getattr(stream, "response", None)
                     if http_response is not None:
-                        await _invoke_on_response(
+                        await invoke_on_response(
                             opts.on_response,
                             ProviderResponse(
                                 status=http_response.status_code,

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -222,7 +222,7 @@ class StreamOptions(BaseModel):
     on_response: OnResponseCallback | None = None
 
 
-async def _invoke_on_payload(
+async def invoke_on_payload(
     callback: OnPayloadCallback | None,
     payload: dict,
     model: Model,
@@ -236,7 +236,7 @@ async def _invoke_on_payload(
     return result if isinstance(result, dict) else payload
 
 
-async def _invoke_on_response(
+async def invoke_on_response(
     callback: OnResponseCallback | None,
     response: ProviderResponse,
     model: Model,

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -21,8 +21,8 @@ from cubepi.providers.base import (
     ToolResultMessage,
     Usage,
     UserMessage,
-    _invoke_on_payload,
-    _invoke_on_response,
+    invoke_on_payload,
+    invoke_on_response,
 )
 
 
@@ -67,14 +67,14 @@ class OpenAIProvider:
         async def _produce() -> None:
             try:
                 nonlocal kwargs
-                kwargs = await _invoke_on_payload(opts.on_payload, kwargs, model)
+                kwargs = await invoke_on_payload(opts.on_payload, kwargs, model)
 
                 response = await self._client.chat.completions.create(**kwargs)
 
                 # Invoke on_response with HTTP metadata if available
                 http_response = getattr(response, "response", None)
                 if http_response is not None:
-                    await _invoke_on_response(
+                    await invoke_on_response(
                         opts.on_response,
                         ProviderResponse(
                             status=http_response.status_code,

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -77,13 +77,7 @@ class OpenAIResponsesProvider:
 
         if system_prompt:
             role = "developer" if model.reasoning else "system"
-            kwargs["instructions"] = system_prompt
-            # The instructions param uses system/developer role implicitly.
-            # For explicit role control, prepend to input instead.
             kwargs["input"] = [{"role": role, "content": system_prompt}] + api_input
-
-            # Remove instructions since we use input-based system prompt
-            del kwargs["instructions"]
 
         if tools:
             kwargs["tools"] = [self._convert_tool(t) for t in tools]

--- a/tests/providers/test_hooks.py
+++ b/tests/providers/test_hooks.py
@@ -10,8 +10,8 @@ from cubepi.providers.base import (
     Model,
     ProviderResponse,
     StreamOptions,
-    _invoke_on_payload,
-    _invoke_on_response,
+    invoke_on_payload,
+    invoke_on_response,
 )
 
 
@@ -43,26 +43,26 @@ class TestProviderResponse:
 
 
 # ---------------------------------------------------------------------------
-# _invoke_on_payload helper
+# invoke_on_payload helper
 # ---------------------------------------------------------------------------
 
 
 class TestInvokeOnPayload:
     async def test_none_callback_returns_original(self):
         payload = {"model": "test"}
-        result = await _invoke_on_payload(None, payload, _model())
+        result = await invoke_on_payload(None, payload, _model())
         assert result is payload
 
     async def test_sync_callback_returning_dict_replaces(self):
         replacement = {"model": "replaced"}
-        result = await _invoke_on_payload(
+        result = await invoke_on_payload(
             lambda p, m: replacement, {"model": "original"}, _model()
         )
         assert result is replacement
 
     async def test_sync_callback_returning_none_keeps_original(self):
         original = {"model": "original"}
-        result = await _invoke_on_payload(lambda p, m: None, original, _model())
+        result = await invoke_on_payload(lambda p, m: None, original, _model())
         assert result is original
 
     async def test_async_callback_returning_dict_replaces(self):
@@ -71,7 +71,7 @@ class TestInvokeOnPayload:
         async def cb(p: dict, m: Model) -> dict:
             return replacement
 
-        result = await _invoke_on_payload(cb, {"model": "original"}, _model())
+        result = await invoke_on_payload(cb, {"model": "original"}, _model())
         assert result is replacement
 
     async def test_async_callback_returning_none_keeps_original(self):
@@ -80,7 +80,7 @@ class TestInvokeOnPayload:
         async def cb(p: dict, m: Model) -> None:
             return None
 
-        result = await _invoke_on_payload(cb, original, _model())
+        result = await invoke_on_payload(cb, original, _model())
         assert result is original
 
     async def test_callback_receives_correct_args(self):
@@ -92,21 +92,21 @@ class TestInvokeOnPayload:
 
         payload = {"model": "test-model"}
         model = _model()
-        await _invoke_on_payload(cb, payload, model)
+        await invoke_on_payload(cb, payload, model)
         assert len(received) == 1
         assert received[0][0] is payload
         assert received[0][1] is model
 
 
 # ---------------------------------------------------------------------------
-# _invoke_on_response helper
+# invoke_on_response helper
 # ---------------------------------------------------------------------------
 
 
 class TestInvokeOnResponse:
     async def test_none_callback_is_noop(self):
         # Should not raise
-        await _invoke_on_response(None, ProviderResponse(status=200), _model())
+        await invoke_on_response(None, ProviderResponse(status=200), _model())
 
     async def test_sync_callback_called(self):
         received: list[tuple[ProviderResponse, Model]] = []
@@ -116,7 +116,7 @@ class TestInvokeOnResponse:
 
         resp = ProviderResponse(status=200, headers={"h": "v"})
         model = _model()
-        await _invoke_on_response(cb, resp, model)
+        await invoke_on_response(cb, resp, model)
         assert len(received) == 1
         assert received[0][0] is resp
         assert received[0][1] is model
@@ -128,7 +128,7 @@ class TestInvokeOnResponse:
             received.append(r)
 
         resp = ProviderResponse(status=200)
-        await _invoke_on_response(cb, resp, _model())
+        await invoke_on_response(cb, resp, _model())
         assert len(received) == 1
         assert received[0] is resp
 


### PR DESCRIPTION
## Summary
- Removed dead code in `openai_responses.py` where `kwargs["instructions"]` was assigned and immediately deleted — simplified to just the input-based system prompt prepend
- Renamed `_invoke_on_payload` and `_invoke_on_response` to `invoke_on_payload` and `invoke_on_response` since they are imported cross-module and should not be private
- Updated all imports and call sites in `anthropic.py`, `openai.py`, and `test_hooks.py`

Closes #25

## Test plan
- [x] All 265 tests pass (`pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q`)
- [x] No behavior changes — pure refactoring
- [x] Verified no remaining references to old `_invoke_on_payload` / `_invoke_on_response` names