### PR TITLE
fix: set provider_id and model_id on FauxProvider streamed messages

### DIFF
--- a/cubepi/providers/faux.py
+++ b/cubepi/providers/faux.py
@@ -267,7 +267,13 @@ class FauxProvider:
                 cache_usage = self._compute_cache_usage(
                     system_prompt, tools, messages, base_usage
                 )
-                resolved = resolved.model_copy(update={"usage": cache_usage})
+                resolved = resolved.model_copy(
+                    update={
+                        "usage": cache_usage,
+                        "provider_id": model.provider,
+                        "model_id": model.id,
+                    }
+                )
 
                 await self._stream_with_deltas(ms, resolved, opts.signal)
             except BaseException as exc:
@@ -297,6 +303,8 @@ class FauxProvider:
             stop_reason=message.stop_reason,
             usage=message.usage,
             timestamp=message.timestamp,
+            provider_id=message.provider_id,
+            model_id=message.model_id,
         )
 
         if signal and signal.is_set():

--- a/tests/providers/test_faux.py
+++ b/tests/providers/test_faux.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from cubepi.providers.base import (
+    Model,
     StreamOptions,
     TextContent,
     ToolDefinition,
@@ -290,6 +291,27 @@ class TestFauxProvider:
         s2 = await provider.stream(model, [])
         _ = [e async for e in s2]
         assert provider.call_count == 2
+
+    async def test_provider_metadata_set(self):
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("hello")])
+        model = Model(id="faux-1", provider="faux")
+        stream = await provider.stream(model, [])
+        _ = [e async for e in stream]
+        result = await stream.result()
+        assert result.provider_id == "faux"
+        assert result.model_id == "faux-1"
+
+    async def test_provider_metadata_on_partial_events(self):
+        provider = FauxProvider()
+        provider.set_responses([faux_assistant_message("hello")])
+        model = Model(id="faux-1", provider="faux")
+        stream = await provider.stream(model, [])
+        events = [e async for e in stream]
+        start_event = next(e for e in events if e.type == "start")
+        assert start_event.partial is not None
+        assert start_event.partial.provider_id == "faux"
+        assert start_event.partial.model_id == "faux-1"
 
 
 class TestFauxProviderExtendedFactory:


### PR DESCRIPTION
## Summary
- FauxProvider now sets `provider_id` and `model_id` on streamed `AssistantMessage` objects, matching the behavior of real providers (e.g., Anthropic).
- The metadata is propagated both to partial events during streaming and to the final result message.
- Two new tests verify the fix on both the final result and partial stream events.

Closes #37

## Test plan
- [x] `test_provider_metadata_set` verifies `provider_id` and `model_id` on the final streamed result
- [x] `test_provider_metadata_on_partial_events` verifies the fields on the `start` event's partial message
- [x] Full test suite passes (289 tests, 0 failures)
- [x] Ruff check and format pass