### PR TITLE
test: add coverage for lazy provider factory functions

### DIFF
--- a/tests/providers/test_init.py
+++ b/tests/providers/test_init.py
@@ -1,0 +1,19 @@
+from cubepi.providers import (
+    get_anthropic_provider,
+    get_openai_provider,
+    get_openai_responses_provider,
+)
+
+
+class TestLazyProviderFactories:
+    def test_get_anthropic_provider(self):
+        cls = get_anthropic_provider()
+        assert cls.__name__ == "AnthropicProvider"
+
+    def test_get_openai_provider(self):
+        cls = get_openai_provider()
+        assert cls.__name__ == "OpenAIProvider"
+
+    def test_get_openai_responses_provider(self):
+        cls = get_openai_responses_provider()
+        assert cls.__name__ == "OpenAIResponsesProvider"


### PR DESCRIPTION
## Summary
- Adds `tests/providers/test_init.py` with tests for the three lazy provider factory functions in `cubepi/providers/__init__.py`
- Covers `get_anthropic_provider()`, `get_openai_provider()`, and `get_openai_responses_provider()`
- Improves coverage of `providers/__init__.py` from 54%

## Test plan
- [x] All 302 tests pass (`pytest tests/ -q`)
- [x] Ruff check clean (`ruff check cubepi/ tests/`)
- [x] Ruff format clean (`ruff format --check cubepi/ tests/`)

Closes #46