### PR TITLE
fix: store content_index as int in OpenAI tool_calls_in_progress

### DIFF
--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -181,7 +181,7 @@ class OpenAIProvider:
                                     )
                                 )
                                 tc_content_index = len(partial.content) - 1
-                                tool_calls_in_progress[idx]["content_index"] = str(
+                                tool_calls_in_progress[idx]["content_index"] = (
                                     tc_content_index
                                 )
                                 ms.push(
@@ -199,9 +199,9 @@ class OpenAIProvider:
                                     StreamEvent(
                                         type="toolcall_delta",
                                         delta=tc_delta.function.arguments,
-                                        content_index=int(
-                                            tool_calls_in_progress[idx]["content_index"]
-                                        ),
+                                        content_index=tool_calls_in_progress[idx][
+                                            "content_index"
+                                        ],
                                         partial=partial.model_copy(deep=True),
                                     )
                                 )
@@ -231,7 +231,7 @@ class OpenAIProvider:
                             ms.push(
                                 StreamEvent(
                                     type="toolcall_end",
-                                    content_index=int(tc_data["content_index"]),
+                                    content_index=tc_data["content_index"],
                                     partial=partial.model_copy(deep=True),
                                 )
                             )


### PR DESCRIPTION
## Summary

- Store `content_index` as `int` directly in `tool_calls_in_progress` dict instead of converting to `str` and back
- Remove unnecessary `str()` wrapper when writing and `int()` casts when reading `content_index`

Closes #39

## Test plan

- [x] `pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q` — 287 passed
- [x] `ruff check cubepi/ tests/` — all checks passed
- [x] `ruff format --check cubepi/ tests/` — 48 files already formatted