### PR TITLE
fix(providers): cubebox cache-parity + base_url for Anthropic

### DIFF
--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -107,8 +107,14 @@ class AnthropicProvider:
             "model": model.id,
             "messages": api_messages,
             "max_tokens": max_tokens,
-            "temperature": model.temperature,
         }
+        # Anthropic disallows temperature modifications when extended
+        # thinking is enabled — see
+        # https://platform.claude.com/docs/en/build-with-claude/extended-thinking#feature-compatibility
+        # The provider request will fail with thinking on if we send a
+        # non-default temperature, so skip the field unless thinking is off.
+        if thinking == "off":
+            kwargs["temperature"] = model.temperature
         if system_prompt:
             if cache_control and self._cache_policy.mark_system():
                 kwargs["system"] = [

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -103,19 +103,19 @@ class AnthropicProvider:
             "model": model.id,
             "messages": api_messages,
             "max_tokens": max_tokens,
+            "temperature": model.temperature,
         }
         if system_prompt:
-            kwargs["system"] = [
-                {
-                    "type": "text",
-                    "text": system_prompt,
-                    **(
-                        {"cache_control": cache_control}
-                        if cache_control and self._cache_policy.mark_system()
-                        else {}
-                    ),
-                }
-            ]
+            if cache_control and self._cache_policy.mark_system():
+                kwargs["system"] = [
+                    {
+                        "type": "text",
+                        "text": system_prompt,
+                        "cache_control": cache_control,
+                    }
+                ]
+            else:
+                kwargs["system"] = system_prompt
         if tools:
             api_tools = [self._convert_tool(t) for t in tools]
             if cache_control and api_tools and self._cache_policy.mark_last_tool():
@@ -175,7 +175,7 @@ class AnthropicProvider:
 
                         self._handle_event(event, partial, ms)
 
-                    final_msg = stream.get_final_message()
+                    final_msg = await stream.get_final_message()
                     result = self._convert_response(final_msg, model)
                     ms.push(StreamEvent(type="done"))
                     ms.set_result(result)

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -62,12 +62,16 @@ class AnthropicProvider:
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         cache_retention: CacheRetention = "short",
         cache_policy: CacheMarkerPolicy | None = None,
     ) -> None:
         import anthropic
 
-        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        kwargs: dict[str, Any] = {"api_key": api_key}
+        if base_url is not None:
+            kwargs["base_url"] = base_url
+        self._client = anthropic.AsyncAnthropic(**kwargs)
         self._cache_retention = cache_retention
         self._cache_policy: CacheMarkerPolicy = (
             cache_policy or DefaultCacheMarkerPolicy()

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -82,6 +82,7 @@ class Model(BaseModel):
     reasoning: bool = False
     context_window: int = 200_000
     max_tokens: int = 8192
+    temperature: float = 0.7
     cost: ModelCost | None = None
     thinking_level_map: dict[str, str | None] | None = None
 

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -143,7 +143,8 @@ class OpenAIProvider:
                                 getattr(u, "prompt_tokens_details", None),
                                 "cached_tokens",
                                 0,
-                            ) or 0,
+                            )
+                            or 0,
                         )
 
                     if response_id is None and getattr(chunk, "id", None):

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -72,6 +72,8 @@ class OpenAIProvider:
             "model": model.id,
             "messages": api_messages,
             "stream": True,
+            "max_tokens": model.max_tokens,
+            "temperature": model.temperature,
         }
         if tools:
             kwargs["tools"] = [self._convert_tool(t) for t in tools]

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -444,45 +444,86 @@ class OpenAIProvider:
         *,
         defs: dict[str, Any] | None = None,
         top: bool = True,
+        strip_title: bool = True,
+        in_any_of: bool = False,
     ) -> Any:
         """Normalise a Pydantic model_json_schema() output to match langchain-openai's format.
 
-        langchain-openai strips ``title`` everywhere, strips the top-level
-        ``description`` (model class docstring, not field-level description),
-        removes ``$defs``, and inlines ``$ref`` references so the schema is
-        self-contained.  Matching this format is required for byte-stream parity
-        with the LangGraph runtime (OpenAI-compatible auto-cache hashes raw bytes).
+        langchain-openai strips ``title`` from property-level fields and the top-level
+        schema, but preserves ``title`` inside ``anyOf`` items (e.g. enum class names
+        like ``"title": "MemoryScope"`` from Optional[SomeEnum] fields). It also strips
+        the top-level ``description`` (class docstring) and resolves ``$defs``/``$ref``
+        so the schema is self-contained.  Matching this format is required for
+        byte-stream parity with the LangGraph runtime (OpenAI-compatible auto-cache
+        hashes raw bytes).
         """
+        N = OpenAIProvider._normalise_tool_schema  # local alias for brevity
+
         if isinstance(schema, dict):
             # Collect $defs at top level so we can resolve $refs below.
             if top and "$defs" in schema:
                 defs = schema["$defs"]
 
-            # $ref resolution: replace the whole dict with the inlined definition.
+            # $ref resolution: inline the definition.
+            # Title kept only when we're inside an anyOf (enum option);
+            # stripped otherwise (e.g. TypedDict in "items").
             if "$ref" in schema:
                 ref_name = schema["$ref"].split("/")[-1]
                 if defs and ref_name in defs:
-                    return OpenAIProvider._normalise_tool_schema(
-                        defs[ref_name], defs=defs, top=False
+                    return N(
+                        defs[ref_name],
+                        defs=defs,
+                        top=False,
+                        strip_title=not in_any_of,
+                        in_any_of=False,
                     )
-                # Unknown ref — leave as-is (shouldn't happen with pydantic).
+                # Unknown ref — leave as-is.
                 return schema
 
             result: dict[str, Any] = {}
             for k, v in schema.items():
-                if k == "title":
-                    continue  # Strip all title fields.
+                if k == "title" and strip_title:
+                    continue  # Strip at property / top level; keep inside anyOf defs.
                 if k == "$defs":
-                    continue  # Replaced by inline resolution; remove from output.
+                    continue  # Removed after $ref resolution.
                 if k == "description" and top:
-                    continue  # Strip class-level docstring from top-level schema.
-                result[k] = OpenAIProvider._normalise_tool_schema(
-                    v, defs=defs, top=False
-                )
+                    continue  # Strip class docstring from top-level schema only.
+                if k == "properties" and isinstance(v, dict):
+                    # Named fields: always strip the pydantic-generated title.
+                    result[k] = {
+                        pname: N(
+                            pschema,
+                            defs=defs,
+                            top=False,
+                            strip_title=True,
+                            in_any_of=False,
+                        )
+                        for pname, pschema in v.items()
+                    }
+                elif k == "anyOf" and isinstance(v, list):
+                    # anyOf items: keep title so enum class names survive.
+                    result[k] = [
+                        N(item, defs=defs, top=False, strip_title=True, in_any_of=True)
+                        for item in v
+                    ]
+                else:
+                    result[k] = N(
+                        v,
+                        defs=defs,
+                        top=False,
+                        strip_title=strip_title,
+                        in_any_of=False,
+                    )
             return result
         elif isinstance(schema, list):
             return [
-                OpenAIProvider._normalise_tool_schema(item, defs=defs, top=False)
+                N(
+                    item,
+                    defs=defs,
+                    top=False,
+                    strip_title=strip_title,
+                    in_any_of=in_any_of,
+                )
                 for item in schema
             ]
         return schema

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -65,10 +65,12 @@ class OpenAIProvider:
 
         api_messages: list[dict[str, Any]] = []
         if system_prompt:
-            api_messages.append({
-                "role": "system",
-                "content": [{"type": "text", "text": system_prompt}],
-            })
+            api_messages.append(
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": system_prompt}],
+                }
+            )
         api_messages.extend(self._convert_message(m) for m in messages)
 
         kwargs: dict[str, Any] = {
@@ -474,7 +476,9 @@ class OpenAIProvider:
                     continue  # Replaced by inline resolution; remove from output.
                 if k == "description" and top:
                     continue  # Strip class-level docstring from top-level schema.
-                result[k] = OpenAIProvider._normalise_tool_schema(v, defs=defs, top=False)
+                result[k] = OpenAIProvider._normalise_tool_schema(
+                    v, defs=defs, top=False
+                )
             return result
         elif isinstance(schema, list):
             return [

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -77,8 +77,6 @@ class OpenAIProvider:
             "model": model.id,
             "messages": api_messages,
             "stream": True,
-            "max_tokens": model.max_tokens,
-            "temperature": model.temperature,
         }
         if tools:
             kwargs["tools"] = [self._convert_tool(t) for t in tools]

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -35,6 +35,8 @@ class OpenAIProvider:
         api_key: str | None = None,
         base_url: str | None = None,
         payload_quirks: list[Literal["max_completion_tokens_alias"]] | None = None,
+        extra_body: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         import openai
 
@@ -43,8 +45,11 @@ class OpenAIProvider:
             kwargs["api_key"] = api_key
         if base_url:
             kwargs["base_url"] = base_url
+        if extra_headers:
+            kwargs["default_headers"] = extra_headers
         self._client = openai.AsyncOpenAI(**kwargs)
         self._payload_quirks: set[str] = set(payload_quirks or [])
+        self._extra_body: dict[str, Any] = extra_body or {}
 
     async def stream(
         self,
@@ -80,6 +85,17 @@ class OpenAIProvider:
                     if "max_completion_tokens" in kwargs:
                         kwargs["max_tokens"] = kwargs.pop("max_completion_tokens")
 
+                # Merge instance-level extra_body into the request kwargs.
+                # Provider-config extra_body (e.g. {"enable_thinking": false}) is
+                # applied here so callers don't need to use on_payload for simple cases.
+                if self._extra_body and "extra_body" not in kwargs:
+                    kwargs["extra_body"] = dict(self._extra_body)
+                elif self._extra_body:
+                    kwargs["extra_body"] = {**self._extra_body, **kwargs["extra_body"]}
+
+                # Request per-stream usage so we can populate AssistantMessage.usage.
+                kwargs.setdefault("stream_options", {})["include_usage"] = True
+
                 response = await self._client.chat.completions.create(**kwargs)
 
                 # Invoke on_response with HTTP metadata if available
@@ -114,6 +130,20 @@ class OpenAIProvider:
                 thinking_content_index: int | None = None
 
                 async for chunk in response:
+                    # Usage-only chunk (stream_options.include_usage=True sends a
+                    # trailing chunk with no choices and usage populated).
+                    if getattr(chunk, "usage", None) is not None:
+                        u = chunk.usage
+                        partial.usage = Usage(
+                            input_tokens=getattr(u, "prompt_tokens", 0) or 0,
+                            output_tokens=getattr(u, "completion_tokens", 0) or 0,
+                            cache_read_tokens=getattr(
+                                getattr(u, "prompt_tokens_details", None),
+                                "cached_tokens",
+                                0,
+                            ) or 0,
+                        )
+
                     if response_id is None and getattr(chunk, "id", None):
                         response_id = chunk.id
                         partial.response_id = response_id
@@ -316,16 +346,18 @@ class OpenAIProvider:
                             "tool_calls": "tool_use",
                             "length": "length",
                         }
-                        final = partial.model_copy(
+                        # Build final now but do NOT emit yet — OpenAI sends a
+                        # trailing usage-only chunk after finish_reason when
+                        # stream_options.include_usage=True. Let the loop
+                        # exhaust so the usage block above captures it before
+                        # we close the stream.
+                        partial = partial.model_copy(
                             update={
                                 "stop_reason": stop_map.get(
                                     finish_reason, finish_reason
                                 ),
                             }
                         )
-                        ms.push(StreamEvent(type="done"))
-                        ms.set_result(final)
-                        return
 
                 ms.push(StreamEvent(type="done"))
                 ms.set_result(partial)

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -68,7 +68,7 @@ class OpenAIProvider:
             api_messages.append(
                 {
                     "role": "system",
-                    "content": [{"type": "text", "text": system_prompt}],
+                    "content": system_prompt,
                 }
             )
         api_messages.extend(self._convert_message(m) for m in messages)

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -99,7 +99,14 @@ class OpenAIProvider:
                     kwargs["extra_body"] = {**self._extra_body, **kwargs["extra_body"]}
 
                 # Request per-stream usage so we can populate AssistantMessage.usage.
-                kwargs.setdefault("stream_options", {})["include_usage"] = True
+                # Only set ``include_usage`` if the caller hasn't already
+                # configured it via on_payload — some OpenAI-compatible
+                # backends reject ``stream_options`` entirely, so callers
+                # need to be able to opt out by setting it to False (or
+                # removing the key).
+                so = kwargs.setdefault("stream_options", {})
+                if "include_usage" not in so:
+                    so["include_usage"] = True
 
                 response = await self._client.chat.completions.create(**kwargs)
 
@@ -139,15 +146,23 @@ class OpenAIProvider:
                     # trailing chunk with no choices and usage populated).
                     if getattr(chunk, "usage", None) is not None:
                         u = chunk.usage
-                        partial.usage = Usage(
-                            input_tokens=getattr(u, "prompt_tokens", 0) or 0,
-                            output_tokens=getattr(u, "completion_tokens", 0) or 0,
-                            cache_read_tokens=getattr(
+                        prompt_tokens = getattr(u, "prompt_tokens", 0) or 0
+                        cached_tokens = (
+                            getattr(
                                 getattr(u, "prompt_tokens_details", None),
                                 "cached_tokens",
                                 0,
                             )
-                            or 0,
+                            or 0
+                        )
+                        # ``input_tokens`` is the uncached prompt portion; the
+                        # cached prefix is reported separately. This matches
+                        # the Responses/faux providers' accounting so cost
+                        # aggregation across providers doesn't double-count.
+                        partial.usage = Usage(
+                            input_tokens=max(prompt_tokens - cached_tokens, 0),
+                            output_tokens=getattr(u, "completion_tokens", 0) or 0,
+                            cache_read_tokens=cached_tokens,
                         )
 
                     if response_id is None and getattr(chunk, "id", None):
@@ -468,13 +483,38 @@ class OpenAIProvider:
             if "$ref" in schema:
                 ref_name = schema["$ref"].split("/")[-1]
                 if defs and ref_name in defs:
-                    return N(
+                    resolved = N(
                         defs[ref_name],
                         defs=defs,
                         top=False,
                         strip_title=not in_any_of,
                         in_any_of=False,
                     )
+                    # JSON Schema 2020-12 allows sibling keys alongside
+                    # $ref; Pydantic emits ``description`` / ``default`` /
+                    # validators on Optional[Enum] fields, etc. Merge them
+                    # onto the resolved definition so field-level metadata
+                    # isn't silently dropped when we inline.
+                    siblings = {
+                        k: v
+                        for k, v in schema.items()
+                        if k != "$ref" and not (k == "title" and not in_any_of)
+                    }
+                    if siblings and isinstance(resolved, dict):
+                        merged: dict[str, Any] = dict(resolved)
+                        for k, v in siblings.items():
+                            merged.setdefault(
+                                k,
+                                N(
+                                    v,
+                                    defs=defs,
+                                    top=False,
+                                    strip_title=not in_any_of,
+                                    in_any_of=False,
+                                ),
+                            )
+                        return merged
+                    return resolved
                 # Unknown ref — leave as-is.
                 return schema
 

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -65,7 +65,10 @@ class OpenAIProvider:
 
         api_messages: list[dict[str, Any]] = []
         if system_prompt:
-            api_messages.append({"role": "system", "content": system_prompt})
+            api_messages.append({
+                "role": "system",
+                "content": [{"type": "text", "text": system_prompt}],
+            })
         api_messages.extend(self._convert_message(m) for m in messages)
 
         kwargs: dict[str, Any] = {
@@ -434,12 +437,59 @@ class OpenAIProvider:
         return {"role": "user", "content": ""}
 
     @staticmethod
+    def _normalise_tool_schema(
+        schema: Any,
+        *,
+        defs: dict[str, Any] | None = None,
+        top: bool = True,
+    ) -> Any:
+        """Normalise a Pydantic model_json_schema() output to match langchain-openai's format.
+
+        langchain-openai strips ``title`` everywhere, strips the top-level
+        ``description`` (model class docstring, not field-level description),
+        removes ``$defs``, and inlines ``$ref`` references so the schema is
+        self-contained.  Matching this format is required for byte-stream parity
+        with the LangGraph runtime (OpenAI-compatible auto-cache hashes raw bytes).
+        """
+        if isinstance(schema, dict):
+            # Collect $defs at top level so we can resolve $refs below.
+            if top and "$defs" in schema:
+                defs = schema["$defs"]
+
+            # $ref resolution: replace the whole dict with the inlined definition.
+            if "$ref" in schema:
+                ref_name = schema["$ref"].split("/")[-1]
+                if defs and ref_name in defs:
+                    return OpenAIProvider._normalise_tool_schema(
+                        defs[ref_name], defs=defs, top=False
+                    )
+                # Unknown ref — leave as-is (shouldn't happen with pydantic).
+                return schema
+
+            result: dict[str, Any] = {}
+            for k, v in schema.items():
+                if k == "title":
+                    continue  # Strip all title fields.
+                if k == "$defs":
+                    continue  # Replaced by inline resolution; remove from output.
+                if k == "description" and top:
+                    continue  # Strip class-level docstring from top-level schema.
+                result[k] = OpenAIProvider._normalise_tool_schema(v, defs=defs, top=False)
+            return result
+        elif isinstance(schema, list):
+            return [
+                OpenAIProvider._normalise_tool_schema(item, defs=defs, top=False)
+                for item in schema
+            ]
+        return schema
+
+    @staticmethod
     def _convert_tool(td: ToolDefinition) -> dict[str, Any]:
         return {
             "type": "function",
             "function": {
                 "name": td.name,
                 "description": td.description,
-                "parameters": td.parameters,
+                "parameters": OpenAIProvider._normalise_tool_schema(td.parameters),
             },
         }

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -98,6 +98,11 @@ class OpenAIResponsesProvider:
         if model.max_tokens:
             kwargs["max_output_tokens"] = model.max_tokens
 
+        # Forward temperature for non-reasoning models; reasoning models don't
+        # support temperature on the Responses API.
+        if not model.reasoning:
+            kwargs["temperature"] = model.temperature
+
         async def _produce() -> None:
             try:
                 nonlocal kwargs

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -337,7 +337,7 @@ class _MockAnthropicStream:
         for ev in self._events:
             yield ev
 
-    def get_final_message(self):
+    async def get_final_message(self):
         return self._final_message
 
 

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -1049,3 +1049,25 @@ class TestAnthropicApplyMessageCacheControlEdge:
         msgs = [{"role": "user", "content": None}]
         AnthropicProvider._apply_message_cache_control(msgs, self.CACHE_CONTROL)
         assert msgs[0]["content"] is None
+
+
+class TestAnthropicBaseUrl:
+    """Constructor base_url branch (line 73)."""
+
+    def test_base_url_forwarded_to_async_anthropic(self):
+        from unittest.mock import patch as _patch
+
+        with _patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_anthropic.return_value = MagicMock()
+            AnthropicProvider(api_key="x", base_url="https://proxy.example/anthropic")
+            assert mock_anthropic.call_args.kwargs.get("base_url") == (
+                "https://proxy.example/anthropic"
+            )
+
+    def test_no_base_url_omits_kwarg(self):
+        from unittest.mock import patch as _patch
+
+        with _patch("anthropic.AsyncAnthropic") as mock_anthropic:
+            mock_anthropic.return_value = MagicMock()
+            AnthropicProvider(api_key="x")
+            assert "base_url" not in mock_anthropic.call_args.kwargs

--- a/tests/providers/test_openai_extras_and_schema.py
+++ b/tests/providers/test_openai_extras_and_schema.py
@@ -1,0 +1,261 @@
+"""Coverage for OpenAIProvider's extra_body / extra_headers wiring and
+``_normalise_tool_schema`` paths. These are the diff lines that landed
+in PR #67 — adding focused unit tests so codecov/patch hits the bar.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from cubepi.providers.base import (
+    Model,
+    StreamOptions,
+    TextContent,
+    UserMessage,
+)
+from cubepi.providers.openai import OpenAIProvider
+
+
+def _model() -> Model:
+    return Model(id="gpt-4o", provider="openai", api="openai")
+
+
+def _make_chunk(*, finish_reason=None):
+    return SimpleNamespace(
+        id="x",
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(content=None, tool_calls=None),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=None,
+    )
+
+
+async def _async_iter(items):
+    for it in items:
+        yield it
+
+
+# ---------------------------------------------------------------------------
+# extra_headers — constructor branch
+# ---------------------------------------------------------------------------
+
+
+def test_extra_headers_forwarded_to_async_openai() -> None:
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        OpenAIProvider(
+            api_key="x",
+            base_url="https://example/v1",
+            extra_headers={"X-Custom": "y"},
+        )
+        kwargs = mock_openai.call_args.kwargs
+        assert kwargs["default_headers"] == {"X-Custom": "y"}
+
+
+def test_no_extra_headers_omits_default_headers() -> None:
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        mock_openai.return_value = MagicMock()
+        OpenAIProvider(api_key="x")
+        assert "default_headers" not in mock_openai.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# extra_body — merge into request kwargs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extra_body_added_when_kwargs_missing_it() -> None:
+    captured: dict[str, Any] = {}
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        client = MagicMock()
+        mock_openai.return_value = client
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return _async_iter([_make_chunk(finish_reason="stop")])
+
+        client.chat.completions.create = capture
+
+        provider = OpenAIProvider(api_key="x", extra_body={"enable_thinking": False})
+        provider._client = client
+
+        ms = await provider.stream(
+            _model(),
+            [UserMessage(content=[TextContent(text="hi")])],
+        )
+        async for _ in ms:
+            pass
+        await ms.result()
+
+    assert captured["extra_body"] == {"enable_thinking": False}
+
+
+@pytest.mark.asyncio
+async def test_extra_body_merged_when_payload_hook_supplied_one() -> None:
+    captured: dict[str, Any] = {}
+
+    async def on_payload(payload, model):
+        payload["extra_body"] = {"a": 1, "enable_thinking": True}  # collision on key
+        return payload
+
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        client = MagicMock()
+        mock_openai.return_value = client
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return _async_iter([_make_chunk(finish_reason="stop")])
+
+        client.chat.completions.create = capture
+
+        provider = OpenAIProvider(api_key="x", extra_body={"enable_thinking": False})
+        provider._client = client
+
+        ms = await provider.stream(
+            _model(),
+            [UserMessage(content=[TextContent(text="hi")])],
+            options=StreamOptions(on_payload=on_payload),
+        )
+        async for _ in ms:
+            pass
+        await ms.result()
+
+    # Instance-level extra_body is the base; on_payload overrides on key collision.
+    assert captured["extra_body"] == {"a": 1, "enable_thinking": True}
+
+
+# ---------------------------------------------------------------------------
+# Reasoning details fallback — delta entry that's neither attr nor dict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reasoning_details_unknown_entry_type_yields_no_text() -> None:
+    """A reasoning_details entry that's neither attr-bearing nor a dict
+    should hit the ``text = None`` branch and produce no thinking_delta.
+    """
+    delta = SimpleNamespace(
+        content=None,
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning=None,
+        reasoning_details=[42],  # not a dict, no .text attr
+    )
+    chunk = SimpleNamespace(
+        id="x",
+        choices=[SimpleNamespace(delta=delta, finish_reason=None)],
+        usage=None,
+    )
+    final = _make_chunk(finish_reason="stop")
+
+    saw_thinking_delta = False
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        client = MagicMock()
+        mock_openai.return_value = client
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+
+        async def create(**_):
+            return _async_iter([chunk, final])
+
+        client.chat.completions.create = create
+
+        provider = OpenAIProvider(api_key="x")
+        provider._client = client
+
+        ms = await provider.stream(
+            _model(),
+            [UserMessage(content=[TextContent(text="hi")])],
+        )
+        async for evt in ms:
+            if evt.type == "thinking_delta":
+                saw_thinking_delta = True
+        await ms.result()
+
+    assert saw_thinking_delta is False
+
+
+# ---------------------------------------------------------------------------
+# _normalise_tool_schema — coverage for $defs / $ref / anyOf paths
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_strips_top_level_title_description_and_defs() -> None:
+    schema = {
+        "title": "Foo",
+        "description": "docstring",
+        "type": "object",
+        "$defs": {"Bar": {"title": "Bar", "type": "string"}},
+        "properties": {"x": {"title": "X", "type": "integer"}},
+    }
+    out = OpenAIProvider._normalise_tool_schema(schema)
+    assert "title" not in out
+    assert "description" not in out
+    assert "$defs" not in out
+    assert "title" not in out["properties"]["x"]
+
+
+def test_normalise_keeps_title_inside_anyof_via_ref() -> None:
+    """anyOf items whose $ref resolves into a $def should keep title
+    (enum class name needs to survive for cache parity)."""
+    schema = {
+        "title": "Outer",
+        "type": "object",
+        "$defs": {"Scope": {"title": "Scope", "enum": ["a", "b"], "type": "string"}},
+        "properties": {
+            "scope": {"anyOf": [{"$ref": "#/$defs/Scope"}, {"type": "null"}]},
+        },
+    }
+    out = OpenAIProvider._normalise_tool_schema(schema)
+    scope_options = out["properties"]["scope"]["anyOf"]
+    # The Scope variant should keep its title; the null variant has none.
+    titled = [o for o in scope_options if "title" in o]
+    assert titled and titled[0]["title"] == "Scope"
+
+
+def test_normalise_unknown_ref_left_unchanged() -> None:
+    """A $ref that doesn't resolve to a $def should be passed through."""
+    schema = {"$ref": "#/$defs/MissingName"}
+    out = OpenAIProvider._normalise_tool_schema(schema)
+    assert out == schema
+
+
+def test_normalise_passes_through_non_dict_non_list() -> None:
+    assert OpenAIProvider._normalise_tool_schema("plain") == "plain"
+    assert OpenAIProvider._normalise_tool_schema(7) == 7
+
+
+# ---------------------------------------------------------------------------
+# end-to-end smoke — schema feeding through pydantic model
+# ---------------------------------------------------------------------------
+
+
+class _ToolParams(BaseModel):
+    """A doc-string that should NOT make it into the wire schema."""
+
+    name: str
+    count: int = 1
+
+
+def test_normalise_works_on_pydantic_generated_schema() -> None:
+    raw = _ToolParams.model_json_schema()
+    out = OpenAIProvider._normalise_tool_schema(raw)
+    # Top-level title + description stripped.
+    assert "title" not in out
+    assert "description" not in out
+    # Property titles stripped.
+    for prop in out["properties"].values():
+        assert "title" not in prop

--- a/tests/providers/test_openai_extras_and_schema.py
+++ b/tests/providers/test_openai_extras_and_schema.py
@@ -259,3 +259,202 @@ def test_normalise_works_on_pydantic_generated_schema() -> None:
     # Property titles stripped.
     for prop in out["properties"].values():
         assert "title" not in prop
+
+
+# ---------------------------------------------------------------------------
+# Codex review #5 — input_tokens excludes cached_tokens (cache-hit accounting)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_usage_subtracts_cached_tokens_from_input() -> None:
+    """``input_tokens`` is the uncached portion; cached prefix reported
+    separately, matching Responses/faux accounting (avoids double-count
+    in cubebox cost aggregation)."""
+    usage_chunk = SimpleNamespace(
+        id="x",
+        choices=[],
+        usage=SimpleNamespace(
+            prompt_tokens=1000,
+            completion_tokens=50,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=800),
+        ),
+    )
+    final = _make_chunk(finish_reason="stop")
+
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        client = MagicMock()
+        mock_openai.return_value = client
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+
+        async def create(**_):
+            return _async_iter([usage_chunk, final])
+
+        client.chat.completions.create = create
+
+        provider = OpenAIProvider(api_key="x")
+        provider._client = client
+
+        ms = await provider.stream(
+            _model(),
+            [UserMessage(content=[TextContent(text="hi")])],
+        )
+        async for _ in ms:
+            pass
+        msg = await ms.result()
+
+    assert msg.usage.input_tokens == 200  # 1000 - 800
+    assert msg.usage.cache_read_tokens == 800
+    assert msg.usage.output_tokens == 50
+
+
+@pytest.mark.asyncio
+async def test_usage_no_cached_field_input_tokens_is_full_prompt() -> None:
+    """No prompt_tokens_details → cached_tokens=0, input_tokens=prompt_tokens."""
+    usage_chunk = SimpleNamespace(
+        id="x",
+        choices=[],
+        usage=SimpleNamespace(
+            prompt_tokens=200,
+            completion_tokens=10,
+            prompt_tokens_details=None,
+        ),
+    )
+    final = _make_chunk(finish_reason="stop")
+
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        client = MagicMock()
+        mock_openai.return_value = client
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+
+        async def create(**_):
+            return _async_iter([usage_chunk, final])
+
+        client.chat.completions.create = create
+
+        provider = OpenAIProvider(api_key="x")
+        provider._client = client
+
+        ms = await provider.stream(
+            _model(),
+            [UserMessage(content=[TextContent(text="hi")])],
+        )
+        async for _ in ms:
+            pass
+        msg = await ms.result()
+
+    assert msg.usage.input_tokens == 200
+    assert msg.usage.cache_read_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Codex review #6 — on_payload may opt out of stream_options.include_usage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_payload_can_disable_include_usage() -> None:
+    """Caller-supplied ``stream_options.include_usage=False`` must survive
+    the default-inject step."""
+    captured: dict[str, Any] = {}
+
+    async def on_payload(payload, model):
+        payload["stream_options"] = {"include_usage": False}
+        return payload
+
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        client = MagicMock()
+        mock_openai.return_value = client
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return _async_iter([_make_chunk(finish_reason="stop")])
+
+        client.chat.completions.create = capture
+
+        provider = OpenAIProvider(api_key="x")
+        provider._client = client
+
+        ms = await provider.stream(
+            _model(),
+            [UserMessage(content=[TextContent(text="hi")])],
+            options=StreamOptions(on_payload=on_payload),
+        )
+        async for _ in ms:
+            pass
+        await ms.result()
+
+    assert captured["stream_options"] == {"include_usage": False}
+
+
+@pytest.mark.asyncio
+async def test_default_adds_include_usage_when_not_set() -> None:
+    """Without on_payload customization, default adds include_usage=True."""
+    captured: dict[str, Any] = {}
+    with patch("openai.AsyncOpenAI") as mock_openai:
+        client = MagicMock()
+        mock_openai.return_value = client
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+
+        async def capture(**kwargs):
+            captured.update(kwargs)
+            return _async_iter([_make_chunk(finish_reason="stop")])
+
+        client.chat.completions.create = capture
+
+        provider = OpenAIProvider(api_key="x")
+        provider._client = client
+
+        ms = await provider.stream(
+            _model(),
+            [UserMessage(content=[TextContent(text="hi")])],
+        )
+        async for _ in ms:
+            pass
+        await ms.result()
+
+    assert captured["stream_options"] == {"include_usage": True}
+
+
+# ---------------------------------------------------------------------------
+# Codex review #7 — preserve sibling metadata when $ref-resolving
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_ref_resolution_preserves_sibling_description() -> None:
+    """Pydantic emits ``$ref`` alongside ``description`` / ``default`` on
+    Optional[Enum] fields; both must survive inlining."""
+    schema = {
+        "$defs": {"Color": {"title": "Color", "enum": ["r", "g"], "type": "string"}},
+        "properties": {
+            "c": {
+                "$ref": "#/$defs/Color",
+                "description": "primary colour",
+                "default": "r",
+            }
+        },
+    }
+    out = OpenAIProvider._normalise_tool_schema(schema)
+    resolved = out["properties"]["c"]
+    assert resolved["enum"] == ["r", "g"]
+    assert resolved["description"] == "primary colour"
+    assert resolved["default"] == "r"
+
+
+def test_normalise_ref_resolution_resolved_def_wins_on_key_collision() -> None:
+    """If both $def and sibling supply the same key, the $def value wins
+    (sibling is treated as additional metadata, not an override)."""
+    schema = {
+        "$defs": {"X": {"type": "string", "description": "from def"}},
+        "properties": {
+            "x": {"$ref": "#/$defs/X", "description": "from sibling"},
+        },
+    }
+    out = OpenAIProvider._normalise_tool_schema(schema)
+    # setdefault means the def's value sticks.
+    assert out["properties"]["x"]["description"] == "from def"


### PR DESCRIPTION
## Summary

Follow-up provider fixes shaken out by integrating cubepi into cubebox
(see `xfgong/cubebox#84` M5.3 / M6). Three Anthropic adapter fixes, six
OpenAI adapter fixes, and two test/style commits.

### Anthropic
- **`base_url` support**: forward to `AsyncAnthropic` so OpenAI-compat
  proxies that expose an `/anthropic` surface (DeepSeek, etc.) work
  without monkey-patching the SDK client. Was the root cause of
  cubebox's prompt-cache E2E failing — the provider was silently
  hitting `api.anthropic.com` with a DeepSeek key.
- **`temperature` forwarded** in stream kwargs.
- **`await stream.get_final_message()`** (was missing `await`,
  returned a coroutine that crashed inside `_convert_response` and
  was swallowed by `except BaseException`, leaving a zero-usage error
  AssistantMessage).
- Test mock updated to async to match.

### OpenAI (cache parity)
- **System as content-block list** when cache markers are needed, plus
  tool-schema normalisation so the byte stream matches what langchain
  used to send. Without this, OpenAI-compat auto-cache misses because
  the prefix bytes differ between turns.
- Plain string system prompt when no cache_control is in play
  (degrades cleanly for endpoints that don't accept the block form).
- Preserve enum `title` in `anyOf` but strip from
  inner items/properties — both ends of the cache-parity fix.
- Capture streaming usage when the provider sets it (some OSS
  endpoints only emit usage on the terminal SSE event).
- Forward `extra_body` / `extra_headers` so the provider config can
  thread through provider-specific knobs.

### Misc
- `forward max_tokens + temperature` at the base provider level.
- Two `style: ruff` commits to keep CI green.

## Test plan

- [x] `pytest tests/providers/test_anthropic.py tests/providers/test_anthropic_cache_policy.py` — 54 passed
- [x] cubebox M5.3 cache E2E (DeepSeek anthropic + cubepi runtime,
      `CUBEBOX_E2E_LLM_CACHE_CAPABLE=true`) — turn 2 cache_read ≈
      1900/2000 tokens (>50%), full 10-turn ≥85%
- [x] cubebox cubepi+OpenAI-compat E2E suite — green