### PR TITLE
feat(agent): extend ToolExecutionEndEvent with terminate / block fields

### DIFF
--- a/cubepi/agent/tools.py
+++ b/cubepi/agent/tools.py
@@ -45,6 +45,8 @@ class _PreparedToolCall:
 class _ImmediateOutcome:
     result: AgentToolResult
     is_error: bool
+    blocked_by_hook: bool = False
+    block_reason: str | None = None
 
 
 @dataclass
@@ -52,6 +54,8 @@ class _FinalizedOutcome:
     tool_call: ToolCall
     result: AgentToolResult
     is_error: bool
+    blocked_by_hook: bool = False
+    block_reason: str | None = None
 
 
 def _error_result(message: str) -> AgentToolResult:
@@ -109,6 +113,8 @@ async def _prepare_tool_call(
                         before_result.reason or "Tool execution was blocked"
                     ),
                     is_error=True,
+                    blocked_by_hook=True,
+                    block_reason=before_result.reason,
                 )
         except Exception as exc:
             return _ImmediateOutcome(result=_error_result(str(exc)), is_error=True)
@@ -267,6 +273,8 @@ async def _execute_sequential(
                 tool_call=tc,
                 result=preparation.result,
                 is_error=preparation.is_error,
+                blocked_by_hook=preparation.blocked_by_hook,
+                block_reason=preparation.block_reason,
             )
         else:
             result, is_error = await _execute_prepared(preparation, signal, emit_fn)
@@ -287,6 +295,9 @@ async def _execute_sequential(
                 tool_name=tc.name,
                 result=finalized.result,
                 is_error=finalized.is_error,
+                terminate=bool(finalized.result.terminate),
+                blocked_by_hook=finalized.blocked_by_hook,
+                block_reason=finalized.block_reason,
             ),
         )
         tool_msg = _make_tool_result_message(finalized)
@@ -326,6 +337,8 @@ async def _execute_parallel(
                 tool_call=tc,
                 result=preparation.result,
                 is_error=preparation.is_error,
+                blocked_by_hook=preparation.blocked_by_hook,
+                block_reason=preparation.block_reason,
             )
             await emit_event(
                 emit_fn,
@@ -334,6 +347,9 @@ async def _execute_parallel(
                     tool_name=tc.name,
                     result=finalized.result,
                     is_error=finalized.is_error,
+                    terminate=bool(finalized.result.terminate),
+                    blocked_by_hook=finalized.blocked_by_hook,
+                    block_reason=finalized.block_reason,
                 ),
             )
             entries.append(finalized)
@@ -357,6 +373,9 @@ async def _execute_parallel(
                         tool_name=prep.tool_call.name,
                         result=fin.result,
                         is_error=fin.is_error,
+                        terminate=bool(fin.result.terminate),
+                        blocked_by_hook=fin.blocked_by_hook,
+                        block_reason=fin.block_reason,
                     ),
                 )
                 return fin

--- a/cubepi/agent/types.py
+++ b/cubepi/agent/types.py
@@ -153,6 +153,18 @@ class ToolExecutionEndEvent(BaseModel):
     tool_name: str
     result: Any = None
     is_error: bool = False
+    terminate: bool = False
+    """True iff the tool's AgentToolResult.terminate was True (or the
+    after_tool_call hook set terminate=True). Recorders use this to mark
+    the turn as terminated-by-tool without unwrapping ``result``."""
+    blocked_by_hook: bool = False
+    """True iff the tool call was blocked by a ``before_tool_call`` hook
+    returning ``block=True``. Distinguishes hook-blocks from other
+    immediate errors (tool-not-found, arg-validation failure)."""
+    block_reason: str | None = None
+    """When ``blocked_by_hook`` is True, the reason string from
+    ``BeforeToolCallResult.reason`` (or ``None`` if the hook supplied
+    no reason)."""
 
 
 AgentEvent = (

--- a/tests/agent/test_tool_event_extension.py
+++ b/tests/agent/test_tool_event_extension.py
@@ -1,0 +1,206 @@
+"""Pin the new `ToolExecutionEndEvent` fields: ``terminate``,
+``blocked_by_hook``, ``block_reason``.
+
+Phase 0b of the cubepi tracing plan — these fields let observers
+(tracing, dashboards) recognize tool-driven turn termination and
+hook-driven blocks without unwrapping ``result``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from cubepi.agent.tools import execute_tool_calls
+from cubepi.agent.types import (
+    AgentContext,
+    AgentTool,
+    AgentToolResult,
+    BeforeToolCallResult,
+)
+from cubepi.providers.base import AssistantMessage, TextContent, ToolCall
+
+
+class Params(BaseModel):
+    value: str = ""
+
+
+def _tool(name: str, fn) -> AgentTool:
+    return AgentTool(
+        name=name,
+        description="test tool",
+        parameters=Params,
+        execute=fn,
+    )
+
+
+def _ctx(tools: list[AgentTool]) -> AgentContext:
+    return AgentContext(system_prompt="", messages=[], tools=tools)
+
+
+def _msg(calls: list[ToolCall]) -> AssistantMessage:
+    return AssistantMessage(content=list(calls))
+
+
+def _tool_end_event(events: list):
+    for e in events:
+        if getattr(e, "type", None) == "tool_execution_end":
+            return e
+    raise AssertionError("no tool_execution_end event captured")
+
+
+class TestTerminate:
+    async def test_terminate_true_propagates(self):
+        async def run(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="ok")], terminate=True)
+
+        events: list = []
+        await execute_tool_calls(
+            _ctx([_tool("term", run)]),
+            _msg([ToolCall(id="t1", name="term", arguments={})]),
+            tool_execution="sequential",
+            emit=lambda e: events.append(e),
+        )
+
+        ev = _tool_end_event(events)
+        assert ev.terminate is True
+        assert ev.is_error is False
+        assert ev.blocked_by_hook is False
+        assert ev.block_reason is None
+
+    async def test_terminate_default_false(self):
+        async def run(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="ok")])
+
+        events: list = []
+        await execute_tool_calls(
+            _ctx([_tool("plain", run)]),
+            _msg([ToolCall(id="t1", name="plain", arguments={})]),
+            tool_execution="sequential",
+            emit=lambda e: events.append(e),
+        )
+
+        assert _tool_end_event(events).terminate is False
+
+
+class TestBlockedByHook:
+    async def test_before_hook_block_sets_fields(self):
+        async def run(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="should not run")])
+
+        async def before(ctx, *, signal=None):
+            return BeforeToolCallResult(block=True, reason="not allowed by policy")
+
+        events: list = []
+        await execute_tool_calls(
+            _ctx([_tool("guarded", run)]),
+            _msg([ToolCall(id="t1", name="guarded", arguments={})]),
+            tool_execution="sequential",
+            before_tool_call=before,
+            emit=lambda e: events.append(e),
+        )
+
+        ev = _tool_end_event(events)
+        assert ev.is_error is True
+        assert ev.blocked_by_hook is True
+        assert ev.block_reason == "not allowed by policy"
+        assert ev.terminate is False
+
+    async def test_before_hook_block_with_no_reason(self):
+        async def run(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[])
+
+        async def before(ctx, *, signal=None):
+            return BeforeToolCallResult(block=True)  # reason omitted
+
+        events: list = []
+        await execute_tool_calls(
+            _ctx([_tool("guarded", run)]),
+            _msg([ToolCall(id="t1", name="guarded", arguments={})]),
+            tool_execution="sequential",
+            before_tool_call=before,
+            emit=lambda e: events.append(e),
+        )
+
+        ev = _tool_end_event(events)
+        assert ev.blocked_by_hook is True
+        assert ev.block_reason is None
+
+
+class TestOtherImmediateErrorsNotBlocked:
+    async def test_tool_not_found(self):
+        # No tools registered → "Tool xxx not found" path; is_error=True
+        # but NOT blocked_by_hook.
+        events: list = []
+        await execute_tool_calls(
+            _ctx([]),
+            _msg([ToolCall(id="t1", name="missing", arguments={})]),
+            tool_execution="sequential",
+            emit=lambda e: events.append(e),
+        )
+
+        ev = _tool_end_event(events)
+        assert ev.is_error is True
+        assert ev.blocked_by_hook is False
+        assert ev.block_reason is None
+
+    async def test_arg_validation_failure(self):
+        async def run(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[])
+
+        class StrictParams(BaseModel):
+            value: int  # require int
+
+        tool = AgentTool(
+            name="strict",
+            description="strict",
+            parameters=StrictParams,
+            execute=run,
+        )
+
+        events: list = []
+        await execute_tool_calls(
+            _ctx([tool]),
+            _msg([ToolCall(id="t1", name="strict", arguments={"value": "abc"})]),
+            tool_execution="sequential",
+            emit=lambda e: events.append(e),
+        )
+
+        ev = _tool_end_event(events)
+        assert ev.is_error is True
+        assert ev.blocked_by_hook is False
+        assert ev.block_reason is None
+
+
+class TestParallelPath:
+    async def test_parallel_path_populates_fields_on_block(self):
+        async def run(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="ran")], terminate=False)
+
+        async def before(ctx, *, signal=None):
+            if ctx.tool_call.id == "blocked_one":
+                return BeforeToolCallResult(block=True, reason="parallel-block")
+            return None
+
+        events: list = []
+        await execute_tool_calls(
+            _ctx([_tool("p", run)]),
+            _msg(
+                [
+                    ToolCall(id="blocked_one", name="p", arguments={}),
+                    ToolCall(id="passed_one", name="p", arguments={}),
+                ]
+            ),
+            tool_execution="parallel",
+            before_tool_call=before,
+            emit=lambda e: events.append(e),
+        )
+
+        ends = [e for e in events if getattr(e, "type", None) == "tool_execution_end"]
+        assert len(ends) == 2
+        by_id = {e.tool_call_id: e for e in ends}
+        assert by_id["blocked_one"].blocked_by_hook is True
+        assert by_id["blocked_one"].block_reason == "parallel-block"
+        assert by_id["blocked_one"].is_error is True
+        assert by_id["passed_one"].blocked_by_hook is False
+        assert by_id["passed_one"].block_reason is None
+        assert by_id["passed_one"].is_error is False


### PR DESCRIPTION
## Summary

Phase 0b prerequisite for the upcoming \`cubepi.tracing\` module — the listener-registry PR (#80) shipped the provider-side observability surface; this PR completes the agent-side observability surface by exposing three additive fields on \`ToolExecutionEndEvent\` so observers can recognize tool-driven turn termination and hook-driven blocks without unwrapping the result payload.

- **\`terminate: bool\`** — mirrors \`AgentToolResult.terminate\` (after \`after_tool_call\` hook has had a chance to set it). Lets recorders mark the parent turn as terminated-by-tool with one bool, no result unwrapping.
- **\`blocked_by_hook: bool\`** — True iff \`before_tool_call\` returned \`block=True\`. Distinguishes hook-blocks from other immediate errors (tool-not-found, arg-validation failure) which until now were all reported with \`is_error=True\` and indistinguishable strings.
- **\`block_reason: str | None\`** — \`BeforeToolCallResult.reason\` when blocked, else \`None\`.

Internal plumbing (\`cubepi/agent/tools.py\`):
- \`_ImmediateOutcome\` and \`_FinalizedOutcome\` carry \`blocked_by_hook\`/\`block_reason\`; populated in \`_prepare_tool_call\`'s before-hook branch.
- All **three** \`ToolExecutionEndEvent\` emission sites (sequential, parallel-immediate-outcome, parallel-async-execution) emit the three new fields. \`terminate\` is read from \`finalized.result.terminate\`.

Additive — defaults are conservative (\`False\`/\`False\`/\`None\`); no existing test changed.

This is the second of two prerequisite PRs from \`docs/plans/2026-05-18-cubepi-tracing-phase-0.md\` (\`local\`, gitignored). Phase 1 (\`cubepi/tracing/\` itself) follows.

## Test plan

- [x] \`uv run pytest tests/\` — 571 passed, 1 skipped (564 baseline + 7 new in \`tests/agent/test_tool_event_extension.py\`)
- [x] \`uv run ruff check cubepi/ tests/\` — clean
- [x] \`uv run ruff format --check cubepi/ tests/\` — clean
- [ ] CI green
- [ ] @codex review

### What the new tests pin
- \`terminate=True\` from the tool result propagates to the event
- \`terminate\` defaults to \`False\` for plain tools
- \`before_tool_call\` block sets \`blocked_by_hook=True\` + \`block_reason\` (or \`None\` when reason omitted)
- Tool-not-found and arg-validation errors set \`is_error=True\` but **NOT** \`blocked_by_hook\`
- Parallel-execution path populates the fields per-tool-call correctly (one blocked, one passes)

@codex please review.