### PR TITLE
refactor: replace hasattr checks with isinstance in test_agent.py

### DIFF
--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -3,6 +3,7 @@ import asyncio
 from cubepi.agent.agent import Agent
 from cubepi.agent.types import AgentTool
 from cubepi.providers.base import (
+    AssistantMessage,
     Model,
     TextContent,
     UserMessage,
@@ -276,14 +277,11 @@ class TestAgentResume:
         await agent.resume()
 
         has_follow_up = any(
-            hasattr(m, "content")
-            and hasattr(m, "role")
-            and m.role == "user"
+            isinstance(m, UserMessage)
             and any(
-                hasattr(c, "text") and c.text == "follow-up"
-                for c in (m.content if isinstance(m.content, list) else [])
+                isinstance(c, TextContent) and c.text == "follow-up" for c in m.content
             )
             for m in agent.state.messages
         )
         assert has_follow_up
-        assert agent.state.messages[-1].role == "assistant"
+        assert isinstance(agent.state.messages[-1], AssistantMessage)


### PR DESCRIPTION
## Summary
- Replaced `hasattr(m, "content")` / `hasattr(m, "role")` / `hasattr(c, "text")` checks in `test_agent.py` with `isinstance(m, UserMessage)` / `isinstance(c, TextContent)` / `isinstance(..., AssistantMessage)`
- Added `AssistantMessage` to the imports from `cubepi.providers.base`
- Aligns test code with the agent layer refactoring that already uses `isinstance` for message type discrimination

Closes #40

## Test plan
- [x] `pytest tests/ --ignore=tests/checkpointer/test_sqlite.py -q` -- 287 passed
- [x] `uv run ruff check cubepi/ tests/ && uv run ruff format --check cubepi/ tests/` -- all clean