### PR TITLE
fix(website): PostHog api_host empty-string fallback

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -2,8 +2,12 @@ import type { Config } from '@docusaurus/types';
 import type { Options as ClassicOptions } from '@docusaurus/preset-classic';
 import { themes as prismThemes } from 'prism-react-renderer';
 
-const POSTHOG_KEY = process.env.POSTHOG_KEY ?? '';
-const POSTHOG_HOST = process.env.POSTHOG_HOST ?? 'https://us.i.posthog.com';
+// Use `||` not `??` here: GitHub Actions expands an unset secret to "" (an
+// empty string passes the nullish check, so `??` would leave api_host empty
+// and PostHog falls back to the current origin — sending POST /e/ to the
+// docs domain and hitting a 405 from Cloudflare Pages).
+const POSTHOG_KEY = process.env.POSTHOG_KEY || '';
+const POSTHOG_HOST = process.env.POSTHOG_HOST || 'https://us.i.posthog.com';
 const GIT_SHA = process.env.GITHUB_SHA?.slice(0, 7) ?? 'dev';
 
 const classicOptions: ClassicOptions = {

--- a/website/src/clientModules/posthog.ts
+++ b/website/src/clientModules/posthog.ts
@@ -1,8 +1,10 @@
 import posthog from 'posthog-js';
 import siteConfig from '@generated/docusaurus.config';
 
-const key   = (siteConfig.customFields?.POSTHOG_KEY  as string | undefined) ?? '';
-const host  = (siteConfig.customFields?.POSTHOG_HOST as string | undefined) ?? 'https://us.i.posthog.com';
+// Use `||` not `??`: the build embeds POSTHOG_HOST="" when the secret is
+// unset, and we need the empty string to fall back to the US endpoint.
+const key  = (siteConfig.customFields?.POSTHOG_KEY  as string | undefined) || '';
+const host = (siteConfig.customFields?.POSTHOG_HOST as string | undefined) || 'https://us.i.posthog.com';
 
 if (typeof window !== 'undefined' && key) {
   posthog.init(key, {


### PR DESCRIPTION
## Problem

After merging #69 and setting the \`POSTHOG_KEY\` secret, page-feedback events still didn't reach PostHog. Inspecting the deployed bundle showed:

\`\`\`
customFields:{
  POSTHOG_KEY: "phc_…"   ✓
  POSTHOG_HOST: ""       ← empty, not the default
}
\`\`\`

GitHub Actions expands a not-set secret to \`""\`. Our \`??\` operator only catches \`null\`/\`undefined\`, so the empty string flowed through and PostHog initialised with \`api_host: ""\`. The SDK then falls back to the current origin and sends \`POST /e/?…\` to \`cubepi.pages.dev\` — Cloudflare Pages rejects with **405 Method Not Allowed**.

## Fix

Switch both the build-time embed and the client init from \`??\` to \`||\` so empty strings also route to \`https://us.i.posthog.com\`.

## Verification

\`\`\`bash
pnpm build  # green
\`\`\`

After merge, the bundle should contain \`api_host:"https://us.i.posthog.com"\` and 👍/👎 requests should land on \`us.i.posthog.com/e/\` with 200.

## Test plan

- [ ] Merge → workflow re-builds with default host
- [ ] \`curl -s https://cubepi.pages.dev/assets/js/main.*.js | grep -o 'i.posthog.com'\` returns at least one hit
- [ ] In browser DevTools Network panel, clicking 👍 fires \`POST https://us.i.posthog.com/e/\` returning 200
- [ ] Event appears in PostHog → Live events with \`slug\` / \`helpful\` / \`version\` / \`locale\` properties