### PR TITLE
docs(website): add Google Analytics via official gtag plugin

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -55,6 +55,16 @@ const config: Config = {
 
   presets: [['classic', classicOptions]],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-google-gtag',
+      {
+        trackingID: 'G-NE2PDN0M91',
+        anonymizeIP: false,
+      },
+    ],
+  ],
+
   themeConfig: {
     image: 'img/brand/cubepi-social-preview.png',
     navbar: {

--- a/website/package.json
+++ b/website/package.json
@@ -24,6 +24,7 @@
     "@docusaurus/core": "3.10.1",
     "@docusaurus/faster": "3.10.1",
     "@docusaurus/plugin-content-docs": "3.10.1",
+    "@docusaurus/plugin-google-gtag": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@docusaurus/plugin-content-docs':
         specifier: 3.10.1
         version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@docusaurus/plugin-google-gtag':
+        specifier: 3.10.1
+        version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       '@docusaurus/preset-classic':
         specifier: 3.10.1
         version: 3.10.1(@algolia/client-search@5.52.1)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.33)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(postcss@8.5.14))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.6))(@rspack/core@1.7.11)(@swc/core@1.15.33)(@types/react@19.2.14)(lightningcss@1.32.0)(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(search-insights@2.17.3)(typescript@6.0.3)


### PR DESCRIPTION
## Summary
- Add `@docusaurus/plugin-google-gtag@3.10.1` and wire it in `docusaurus.config.ts`
- Tracking ID: `G-NE2PDN0M91` (data stream `cubepi`, https://cubepi.pages.dev)
- No cookie consent gating for now (per request); can layer Consent Mode v2 later if needed
- Coexists with existing PostHog client module — independent pipelines

## Test plan
- [x] `pnpm build` succeeds for both `en` and `zh-Hans` locales
- [x] Built HTML contains `googletagmanager.com/gtag/js?id=G-NE2PDN0M91` (verified for `/index.html` and `/zh-Hans/index.html`)
- [ ] After deploy, open https://cubepi.pages.dev and confirm GA4 Realtime shows traffic