### PR TITLE
fix(mcp): dispatch HTTP loader by transport so streamable_http servers work

### DIFF
--- a/cubepi/mcp/http_loader.py
+++ b/cubepi/mcp/http_loader.py
@@ -3,10 +3,61 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, Literal
 
 from cubepi.agent.types import AgentTool
 from cubepi.mcp._adapter import make_mcp_agent_tool
+
+Transport = Literal["sse", "streamable_http"]
+
+
+@asynccontextmanager
+async def _open_session(
+    server_url: str,
+    *,
+    headers: dict[str, str] | None,
+    timeout: float,
+    transport: Transport,
+) -> AsyncIterator[Any]:
+    """Open an MCP ClientSession over the requested transport.
+
+    Normalises the two SDK transport client signatures: ``sse_client``
+    yields a 2-tuple ``(read, write)`` while ``streamablehttp_client``
+    yields a 3-tuple ``(read, write, get_session_id_callable)``. We drop
+    the session-id callable and expose a single ``ClientSession`` to the
+    caller.
+    """
+    from mcp import ClientSession
+
+    if transport == "streamable_http":
+        from mcp.client.streamable_http import streamablehttp_client
+
+        async with streamablehttp_client(
+            server_url,
+            headers=headers,
+            timeout=timeout,
+            sse_read_timeout=timeout,
+        ) as (read_stream, write_stream, _get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                yield session
+        return
+
+    if transport == "sse":
+        from mcp.client.sse import sse_client
+
+        async with sse_client(
+            server_url,
+            headers=headers,
+            timeout=timeout,
+            sse_read_timeout=timeout,
+        ) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                yield session
+        return
+
+    raise ValueError(f"unsupported MCP transport '{transport}'")
 
 
 async def load_mcp_tools_http(
@@ -14,33 +65,43 @@ async def load_mcp_tools_http(
     *,
     headers: dict[str, str] | None = None,
     timeout: float = 30.0,
+    transport: Transport = "sse",
 ) -> list[AgentTool]:
-    """Connect to an HTTP/SSE MCP server, discover tools, return AgentTools.
+    """Connect to an HTTP MCP server, discover tools, return AgentTools.
 
-    Uses the `mcp` SDK's HTTP client. Each returned tool's execute method
-    invokes tools/call against a fresh session — v1 simplicity, no pooling.
+    Uses the `mcp` SDK's HTTP client. ``transport`` picks the wire format:
 
-    The transport's own timeout bounds the SSE connection; we additionally
-    wrap initialize/list/call awaits in asyncio.wait_for so a server that
-    accepts the connection but stalls on protocol messages still aborts.
+    - ``"sse"`` (default) — legacy SSE-over-GET transport (``sse_client``).
+    - ``"streamable_http"`` — newer SSE-over-POST transport
+      (``streamablehttp_client``).
+
+    Each returned tool's execute method invokes ``tools/call`` against a
+    fresh session — v1 simplicity, no pooling. The session is opened over
+    the same transport that was used for discovery, so the call path
+    cannot accidentally regress to the wrong wire format.
+
+    The transport's own timeout bounds the connection; we additionally
+    wrap initialize/list/call awaits in ``asyncio.wait_for`` so a server
+    that accepts the connection but stalls on protocol messages still
+    aborts.
     """
-    from mcp import ClientSession
-    from mcp.client.sse import sse_client
 
     async def _call_remote(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
-        async with sse_client(server_url, headers=headers, timeout=timeout) as streams:
-            async with ClientSession(*streams) as session:
-                await asyncio.wait_for(session.initialize(), timeout=timeout)
-                resp = await asyncio.wait_for(
-                    session.call_tool(tool_name, args), timeout=timeout
-                )
-                return _serialize_call_tool_response(resp)
-
-    async with sse_client(server_url, headers=headers, timeout=timeout) as streams:
-        async with ClientSession(*streams) as session:
+        async with _open_session(
+            server_url, headers=headers, timeout=timeout, transport=transport
+        ) as session:
             await asyncio.wait_for(session.initialize(), timeout=timeout)
-            tools_resp = await asyncio.wait_for(session.list_tools(), timeout=timeout)
-            tool_descs = tools_resp.tools
+            resp = await asyncio.wait_for(
+                session.call_tool(tool_name, args), timeout=timeout
+            )
+            return _serialize_call_tool_response(resp)
+
+    async with _open_session(
+        server_url, headers=headers, timeout=timeout, transport=transport
+    ) as session:
+        await asyncio.wait_for(session.initialize(), timeout=timeout)
+        tools_resp = await asyncio.wait_for(session.list_tools(), timeout=timeout)
+        tool_descs = tools_resp.tools
 
     return [
         make_mcp_agent_tool(

--- a/cubepi/mcp/http_loader.py
+++ b/cubepi/mcp/http_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from typing import Any, Literal
 
 from cubepi.agent.types import AgentTool
@@ -34,11 +35,17 @@ async def _open_session(
     if transport == "streamable_http":
         from mcp.client.streamable_http import streamablehttp_client
 
+        # streamablehttp_client's timeout signature drifted across mcp SDK
+        # versions: 1.8/1.9-era releases required ``timedelta`` and called
+        # ``.total_seconds()`` internally, while ~1.10+ accepts ``float |
+        # timedelta``. Passing a ``timedelta`` works on every version we
+        # declare in our ``mcp>=1.0`` floor, so we always convert here.
+        timeout_td = timedelta(seconds=timeout)
         async with streamablehttp_client(
             server_url,
             headers=headers,
-            timeout=timeout,
-            sse_read_timeout=timeout,
+            timeout=timeout_td,
+            sse_read_timeout=timeout_td,
         ) as (read_stream, write_stream, _get_session_id):
             async with ClientSession(read_stream, write_stream) as session:
                 yield session

--- a/tests/mcp/test_http_loader.py
+++ b/tests/mcp/test_http_loader.py
@@ -280,11 +280,17 @@ async def test_load_mcp_tools_http_streamable_transport(monkeypatch) -> None:
 
     # Discovery used streamable_http (sse must not be touched).
     assert sse_calls == []
+    # streamablehttp_client expects ``timedelta`` on older mcp SDKs (1.8/1.9
+    # era) and ``float | timedelta`` on newer ones; we always pass a
+    # ``timedelta`` so the loader works on every release in our ``mcp>=1.0``
+    # dependency range.
+    from datetime import timedelta
+
     assert sh_calls[0] == {
         "url": "https://mcp.example/mcp",
         "headers": {"authorization": "Bearer x"},
-        "timeout": 7.5,
-        "sse_read_timeout": 7.5,
+        "timeout": timedelta(seconds=7.5),
+        "sse_read_timeout": timedelta(seconds=7.5),
     }
     assert len(sessions) == 1
 

--- a/tests/mcp/test_http_loader.py
+++ b/tests/mcp/test_http_loader.py
@@ -1,8 +1,9 @@
 """HTTP MCP loader tests (D2.2).
 
-The loader's transport (`sse_client` + `ClientSession`) is mocked so the
-test runs without a real MCP server. End-to-end against a live server is
-gated behind CUBEPI_TEST_MCP_HTTP_URL.
+The loader's transport (`sse_client` / `streamablehttp_client` +
+`ClientSession`) is mocked so the test runs without a real MCP server.
+End-to-end against a live server is gated behind
+``CUBEPI_TEST_MCP_HTTP_URL``.
 """
 
 import asyncio
@@ -47,16 +48,48 @@ class _FakeSession:
 
 
 def _install_fake_transport(monkeypatch, *, tools, call_response):
+    """Patch both transport clients; return per-transport call recorders.
+
+    The loader picks the transport at runtime, so we patch both
+    ``mcp.client.sse.sse_client`` and
+    ``mcp.client.streamable_http.streamablehttp_client``. Tests can assert
+    on whichever recorder corresponds to the transport under test.
+    """
     import mcp
     import mcp.client.sse as sse_mod
+    import mcp.client.streamable_http as sh_mod
 
     sessions: list[_FakeSession] = []
     sse_calls: list[dict] = []
+    sh_calls: list[dict] = []
 
     @asynccontextmanager
-    async def fake_sse_client(url, *, headers=None, timeout=None):
-        sse_calls.append({"url": url, "headers": headers, "timeout": timeout})
+    async def fake_sse_client(
+        url, *, headers=None, timeout=None, sse_read_timeout=None
+    ):
+        sse_calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "timeout": timeout,
+                "sse_read_timeout": sse_read_timeout,
+            }
+        )
         yield ("read-stream-stub", "write-stream-stub")
+
+    @asynccontextmanager
+    async def fake_streamablehttp_client(
+        url, *, headers=None, timeout=None, sse_read_timeout=None
+    ):
+        sh_calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "timeout": timeout,
+                "sse_read_timeout": sse_read_timeout,
+            }
+        )
+        yield ("read-stream-stub", "write-stream-stub", lambda: None)
 
     def fake_client_session(*streams):
         sess = _FakeSession(*streams, tools=tools, call_response=call_response)
@@ -64,8 +97,9 @@ def _install_fake_transport(monkeypatch, *, tools, call_response):
         return sess
 
     monkeypatch.setattr(sse_mod, "sse_client", fake_sse_client)
+    monkeypatch.setattr(sh_mod, "streamablehttp_client", fake_streamablehttp_client)
     monkeypatch.setattr(mcp, "ClientSession", fake_client_session)
-    return sessions, sse_calls
+    return sessions, sse_calls, sh_calls
 
 
 @pytest.mark.asyncio
@@ -93,7 +127,7 @@ async def test_load_mcp_tools_http_lists_and_calls_tool(monkeypatch) -> None:
         ],
         isError=False,
     )
-    sessions, sse_calls = _install_fake_transport(
+    sessions, sse_calls, sh_calls = _install_fake_transport(
         monkeypatch, tools=tools_resp, call_response=call_resp
     )
 
@@ -107,10 +141,13 @@ async def test_load_mcp_tools_http_lists_and_calls_tool(monkeypatch) -> None:
     tool = tools[0]
     assert tool.name == "search"
     assert tool.description == "Search the web"
+    # Default transport is sse — streamable_http must not be touched.
+    assert sh_calls == []
     assert sse_calls[0] == {
         "url": "https://mcp.example/sse",
         "headers": {"x-test": "1"},
         "timeout": 12.5,
+        "sse_read_timeout": 12.5,
     }
     assert sessions[0].initialized is True
 
@@ -208,6 +245,70 @@ async def test_load_mcp_tools_http_handles_empty_content(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_load_mcp_tools_http_streamable_transport(monkeypatch) -> None:
+    """transport="streamable_http" dispatches to streamablehttp_client.
+
+    Regression gate: cubepi previously hard-coded ``sse_client`` for every
+    URL. A streamable_http server accepts the SSE GET but never pushes
+    the legacy ``endpoint`` event, so the agent would hang in
+    ``session.initialize()`` until the per-op timeout fired. Now both
+    discovery and per-tool ``call_tool`` must go through the matching
+    streamable_http client.
+    """
+    from cubepi.mcp import load_mcp_tools_http
+
+    tools_resp = [
+        SimpleNamespace(
+            name="search",
+            description="",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+    ]
+    call_resp = SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="ok")], isError=False
+    )
+    sessions, sse_calls, sh_calls = _install_fake_transport(
+        monkeypatch, tools=tools_resp, call_response=call_resp
+    )
+
+    tools = await load_mcp_tools_http(
+        "https://mcp.example/mcp",
+        headers={"authorization": "Bearer x"},
+        timeout=7.5,
+        transport="streamable_http",
+    )
+
+    # Discovery used streamable_http (sse must not be touched).
+    assert sse_calls == []
+    assert sh_calls[0] == {
+        "url": "https://mcp.example/mcp",
+        "headers": {"authorization": "Bearer x"},
+        "timeout": 7.5,
+        "sse_read_timeout": 7.5,
+    }
+    assert len(sessions) == 1
+
+    # Per-tool call_tool must reuse the same transport so the call path
+    # cannot regress to the wrong wire format.
+    args = tools[0].parameters()
+    await tools[0].execute("tc-sh", args, signal=None, on_update=None)
+    assert sse_calls == []
+    assert len(sh_calls) == 2  # one for list_tools, one for call_tool
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_tools_http_rejects_unknown_transport() -> None:
+    """Unknown transport raises ValueError; we do not silently fall back."""
+    from cubepi.mcp import load_mcp_tools_http
+
+    with pytest.raises(ValueError, match="unsupported MCP transport"):
+        await load_mcp_tools_http(
+            "https://mcp.example/sse",
+            transport="websocket",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
 async def test_load_mcp_tools_http_initialize_timeout(monkeypatch) -> None:
     """A session that hangs on initialize must raise TimeoutError, not block."""
     from cubepi.mcp import load_mcp_tools_http
@@ -235,7 +336,9 @@ async def test_load_mcp_tools_http_initialize_timeout(monkeypatch) -> None:
     import mcp.client.sse as sse_mod
 
     @asynccontextmanager
-    async def fake_sse_client(url, *, headers=None, timeout=None):
+    async def fake_sse_client(
+        url, *, headers=None, timeout=None, sse_read_timeout=None
+    ):
         yield ("r", "w")
 
     monkeypatch.setattr(sse_mod, "sse_client", fake_sse_client)


### PR DESCRIPTION
## Summary

`load_mcp_tools_http` was hard-coded to `sse_client` for every URL. Calling it against a `streamable_http` MCP server opens the legacy SSE GET, then waits forever for the `endpoint` event that the newer wire format never sends — `session.initialize()` hangs until the per-op `asyncio.wait_for` fires (and the underlying SSE context cleanup can stall the whole agent task beyond that).

This PR adds a `transport=` parameter and an internal `_open_session` helper that dispatches between `sse_client` and `streamablehttp_client`. Default stays `"sse"` so existing callers are unaffected.

## Behaviour

- `load_mcp_tools_http(url, transport="sse")` — unchanged, uses `mcp.client.sse.sse_client`.
- `load_mcp_tools_http(url, transport="streamable_http")` — uses `mcp.client.streamable_http.streamablehttp_client`, ignores its session-id callable.
- Unknown transport → `ValueError`. No silent fallback.
- The inner `_call_remote` (used by each tool invocation) goes through the same helper, so a discovery that succeeded over streamable_http cannot regress to SSE when a tool is actually called.

## Why this exists

cubebox's `cubepi_admin_discovery.py` had already worked around this with its own transport dispatch and left a TODO pointing at `cubepi.mcp.load_mcp_tools_http` being "currently SSE-only". This PR closes that gap so the per-run agent path can talk to any MCP server cubebox lets users install.

Downstream impact: cubebox will pass `transport=spec.transport` from its `CubepiMCPServerSpec` once it picks up this commit; the admin-discovery workaround comment can come out at that point.

## Test plan

- [x] `pytest tests/mcp/test_http_loader.py -q` — 8 passed, 1 skipped (real-server E2E).
- [x] `pytest tests/mcp -q` — 22 passed.
- [x] `ruff check` + `ruff format` clean.
- [x] New `test_load_mcp_tools_http_streamable_transport` asserts: discovery uses `streamablehttp_client` (sse client untouched); per-tool `call_tool` reuses the same transport (recorder shows 2 streamable_http opens, 0 sse opens).
- [x] New `test_load_mcp_tools_http_rejects_unknown_transport` asserts `ValueError` for unknown transports.
- [x] Existing SSE tests now assert the streamable_http recorder is empty, locking in backward compatibility.