### PR TITLE
feat(mcp): expose server + tool icons from discovery handshake

### DIFF
--- a/cubepi/mcp/__init__.py
+++ b/cubepi/mcp/__init__.py
@@ -5,5 +5,18 @@ cubepi[mcp] extra required.
 
 from cubepi.mcp.http_loader import load_mcp_tools_http
 from cubepi.mcp.stdio_loader import load_mcp_tools_stdio
+from cubepi.mcp.types import (
+    MCPDiscoveryResult,
+    MCPIcon,
+    MCPServerInfo,
+    MCPToolInfo,
+)
 
-__all__ = ["load_mcp_tools_http", "load_mcp_tools_stdio"]
+__all__ = [
+    "MCPDiscoveryResult",
+    "MCPIcon",
+    "MCPServerInfo",
+    "MCPToolInfo",
+    "load_mcp_tools_http",
+    "load_mcp_tools_stdio",
+]

--- a/cubepi/mcp/http_loader.py
+++ b/cubepi/mcp/http_loader.py
@@ -8,8 +8,12 @@ from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import Any, Literal
 
-from cubepi.agent.types import AgentTool
 from cubepi.mcp._adapter import make_mcp_agent_tool
+from cubepi.mcp.types import (
+    MCPDiscoveryResult,
+    server_info_from_init_result,
+    tool_info_from_desc,
+)
 
 Transport = Literal["sse", "streamable_http"]
 
@@ -73,10 +77,21 @@ async def load_mcp_tools_http(
     headers: dict[str, str] | None = None,
     timeout: float = 30.0,
     transport: Transport = "sse",
-) -> list[AgentTool]:
-    """Connect to an HTTP MCP server, discover tools, return AgentTools.
+) -> MCPDiscoveryResult:
+    """Connect to an HTTP MCP server and discover its tools + metadata.
 
-    Uses the `mcp` SDK's HTTP client. ``transport`` picks the wire format:
+    Returns a :class:`MCPDiscoveryResult` carrying:
+
+    - ``tools`` — executable ``AgentTool`` per ``tools/list`` entry.
+    - ``server`` — ``MCPServerInfo`` (name, version, websiteUrl, icons)
+      captured from the ``initialize`` handshake's ``serverInfo``. Sourced
+      from MCP spec rev 2025-11-25's ``Implementation`` shape.
+    - ``tool_infos`` — per-tool display metadata (currently ``icons``)
+      captured from each ``tools/list`` entry, separated from
+      ``AgentTool`` so callers can render visuals without coupling
+      core types to display concerns.
+
+    ``transport`` picks the wire format:
 
     - ``"sse"`` (default) — legacy SSE-over-GET transport (``sse_client``).
     - ``"streamable_http"`` — newer SSE-over-POST transport
@@ -106,11 +121,11 @@ async def load_mcp_tools_http(
     async with _open_session(
         server_url, headers=headers, timeout=timeout, transport=transport
     ) as session:
-        await asyncio.wait_for(session.initialize(), timeout=timeout)
+        init_result = await asyncio.wait_for(session.initialize(), timeout=timeout)
         tools_resp = await asyncio.wait_for(session.list_tools(), timeout=timeout)
         tool_descs = tools_resp.tools
 
-    return [
+    tools = [
         make_mcp_agent_tool(
             name=desc.name,
             description=desc.description or "",
@@ -119,6 +134,12 @@ async def load_mcp_tools_http(
         )
         for desc in tool_descs
     ]
+    tool_infos = [tool_info_from_desc(desc) for desc in tool_descs]
+    return MCPDiscoveryResult(
+        tools=tools,
+        server=server_info_from_init_result(init_result),
+        tool_infos=tool_infos,
+    )
 
 
 def _serialize_call_tool_response(resp: Any) -> dict[str, Any]:

--- a/cubepi/mcp/stdio_loader.py
+++ b/cubepi/mcp/stdio_loader.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from cubepi.agent.types import AgentTool
 from cubepi.mcp._adapter import make_mcp_agent_tool
+from cubepi.mcp.types import (
+    MCPDiscoveryResult,
+    server_info_from_init_result,
+    tool_info_from_desc,
+)
 
 
 async def load_mcp_tools_stdio(
@@ -16,8 +20,13 @@ async def load_mcp_tools_stdio(
     env: dict[str, str] | None = None,
     cwd: str | None = None,
     timeout: float = 30.0,
-) -> list[AgentTool]:
-    """Spawn a stdio MCP server subprocess, discover tools, return AgentTools.
+) -> MCPDiscoveryResult:
+    """Spawn a stdio MCP server subprocess and discover its tools + metadata.
+
+    Returns a :class:`MCPDiscoveryResult` with the same shape as
+    :func:`load_mcp_tools_http`: ``tools`` (executable AgentTools),
+    ``server`` (Implementation info from ``initialize``), and ``tool_infos``
+    (per-tool display metadata such as icons).
 
     Each returned tool's execute opens a fresh subprocess per call (v1
     simplicity, no process pooling).
@@ -51,11 +60,11 @@ async def load_mcp_tools_stdio(
 
     async with stdio_client(server_params) as streams:
         async with ClientSession(*streams) as session:
-            await asyncio.wait_for(session.initialize(), timeout=timeout)
+            init_result = await asyncio.wait_for(session.initialize(), timeout=timeout)
             tools_resp = await asyncio.wait_for(session.list_tools(), timeout=timeout)
             tool_descs = tools_resp.tools
 
-    return [
+    tools = [
         make_mcp_agent_tool(
             name=desc.name,
             description=desc.description or "",
@@ -64,6 +73,12 @@ async def load_mcp_tools_stdio(
         )
         for desc in tool_descs
     ]
+    tool_infos = [tool_info_from_desc(desc) for desc in tool_descs]
+    return MCPDiscoveryResult(
+        tools=tools,
+        server=server_info_from_init_result(init_result),
+        tool_infos=tool_infos,
+    )
 
 
 def _serialize_call_tool_response(resp: Any) -> dict[str, Any]:

--- a/cubepi/mcp/types.py
+++ b/cubepi/mcp/types.py
@@ -1,0 +1,124 @@
+"""MCP discovery result types (spec rev 2025-11-25 icons + serverInfo)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from cubepi.agent.types import AgentTool
+
+
+@dataclass(frozen=True)
+class MCPIcon:
+    """One icon entry from an MCP ``Icon`` block.
+
+    Mirrors ``mcp.types.Icon`` with snake_case fields. ``src`` is either an
+    HTTP/HTTPS URL or a ``data:`` URI; ``sizes`` is a tuple of strings such
+    as ``("48x48", "96x96")``.
+    """
+
+    src: str
+    mime_type: str | None = None
+    sizes: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class MCPServerInfo:
+    """Server-level metadata captured from the ``initialize`` handshake.
+
+    Sourced from ``InitializeResult.serverInfo`` (an ``Implementation``):
+    the server's display name + version, an optional website URL, and an
+    optional list of icons that clients can render as the server's logo.
+    """
+
+    name: str
+    version: str
+    website_url: str | None = None
+    icons: tuple[MCPIcon, ...] = ()
+
+
+@dataclass(frozen=True)
+class MCPToolInfo:
+    """Per-tool display metadata captured from ``tools/list``.
+
+    Carries ``Tool.icons`` separately from the executable ``AgentTool`` so
+    consumers can render tool-specific icons without coupling cubepi's
+    core ``AgentTool`` type to MCP display concerns.
+    """
+
+    name: str
+    icons: tuple[MCPIcon, ...] = ()
+
+
+@dataclass(frozen=True)
+class MCPDiscoveryResult:
+    """Outcome of an MCP discovery handshake.
+
+    ``tools`` is the executable surface (one ``AgentTool`` per tool the
+    server exposes). ``server`` and ``tool_infos`` are display metadata
+    captured from the same handshake; both follow MCP spec rev 2025-11-25.
+    """
+
+    tools: list[AgentTool]
+    server: MCPServerInfo | None = None
+    tool_infos: list[MCPToolInfo] = field(default_factory=list)
+
+
+def _icon_from_raw(raw: object) -> MCPIcon | None:
+    """Normalise an ``mcp.types.Icon`` (or duck-type) into ``MCPIcon``.
+
+    Returns ``None`` when the raw entry is missing the required ``src``.
+    Accepts attribute-bearing objects (Pydantic models, SimpleNamespace);
+    callers are expected to pass entries from a parsed MCP response.
+    """
+    src = getattr(raw, "src", None)
+    if not src:
+        return None
+    mime = getattr(raw, "mimeType", None) or getattr(raw, "mime_type", None)
+    sizes_raw = getattr(raw, "sizes", None)
+    sizes = tuple(sizes_raw) if sizes_raw else None
+    return MCPIcon(src=src, mime_type=mime, sizes=sizes)
+
+
+def icons_from_raw(raws: object) -> tuple[MCPIcon, ...]:
+    """Build a tuple of ``MCPIcon`` from a raw ``icons`` field.
+
+    Tolerates ``None``, an empty list, or a list of icon-shaped objects.
+    Entries missing ``src`` are silently dropped.
+    """
+    if not isinstance(raws, list | tuple):
+        return ()
+    out: list[MCPIcon] = []
+    for raw in raws:
+        icon = _icon_from_raw(raw)
+        if icon is not None:
+            out.append(icon)
+    return tuple(out)
+
+
+def server_info_from_init_result(init_result: object) -> MCPServerInfo | None:
+    """Extract ``MCPServerInfo`` from an ``InitializeResult`` (or duck-type).
+
+    Returns ``None`` when ``serverInfo`` is absent or missing the required
+    ``name``.
+    """
+    server = getattr(init_result, "serverInfo", None)
+    if server is None:
+        return None
+    name = getattr(server, "name", None)
+    if not name:
+        return None
+    return MCPServerInfo(
+        name=name,
+        version=getattr(server, "version", "") or "",
+        website_url=getattr(server, "websiteUrl", None)
+        or getattr(server, "website_url", None),
+        icons=icons_from_raw(getattr(server, "icons", None)),
+    )
+
+
+def tool_info_from_desc(desc: object) -> MCPToolInfo:
+    """Build a ``MCPToolInfo`` from a single ``tools/list`` entry."""
+    return MCPToolInfo(
+        name=getattr(desc, "name", "") or "",
+        icons=icons_from_raw(getattr(desc, "icons", None)),
+    )

--- a/cubepi/mcp/types.py
+++ b/cubepi/mcp/types.py
@@ -13,12 +13,16 @@ class MCPIcon:
 
     Mirrors ``mcp.types.Icon`` with snake_case fields. ``src`` is either an
     HTTP/HTTPS URL or a ``data:`` URI; ``sizes`` is a tuple of strings such
-    as ``("48x48", "96x96")``.
+    as ``("48x48", "96x96")``. ``theme`` is ``"light"`` or ``"dark"`` when
+    the server supplies separate variants — the spec lets clients pick the
+    variant matching the current UI theme and fall back to the first entry
+    otherwise.
     """
 
     src: str
     mime_type: str | None = None
     sizes: tuple[str, ...] | None = None
+    theme: str | None = None
 
 
 @dataclass(frozen=True)
@@ -76,7 +80,8 @@ def _icon_from_raw(raw: object) -> MCPIcon | None:
     mime = getattr(raw, "mimeType", None) or getattr(raw, "mime_type", None)
     sizes_raw = getattr(raw, "sizes", None)
     sizes = tuple(sizes_raw) if sizes_raw else None
-    return MCPIcon(src=src, mime_type=mime, sizes=sizes)
+    theme = getattr(raw, "theme", None)
+    return MCPIcon(src=src, mime_type=mime, sizes=sizes, theme=theme)
 
 
 def icons_from_raw(raws: object) -> tuple[MCPIcon, ...]:

--- a/tests/mcp/test_http_loader.py
+++ b/tests/mcp/test_http_loader.py
@@ -24,9 +24,14 @@ def test_import_http_loader() -> None:
 class _FakeSession:
     """Stand-in for mcp.ClientSession that records calls and returns canned data."""
 
-    def __init__(self, *streams, tools=None, call_response=None):
+    def __init__(self, *streams, tools=None, call_response=None, init_result=None):
         self._tools = tools or []
         self._call_response = call_response
+        self._init_result = init_result or SimpleNamespace(
+            serverInfo=SimpleNamespace(
+                name="fake-server", version="0.0.0", icons=None, websiteUrl=None
+            )
+        )
         self.initialized = False
         self.calls: list[tuple[str, dict]] = []
 
@@ -38,6 +43,7 @@ class _FakeSession:
 
     async def initialize(self):
         self.initialized = True
+        return self._init_result
 
     async def list_tools(self):
         return SimpleNamespace(tools=self._tools)
@@ -47,7 +53,7 @@ class _FakeSession:
         return self._call_response
 
 
-def _install_fake_transport(monkeypatch, *, tools, call_response):
+def _install_fake_transport(monkeypatch, *, tools, call_response, init_result=None):
     """Patch both transport clients; return per-transport call recorders.
 
     The loader picks the transport at runtime, so we patch both
@@ -92,7 +98,12 @@ def _install_fake_transport(monkeypatch, *, tools, call_response):
         yield ("read-stream-stub", "write-stream-stub", lambda: None)
 
     def fake_client_session(*streams):
-        sess = _FakeSession(*streams, tools=tools, call_response=call_response)
+        sess = _FakeSession(
+            *streams,
+            tools=tools,
+            call_response=call_response,
+            init_result=init_result,
+        )
         sessions.append(sess)
         return sess
 
@@ -117,6 +128,7 @@ async def test_load_mcp_tools_http_lists_and_calls_tool(monkeypatch) -> None:
                 "properties": {"query": {"type": "string"}},
                 "required": ["query"],
             },
+            icons=None,
         ),
     ]
     call_resp = SimpleNamespace(
@@ -131,12 +143,13 @@ async def test_load_mcp_tools_http_lists_and_calls_tool(monkeypatch) -> None:
         monkeypatch, tools=tools_resp, call_response=call_resp
     )
 
-    tools = await load_mcp_tools_http(
+    result = await load_mcp_tools_http(
         "https://mcp.example/sse",
         headers={"x-test": "1"},
         timeout=12.5,
     )
 
+    tools = result.tools
     assert len(tools) == 1
     tool = tools[0]
     assert tool.name == "search"
@@ -179,6 +192,7 @@ async def test_load_mcp_tools_http_propagates_is_error(monkeypatch) -> None:
             name="boom",
             description=None,  # falsy description path → ""
             inputSchema=None,  # falsy schema path → empty object schema
+            icons=None,
         ),
     ]
     call_resp = SimpleNamespace(
@@ -187,7 +201,8 @@ async def test_load_mcp_tools_http_propagates_is_error(monkeypatch) -> None:
     )
     _install_fake_transport(monkeypatch, tools=tools_resp, call_response=call_resp)
 
-    tools = await load_mcp_tools_http("https://mcp.example/sse")
+    result = await load_mcp_tools_http("https://mcp.example/sse")
+    tools = result.tools
     assert len(tools) == 1
     tool = tools[0]
     # falsy → defaults applied
@@ -208,6 +223,7 @@ async def test_load_mcp_tools_http_preserves_structured_content(monkeypatch) -> 
             name="weather",
             description="",
             inputSchema={"type": "object", "properties": {}},
+            icons=None,
         ),
     ]
     call_resp = SimpleNamespace(
@@ -217,9 +233,11 @@ async def test_load_mcp_tools_http_preserves_structured_content(monkeypatch) -> 
     )
     _install_fake_transport(monkeypatch, tools=tools_resp, call_response=call_resp)
 
-    tools = await load_mcp_tools_http("https://mcp.example/sse")
-    args = tools[0].parameters()
-    result = await tools[0].execute("tc-sc", args, signal=None, on_update=None)
+    discovery = await load_mcp_tools_http("https://mcp.example/sse")
+    args = discovery.tools[0].parameters()
+    result = await discovery.tools[0].execute(
+        "tc-sc", args, signal=None, on_update=None
+    )
     assert result.details["structuredContent"] == {"temp_f": 73, "conditions": "clear"}
 
 
@@ -233,14 +251,15 @@ async def test_load_mcp_tools_http_handles_empty_content(monkeypatch) -> None:
             name="silent",
             description="",
             inputSchema={"type": "object", "properties": {}},
+            icons=None,
         ),
     ]
     call_resp = SimpleNamespace(content=None, isError=False)
     _install_fake_transport(monkeypatch, tools=tools_resp, call_response=call_resp)
 
-    tools = await load_mcp_tools_http("https://mcp.example/sse")
-    args = tools[0].parameters()
-    result = await tools[0].execute("tc-3", args, signal=None, on_update=None)
+    discovery = await load_mcp_tools_http("https://mcp.example/sse")
+    args = discovery.tools[0].parameters()
+    result = await discovery.tools[0].execute("tc-3", args, signal=None, on_update=None)
     assert result.content == []
 
 
@@ -262,6 +281,7 @@ async def test_load_mcp_tools_http_streamable_transport(monkeypatch) -> None:
             name="search",
             description="",
             inputSchema={"type": "object", "properties": {}},
+            icons=None,
         ),
     ]
     call_resp = SimpleNamespace(
@@ -271,12 +291,13 @@ async def test_load_mcp_tools_http_streamable_transport(monkeypatch) -> None:
         monkeypatch, tools=tools_resp, call_response=call_resp
     )
 
-    tools = await load_mcp_tools_http(
+    discovery = await load_mcp_tools_http(
         "https://mcp.example/mcp",
         headers={"authorization": "Bearer x"},
         timeout=7.5,
         transport="streamable_http",
     )
+    tools = discovery.tools
 
     # Discovery used streamable_http (sse must not be touched).
     assert sse_calls == []
@@ -363,8 +384,125 @@ async def test_load_mcp_tools_http_against_test_server() -> None:
 
     from cubepi.mcp import load_mcp_tools_http
 
-    tools = await load_mcp_tools_http(server_url)
-    assert len(tools) > 0
-    first = tools[0]
+    discovery = await load_mcp_tools_http(server_url)
+    assert len(discovery.tools) > 0
+    first = discovery.tools[0]
     assert first.name
     assert first.description is not None
+
+
+# ---------------------------------------------------------------------------
+# New: server + tool icon metadata capture (MCP spec 2025-11-25)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_tools_http_captures_server_info_from_initialize(
+    monkeypatch,
+) -> None:
+    """Implementation.icons + websiteUrl + name flow into MCPServerInfo."""
+    from cubepi.mcp import MCPDiscoveryResult, MCPIcon, load_mcp_tools_http
+
+    init_result = SimpleNamespace(
+        serverInfo=SimpleNamespace(
+            name="Linear",
+            version="1.4.2",
+            websiteUrl="https://linear.app",
+            icons=[
+                SimpleNamespace(
+                    src="https://linear.app/favicon.svg", mimeType="image/svg+xml"
+                ),
+                SimpleNamespace(
+                    src="data:image/png;base64,zzz",
+                    mimeType="image/png",
+                    sizes=["48x48"],
+                ),
+            ],
+        )
+    )
+    tools_resp = [
+        SimpleNamespace(
+            name="create_issue",
+            description="Create a Linear issue",
+            inputSchema={"type": "object", "properties": {}},
+            icons=None,
+        ),
+    ]
+    call_resp = SimpleNamespace(content=[], isError=False)
+    _install_fake_transport(
+        monkeypatch, tools=tools_resp, call_response=call_resp, init_result=init_result
+    )
+
+    discovery = await load_mcp_tools_http("https://mcp.example/sse")
+    assert isinstance(discovery, MCPDiscoveryResult)
+    assert discovery.server is not None
+    assert discovery.server.name == "Linear"
+    assert discovery.server.version == "1.4.2"
+    assert discovery.server.website_url == "https://linear.app"
+    assert discovery.server.icons == (
+        MCPIcon(src="https://linear.app/favicon.svg", mime_type="image/svg+xml"),
+        MCPIcon(
+            src="data:image/png;base64,zzz", mime_type="image/png", sizes=("48x48",)
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_tools_http_captures_per_tool_icons(monkeypatch) -> None:
+    """Per-tool ``Tool.icons`` flow into ``tool_infos`` keyed by tool name."""
+    from cubepi.mcp import MCPIcon, load_mcp_tools_http
+
+    tools_resp = [
+        SimpleNamespace(
+            name="search",
+            description="",
+            inputSchema={"type": "object", "properties": {}},
+            icons=[
+                SimpleNamespace(
+                    src="data:image/svg+xml;base64,abc", mimeType=None, sizes=None
+                )
+            ],
+        ),
+        SimpleNamespace(
+            name="fetch",
+            description="",
+            inputSchema={"type": "object", "properties": {}},
+            icons=None,
+        ),
+    ]
+    call_resp = SimpleNamespace(content=[], isError=False)
+    _install_fake_transport(monkeypatch, tools=tools_resp, call_response=call_resp)
+
+    discovery = await load_mcp_tools_http("https://mcp.example/sse")
+    by_name = {ti.name: ti for ti in discovery.tool_infos}
+    assert by_name["search"].icons == (MCPIcon(src="data:image/svg+xml;base64,abc"),)
+    assert by_name["fetch"].icons == ()
+
+
+@pytest.mark.asyncio
+async def test_load_mcp_tools_http_handles_missing_server_icons(monkeypatch) -> None:
+    """Server without icons / websiteUrl yields MCPServerInfo with empty defaults."""
+    from cubepi.mcp import load_mcp_tools_http
+
+    init_result = SimpleNamespace(
+        serverInfo=SimpleNamespace(
+            name="bare-server", version="0.1.0", icons=None, websiteUrl=None
+        )
+    )
+    tools_resp = [
+        SimpleNamespace(
+            name="echo",
+            description="",
+            inputSchema={"type": "object", "properties": {}},
+            icons=None,
+        ),
+    ]
+    call_resp = SimpleNamespace(content=[], isError=False)
+    _install_fake_transport(
+        monkeypatch, tools=tools_resp, call_response=call_resp, init_result=init_result
+    )
+
+    discovery = await load_mcp_tools_http("https://mcp.example/sse")
+    assert discovery.server is not None
+    assert discovery.server.icons == ()
+    assert discovery.server.website_url is None

--- a/tests/mcp/test_stdio_loader.py
+++ b/tests/mcp/test_stdio_loader.py
@@ -14,15 +14,21 @@ def test_import_stdio_loader() -> None:
 @pytest.mark.asyncio
 async def test_stdio_loader_against_fake_server() -> None:
     """Spawn the fake stdio server, list tools, invoke 'echo'."""
-    from cubepi.mcp import load_mcp_tools_stdio
+    from cubepi.mcp import MCPDiscoveryResult, load_mcp_tools_stdio
 
-    tools = await load_mcp_tools_stdio(
+    discovery = await load_mcp_tools_stdio(
         command=sys.executable,
         args=["-m", "tests.mcp._fake_stdio_server"],
     )
-    assert len(tools) == 1
-    echo = tools[0]
+    assert isinstance(discovery, MCPDiscoveryResult)
+    assert len(discovery.tools) == 1
+    echo = discovery.tools[0]
     assert echo.name == "echo"
+
+    # Server info is captured from the initialize handshake; the fake
+    # server reports its name + version via Implementation.
+    assert discovery.server is not None
+    assert discovery.server.name
 
     args = echo.parameters(text="hello")
     result = await echo.execute("tc-stdio-1", args, signal=None, on_update=None)

--- a/tests/mcp/test_types.py
+++ b/tests/mcp/test_types.py
@@ -1,0 +1,113 @@
+"""Unit tests for ``cubepi.mcp.types`` normalisation helpers.
+
+The HTTP/stdio loader tests exercise the happy paths in aggregate. These
+tests pin the edge cases of the conversion helpers directly so the
+coverage gate doesn't regress when callers refactor.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from cubepi.mcp.types import (
+    MCPIcon,
+    MCPServerInfo,
+    MCPToolInfo,
+    icons_from_raw,
+    server_info_from_init_result,
+    tool_info_from_desc,
+)
+
+
+def test_icons_from_raw_returns_empty_for_non_iterable() -> None:
+    """A ``None`` (or non-list) ``icons`` field yields an empty tuple, not a crash."""
+    assert icons_from_raw(None) == ()
+    assert icons_from_raw("not a list") == ()
+    assert icons_from_raw({"some": "dict"}) == ()
+
+
+def test_icons_from_raw_drops_entries_with_missing_src() -> None:
+    """Icons missing the required ``src`` are silently skipped."""
+    raws = [
+        SimpleNamespace(src="", mimeType="image/svg+xml"),  # empty src
+        SimpleNamespace(src=None),  # None src
+        SimpleNamespace(src="https://x/icon.svg"),  # valid
+    ]
+    icons = icons_from_raw(raws)
+    assert icons == (MCPIcon(src="https://x/icon.svg"),)
+
+
+def test_icons_from_raw_preserves_theme_for_light_dark_variants() -> None:
+    """MCP spec rev 2025-11-25 allows ``theme`` so clients can pick the
+    variant matching the current UI theme."""
+    raws = [
+        SimpleNamespace(
+            src="https://x/icon-light.svg", mimeType="image/svg+xml", theme="light"
+        ),
+        SimpleNamespace(
+            src="https://x/icon-dark.svg", mimeType="image/svg+xml", theme="dark"
+        ),
+    ]
+    icons = icons_from_raw(raws)
+    assert icons == (
+        MCPIcon(
+            src="https://x/icon-light.svg", mime_type="image/svg+xml", theme="light"
+        ),
+        MCPIcon(src="https://x/icon-dark.svg", mime_type="image/svg+xml", theme="dark"),
+    )
+
+
+def test_icons_from_raw_accepts_snake_case_mime_type() -> None:
+    """Some sources use ``mime_type`` instead of ``mimeType`` — accept both."""
+    icons = icons_from_raw(
+        [
+            SimpleNamespace(
+                src="data:image/svg+xml;base64,abc", mime_type="image/svg+xml"
+            )
+        ]
+    )
+    assert icons[0].mime_type == "image/svg+xml"
+
+
+def test_server_info_returns_none_when_server_info_missing() -> None:
+    """No ``serverInfo`` on the InitializeResult → ``None`` (no synthetic info)."""
+    init = SimpleNamespace(serverInfo=None)
+    assert server_info_from_init_result(init) is None
+
+
+def test_server_info_returns_none_when_name_missing() -> None:
+    """``name`` is required by the spec; without it we drop the whole entry
+    rather than fabricate a placeholder."""
+    init = SimpleNamespace(
+        serverInfo=SimpleNamespace(name="", version="1.0", icons=None, websiteUrl=None)
+    )
+    assert server_info_from_init_result(init) is None
+
+
+def test_server_info_captures_all_fields() -> None:
+    init = SimpleNamespace(
+        serverInfo=SimpleNamespace(
+            name="Linear",
+            version="1.4.2",
+            websiteUrl="https://linear.app",
+            icons=[
+                SimpleNamespace(
+                    src="https://linear.app/favicon.svg", mimeType="image/svg+xml"
+                )
+            ],
+        )
+    )
+    info = server_info_from_init_result(init)
+    assert info == MCPServerInfo(
+        name="Linear",
+        version="1.4.2",
+        website_url="https://linear.app",
+        icons=(
+            MCPIcon(src="https://linear.app/favicon.svg", mime_type="image/svg+xml"),
+        ),
+    )
+
+
+def test_tool_info_from_desc_handles_missing_icons() -> None:
+    desc = SimpleNamespace(name="search", icons=None)
+    assert tool_info_from_desc(desc) == MCPToolInfo(name="search", icons=())


### PR DESCRIPTION
## Summary

MCP spec rev 2025-11-25 added an \`icons\` field to \`Tool\`, \`Resource\`, \`Prompt\`, and \`Implementation\`. cubepi's HTTP/stdio loaders previously discarded the \`initialize\` handshake return value and ignored per-tool icons, so downstream UIs had no way to render server logos or tool-specific icons.

Replace the loader return type with a new \`MCPDiscoveryResult\` dataclass carrying:

- \`tools\` — executable AgentTools (unchanged shape).
- \`server: MCPServerInfo\` — name, version, websiteUrl, icons from \`InitializeResult.serverInfo\`.
- \`tool_infos: list[MCPToolInfo]\` — per-tool display metadata captured from \`Tool.icons\`.

Both \`load_mcp_tools_http\` and \`load_mcp_tools_stdio\` are updated for API parity.

## Why a new dataclass instead of a sibling function

Two viable options were considered:

- **Sibling function** (\`load_mcp_metadata_http\`) — keeps old signature, adds a parallel discovery handshake. Doubles the discovery RTT for the one downstream consumer (cubebox) since both functions would each call \`initialize\` + \`list_tools\`.
- **Rich return type** (chosen) — one handshake yields both tools and metadata. Single breaking call site to update (cubebox); coordinated bump.

cubepi has one downstream consumer; the breaking change is cheap to migrate.

## Changes

- \`cubepi/mcp/types.py\` (new) — \`MCPIcon\`, \`MCPServerInfo\`, \`MCPToolInfo\`, \`MCPDiscoveryResult\` dataclasses plus normalisation helpers (\`icons_from_raw\`, \`server_info_from_init_result\`, \`tool_info_from_desc\`).
- \`cubepi/mcp/http_loader.py\` — capture \`initialize\` return; build \`MCPDiscoveryResult\` with server + tool_infos.
- \`cubepi/mcp/stdio_loader.py\` — same shape change.
- \`cubepi/mcp/__init__.py\` — export the new types.
- Tests updated to unwrap \`.tools\`; new tests for icon capture (server-level, per-tool, missing-icons fallback).

## Breaking change

Single downstream caller pattern changes from:

\`\`\`python
tools = await load_mcp_tools_http(url)
\`\`\`

to:

\`\`\`python
discovery = await load_mcp_tools_http(url)
tools = discovery.tools
server_icon = discovery.server.icons[0].src if discovery.server and discovery.server.icons else None
\`\`\`

cubebox PR will bump the cubepi pin once this merges.

## Test plan

- [x] \`pytest tests/mcp/\` — 25 passed, 1 skipped (gated on \`CUBEPI_TEST_MCP_HTTP_URL\`).
- [x] Full suite \`pytest tests/\` — 522 passed.
- [x] \`ruff format\` + \`ruff check\` clean.
- [x] \`mypy cubepi/mcp/\` clean.