### PR TITLE
fix: resolve test warnings and add README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,14 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Run tests
-        run: uv run pytest tests/ -v --cov=cubepi --cov-report=term-missing
+        run: uv run pytest tests/ -v --cov=cubepi --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false
 
       - name: Check import
         run: uv run python -c "import cubepi; print(cubepi.__all__)"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # cubepi
 
+[![CI](https://github.com/cubeplexai/cubepi/actions/workflows/ci.yml/badge.svg)](https://github.com/cubeplexai/cubepi/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/cubeplexai/cubepi/graph/badge.svg)](https://codecov.io/gh/cubeplexai/cubepi)
+[![PyPI](https://img.shields.io/pypi/v/cubepi)](https://pypi.org/project/cubepi/)
+[![Python](https://img.shields.io/pypi/pyversions/cubepi)](https://pypi.org/project/cubepi/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
 Pythonic async-native agent framework. Built to replace [langgraph](https://github.com/langchain-ai/langgraph) with something simpler, faster, and easier to reason about.
 
 Inspired by [pi-agent-core](https://github.com/anthropics/pi-agent-core) (TypeScript), redesigned for Python.

--- a/tests/providers/test_hooks.py
+++ b/tests/providers/test_hooks.py
@@ -155,6 +155,7 @@ class TestAnthropicProviderHooks:
         mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
         mock_stream.__aexit__ = AsyncMock(return_value=False)
         mock_stream.__aiter__ = MagicMock(return_value=iter([]))
+        mock_stream.response = MagicMock(status_code=200, headers={})
 
         final_msg = MagicMock()
         final_msg.content = [MagicMock(type="text", text="hello")]
@@ -204,6 +205,7 @@ class TestAnthropicProviderHooks:
         mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
         mock_stream.__aexit__ = AsyncMock(return_value=False)
         mock_stream.__aiter__ = MagicMock(return_value=iter([]))
+        mock_stream.response = MagicMock(status_code=200, headers={})
 
         final_msg = MagicMock()
         final_msg.content = [MagicMock(type="text", text="ok")]


### PR DESCRIPTION
## Summary
- Fix `RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` in `TestAnthropicProviderHooks` by setting `mock_stream.response = MagicMock(status_code=200, headers={})` instead of letting `AsyncMock` auto-create child `AsyncMock` objects
- Add Codecov upload to CI (Python 3.13 matrix only)
- Add badges to README: CI status, Codecov coverage, PyPI version, Python versions, License

## Badges added
| Badge | Source |
|---|---|
| CI | GitHub Actions workflow badge |
| Coverage | Codecov (needs repo activation at codecov.io) |
| PyPI | shields.io dynamic from PyPI |
| Python | shields.io dynamic from PyPI |
| License | shields.io static |

## Note
Codecov badge requires activating the repo at https://app.codecov.io/gh/cubeplexai/cubepi. For public repos, no token is needed.