### PR TITLE
test: checkpointer save_extra and deserialization coverage

### DIFF
--- a/tests/checkpointer/test_memory.py
+++ b/tests/checkpointer/test_memory.py
@@ -50,3 +50,13 @@ class TestMemoryCheckpointer:
 
         assert d1.messages[0].content[0].text == "t1"
         assert d2.messages[0].content[0].text == "t2"
+
+    async def test_save_extra_creates_thread(self):
+        """save_extra on a thread that has never been used should create an entry."""
+        cp = MemoryCheckpointer()
+        await cp.save_extra("new-thread", {"key": "value"})
+
+        data = await cp.load("new-thread")
+        assert data is not None
+        assert data.messages == []
+        assert data.extra == {"key": "value"}

--- a/tests/checkpointer/test_sqlite.py
+++ b/tests/checkpointer/test_sqlite.py
@@ -61,3 +61,34 @@ class TestSQLiteCheckpointer:
             d2 = await cp.load("t2")
             assert d1.messages[0].content[0].text == "t1"
             assert d2.messages[0].content[0].text == "t2"
+
+    async def test_save_extra_update_merges(self, db_path):
+        """Second save_extra call should merge into existing extra, not replace it."""
+        async with SQLiteCheckpointer(db_path) as cp:
+            await cp.save_extra("thread-1", {"a": 1, "b": 2})
+            await cp.save_extra("thread-1", {"b": 99, "c": 3})
+
+            data = await cp.load("thread-1")
+            assert data is not None
+            assert data.extra == {"a": 1, "b": 99, "c": 3}
+
+    async def test_save_extra_creates_thread(self, db_path):
+        """save_extra on a thread that has no messages should still be loadable."""
+        async with SQLiteCheckpointer(db_path) as cp:
+            await cp.save_extra("new-thread", {"key": "value"})
+
+            data = await cp.load("new-thread")
+            assert data is not None
+            assert data.messages == []
+            assert data.extra == {"key": "value"}
+
+    async def test_deserialize_unknown_role(self, db_path):
+        """A message with an unknown role should be returned as a plain dict."""
+        async with SQLiteCheckpointer(db_path) as cp:
+            raw_msg = {"role": "custom", "data": "test"}
+            await cp.append("thread-1", [raw_msg])
+
+            data = await cp.load("thread-1")
+            assert data is not None
+            assert len(data.messages) == 1
+            assert data.messages[0] == {"role": "custom", "data": "test"}


### PR DESCRIPTION
## Summary

Closes #50

- **SQLiteCheckpointer**: add tests for `save_extra` update/merge path (second call merges, not replaces), `save_extra` creating a thread with no prior messages, and `_deserialize_message` returning unknown roles as plain dicts
- **MemoryCheckpointer**: add test for `save_extra` when the thread does not yet exist (line 22 coverage)

## Test plan

- [x] `pytest tests/ -q` -- 303 passed
- [x] `ruff check cubepi/ tests/` -- all checks passed
- [x] `ruff format --check cubepi/ tests/` -- 48 files already formatted