### PR TITLE
chore: add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    continue-on-error: ${{ matrix.python-version == '3.14' }}
 
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = [


### PR DESCRIPTION
## Summary
- Add `"3.14"` to the CI test matrix with `continue-on-error` since Python 3.14 is still in beta (GA October 2025)
- Add `Programming Language :: Python :: 3.14` classifier to `pyproject.toml`
- Reviewed all source files for known 3.14 incompatibilities (typing, asyncio, inspect, json) -- no issues found

## Compatibility notes
The codebase already uses `from __future__ import annotations` throughout, so PEP 649 (deferred annotation evaluation, new in 3.14) won't cause issues. All `inspect`, `asyncio`, `typing`, and `json` usage relies on stable APIs with no 3.14 deprecations.

## Test plan
- [x] All 388 existing tests pass on Python 3.13
- [x] Ruff lint and format checks pass
- [ ] CI will validate against Python 3.14 (allowed to fail while beta)

Closes #63