### PR TITLE
refactor: replace Any with typed Message union across agent layer

### DIFF
--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -32,26 +32,22 @@ from cubepi.providers.base import (
 TMessage = TypeVar("TMessage")
 
 
-def _default_convert_to_llm(messages: list[Any]) -> list[Message]:
-    return [
-        m
-        for m in messages
-        if hasattr(m, "role") and m.role in ("user", "assistant", "tool_result")
-    ]
+def _default_convert_to_llm(messages: list[Message]) -> list[Message]:
+    return list(messages)
 
 
 class _MessageQueue:
     def __init__(self, mode: str = "one-at-a-time") -> None:
         self.mode = mode
-        self._messages: list[Any] = []
+        self._messages: list[Message] = []
 
-    def enqueue(self, message: Any) -> None:
+    def enqueue(self, message: Message) -> None:
         self._messages.append(message)
 
     def has_items(self) -> bool:
         return len(self._messages) > 0
 
-    def drain(self) -> list[Any]:
+    def drain(self) -> list[Message]:
         if self.mode == "all":
             drained = self._messages[:]
             self._messages = []
@@ -74,10 +70,10 @@ class AgentState:
     )
     thinking: ThinkingLevel = "off"
     is_streaming: bool = False
-    streaming_message: Any = None
+    streaming_message: Message | None = None
     error_message: str | None = None
     _tools: list[AgentTool] = field(default_factory=list)
-    _messages: list[Any] = field(default_factory=list)
+    _messages: list[Message] = field(default_factory=list)
     _pending_tool_calls: set[str] = field(default_factory=set)
 
     @property
@@ -89,11 +85,11 @@ class AgentState:
         self._tools = list(value)
 
     @property
-    def messages(self) -> list[Any]:
+    def messages(self) -> list[Message]:
         return list(self._messages)
 
     @messages.setter
-    def messages(self, value: list[Any]) -> None:
+    def messages(self, value: list[Message]) -> None:
         self._messages = list(value)
 
     @property
@@ -114,7 +110,7 @@ class Agent(Generic[TMessage]):
         system_prompt: str = "",
         tools: list[AgentTool] | None = None,
         thinking: ThinkingLevel = "off",
-        convert_to_llm: Callable | None = None,
+        convert_to_llm: Callable[[list[Message]], list[Message]] | None = None,
         transform_context: Callable | None = None,
         before_tool_call: Callable | None = None,
         after_tool_call: Callable | None = None,
@@ -162,10 +158,10 @@ class Agent(Generic[TMessage]):
             self._listeners.remove(listener) if listener in self._listeners else None
         )
 
-    def steer(self, message: Any) -> None:
+    def steer(self, message: Message) -> None:
         self._steering_queue.enqueue(message)
 
-    def follow_up(self, message: Any) -> None:
+    def follow_up(self, message: Message) -> None:
         self._follow_up_queue.enqueue(message)
 
     def abort(self) -> None:
@@ -185,7 +181,7 @@ class Agent(Generic[TMessage]):
         self._steering_queue.clear()
         self._follow_up_queue.clear()
 
-    async def prompt(self, message: str | Any | list[Any]) -> None:
+    async def prompt(self, message: str | Message | list[Message]) -> None:
         if self._state.is_streaming:
             raise RuntimeError(
                 "Agent is already processing a prompt. "
@@ -213,7 +209,7 @@ class Agent(Generic[TMessage]):
             raise RuntimeError("No messages to continue from")
 
         last = self._state._messages[-1]
-        if hasattr(last, "role") and last.role == "assistant":
+        if isinstance(last, AssistantMessage):
             # Check for queued messages
             steering = self._steering_queue.drain()
             if steering:
@@ -237,7 +233,7 @@ class Agent(Generic[TMessage]):
             on_response=self.on_response,
         )
 
-    async def _run_prompt(self, messages: list[Any]) -> None:
+    async def _run_prompt(self, messages: list[Message]) -> None:
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop(
                 prompts=messages,
@@ -278,7 +274,7 @@ class Agent(Generic[TMessage]):
 
     @staticmethod
     def _make_async_drain(queue: _MessageQueue) -> Callable:
-        async def _drain() -> list[Any]:
+        async def _drain() -> list[Message]:
             return queue.drain()
 
         return _drain
@@ -344,12 +340,7 @@ class Agent(Generic[TMessage]):
             }
         elif event.type == "turn_end":
             msg = event.message
-            if (
-                hasattr(msg, "role")
-                and msg.role == "assistant"
-                and hasattr(msg, "error_message")
-                and msg.error_message
-            ):
+            if isinstance(msg, AssistantMessage) and msg.error_message:
                 self._state.error_message = msg.error_message
         elif event.type == "agent_end":
             self._state.streaming_message = None

--- a/cubepi/agent/loop.py
+++ b/cubepi/agent/loop.py
@@ -17,6 +17,7 @@ from cubepi.agent.types import (
 )
 from cubepi.providers.base import (
     AssistantMessage,
+    Message,
     Model,
     Provider,
     StreamOptions,
@@ -33,7 +34,7 @@ async def _emit(emit_fn: Callable, event: Any) -> None:
 
 async def run_agent_loop(
     *,
-    prompts: list[Any],
+    prompts: list[Message],
     context: AgentContext,
     provider: Provider,
     model: Model,
@@ -48,8 +49,8 @@ async def run_agent_loop(
     stream_options: StreamOptions | None = None,
     tool_execution: str = "parallel",
     system_prompt: str | None = None,
-) -> list[Any]:
-    new_messages: list[Any] = list(prompts)
+) -> list[Message]:
+    new_messages: list[Message] = list(prompts)
     current_context = AgentContext(
         system_prompt=system_prompt
         if system_prompt is not None
@@ -99,11 +100,11 @@ async def run_agent_loop_continue(
     stream_options: StreamOptions | None = None,
     tool_execution: str = "parallel",
     system_prompt: str | None = None,
-) -> list[Any]:
+) -> list[Message]:
     if not context.messages:
         raise ValueError("Cannot continue: no messages in context")
 
-    new_messages: list[Any] = []
+    new_messages: list[Message] = []
     current_context = AgentContext(
         system_prompt=system_prompt
         if system_prompt is not None
@@ -137,7 +138,7 @@ async def run_agent_loop_continue(
 async def _run_loop(
     *,
     current_context: AgentContext,
-    new_messages: list[Any],
+    new_messages: list[Message],
     provider: Provider,
     model: Model,
     convert_to_llm: Callable,

--- a/cubepi/agent/types.py
+++ b/cubepi/agent/types.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from cubepi.providers.base import (
     AssistantMessage,
     Content,
+    Message,
     StreamEvent,
     ToolCall,
     ToolDefinition,
@@ -46,7 +47,7 @@ class AgentTool(Generic[TParams]):
 @dataclass
 class AgentContext:
     system_prompt: str
-    messages: list[Any]
+    messages: list[Message]
     tools: list[AgentTool] | None = None
 
 
@@ -88,7 +89,7 @@ class ShouldStopAfterTurnContext:
     message: AssistantMessage
     tool_results: list[ToolResultMessage]
     context: AgentContext
-    new_messages: list[Any]
+    new_messages: list[Message]
 
 
 # --- Event types (11 total, matching pi) ---
@@ -100,7 +101,7 @@ class AgentStartEvent(BaseModel):
 
 class AgentEndEvent(BaseModel):
     type: Literal["agent_end"] = "agent_end"
-    messages: list[Any]
+    messages: list[Message]
 
 
 class TurnStartEvent(BaseModel):
@@ -109,24 +110,24 @@ class TurnStartEvent(BaseModel):
 
 class TurnEndEvent(BaseModel):
     type: Literal["turn_end"] = "turn_end"
-    message: Any
+    message: AssistantMessage
     tool_results: list[ToolResultMessage]
 
 
 class MessageStartEvent(BaseModel):
     type: Literal["message_start"] = "message_start"
-    message: Any
+    message: Message
 
 
 class MessageUpdateEvent(BaseModel):
     type: Literal["message_update"] = "message_update"
-    message: Any
+    message: AssistantMessage
     stream_event: StreamEvent
 
 
 class MessageEndEvent(BaseModel):
     type: Literal["message_end"] = "message_end"
-    message: Any
+    message: Message
 
 
 class ToolExecutionStartEvent(BaseModel):

--- a/tests/agent/test_types.py
+++ b/tests/agent/test_types.py
@@ -21,6 +21,7 @@ from cubepi.providers.base import (
     AssistantMessage,
     StreamEvent,
     TextContent,
+    ToolResultMessage,
     UserMessage,
 )
 
@@ -147,3 +148,30 @@ class TestHookTypes:
         assert r.terminate is True
         assert r.content is None
         assert r.is_error is None
+
+
+class TestTypedMessages:
+    def test_agent_context_accepts_message_union(self):
+        ctx = AgentContext(
+            system_prompt="test",
+            messages=[
+                UserMessage(content=[TextContent(text="hi")]),
+                AssistantMessage(content=[TextContent(text="hello")]),
+            ],
+        )
+        assert len(ctx.messages) == 2
+
+    def test_agent_end_event_typed_messages(self):
+        msg = UserMessage(content=[TextContent(text="hi")])
+        event = AgentEndEvent(messages=[msg])
+        assert event.messages[0].role == "user"
+
+    def test_turn_end_event_typed_message(self):
+        msg = AssistantMessage(content=[TextContent(text="done")])
+        event = TurnEndEvent(message=msg, tool_results=[])
+        assert event.message.role == "assistant"
+
+    def test_message_start_event_typed(self):
+        msg = UserMessage(content=[TextContent(text="hi")])
+        event = MessageStartEvent(message=msg)
+        assert event.message.role == "user"

--- a/tests/agent/test_types.py
+++ b/tests/agent/test_types.py
@@ -175,3 +175,14 @@ class TestTypedMessages:
         msg = UserMessage(content=[TextContent(text="hi")])
         event = MessageStartEvent(message=msg)
         assert event.message.role == "user"
+
+    def test_turn_end_event_typed_tool_results(self):
+        msg = AssistantMessage(content=[TextContent(text="done")])
+        tr = ToolResultMessage(
+            tool_call_id="t1",
+            tool_name="search",
+            content=[TextContent(text="result")],
+        )
+        event = TurnEndEvent(message=msg, tool_results=[tr])
+        assert len(event.tool_results) == 1
+        assert event.tool_results[0].role == "tool_result"


### PR DESCRIPTION
## Summary

- Replace all `list[Any]` and untyped `Any` annotations with the proper `Message` union type (`UserMessage | AssistantMessage | ToolResultMessage`) across `AgentContext`, `AgentState`, event types (`AgentEndEvent`, `TurnEndEvent`, `MessageStartEvent`, `MessageUpdateEvent`, `MessageEndEvent`), `ShouldStopAfterTurnContext`, `_MessageQueue`, and loop function signatures
- Replace `hasattr` duck-typing checks with `isinstance` in `Agent.resume()` and `Agent._process_event()`
- Simplify `_default_convert_to_llm` since messages are now guaranteed to be proper `Message` instances
- Add typed tests for the `Message` union in `TestTypedMessages`

Closes #18

## Test plan

- [x] All 269 existing tests pass (`pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q`)
- [x] 5 new tests validate typed message construction in event and context types
- [x] Pre-push ruff lint checks pass