### PR TITLE
chore(ci): enable Codecov project check + PR comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
## Summary
- Add `codecov.yml` so Codecov runs a **project** status check (not just `patch`) and posts a coverage summary comment on PRs.
- `target: auto` for both — bar is the base commit's coverage, so we just guard against regression instead of pinning a hard %.
- `threshold: 1%` on project to tolerate tiny float drift.

## Test plan
- [ ] Merge and confirm the next PR shows both `codecov/project` and `codecov/patch` checks.
- [ ] Confirm Codecov posts a project-coverage comment with the `reach, diff, flags, files` layout.