### PR TITLE
feat(tracing): Phase 5 — MCP CLIENT spans + traceparent helper

### DIFF
--- a/cubepi/mcp/_adapter.py
+++ b/cubepi/mcp/_adapter.py
@@ -7,6 +7,7 @@ from typing import Any, Awaitable, Callable, Literal
 from pydantic import BaseModel, Field, create_model
 
 from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.mcp._tracing import mcp_client_span
 from cubepi.providers.base import Content, ImageContent, TextContent
 
 
@@ -104,12 +105,21 @@ def make_mcp_agent_tool(
     description: str,
     input_schema: dict[str, Any],
     call_remote: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]],
+    server_address: str | None = None,
+    server_port: int | None = None,
+    protocol_version: str | None = None,
+    session_id: str | None = None,
 ) -> AgentTool:
     """Build a cubepi.AgentTool wrapping an MCP tool call.
 
     call_remote is the transport-specific RPC: given (tool_name, args_dict),
     returns the MCP tools/call response dict normalized to:
         {"content": [{"type": "text", "text": ...}, ...], "isError": bool}
+
+    The optional ``server_address`` / ``server_port`` / ``protocol_version``
+    / ``session_id`` are recorded on the OTel CLIENT span around the
+    remote call when ``cubepi[tracing]`` is installed. Loaders pass
+    whichever values they have access to from the MCP handshake.
     """
     parameters_model = mcp_schema_to_pydantic_model(
         tool_name=name,
@@ -132,7 +142,15 @@ def make_mcp_agent_tool(
             if hasattr(args, "model_dump")
             else dict(args)
         )
-        result = await call_remote(name, args_dict)
+        async with mcp_client_span(
+            method="tools/call",
+            tool_name=name,
+            session_id=session_id,
+            protocol_version=protocol_version,
+            server_address=server_address,
+            server_port=server_port,
+        ):
+            result = await call_remote(name, args_dict)
         content_blocks: list[Content] = []
         for c in result.get("content", []):
             ctype = c.get("type")

--- a/cubepi/mcp/_adapter.py
+++ b/cubepi/mcp/_adapter.py
@@ -7,7 +7,7 @@ from typing import Any, Awaitable, Callable, Literal
 from pydantic import BaseModel, Field, create_model
 
 from cubepi.agent.types import AgentTool, AgentToolResult
-from cubepi.mcp._tracing import mcp_client_span
+from cubepi.mcp._tracing import mark_span_mcp_error, mcp_client_span
 from cubepi.providers.base import Content, ImageContent, TextContent
 
 
@@ -149,8 +149,15 @@ def make_mcp_agent_tool(
             protocol_version=protocol_version,
             server_address=server_address,
             server_port=server_port,
-        ):
+        ) as span:
             result = await call_remote(name, args_dict)
+            # MCP server-reported tool failure (``isError: true``): the
+            # JSON-RPC call succeeded but the tool's logic failed. Mark
+            # the CLIENT span ERROR so backends count it as a failure,
+            # matching the cubepi.tool.is_error treatment for non-MCP
+            # tool spans.
+            if result.get("isError"):
+                mark_span_mcp_error(span, "MCP server returned isError")
         content_blocks: list[Content] = []
         for c in result.get("content", []):
             ctype = c.get("type")

--- a/cubepi/mcp/_adapter.py
+++ b/cubepi/mcp/_adapter.py
@@ -133,10 +133,11 @@ def make_mcp_agent_tool(
         signal=None,
         on_update=None,
     ) -> AgentToolResult:
-        # tool_call_id and on_update are unused by MCP semantics (MCP RPC is
-        # not incremental), but we accept them for signature compatibility
-        # with cubepi's agent loop.
-        del tool_call_id, on_update
+        # on_update is unused by MCP semantics (MCP RPC is not
+        # incremental). ``tool_call_id`` is forwarded as the parent
+        # lookup key so the CLIENT span nests under the cubepi recorder's
+        # execute_tool span when tracing is enabled.
+        del on_update
         args_dict = (
             args.model_dump(exclude_none=True)
             if hasattr(args, "model_dump")
@@ -149,6 +150,7 @@ def make_mcp_agent_tool(
             protocol_version=protocol_version,
             server_address=server_address,
             server_port=server_port,
+            parent_tool_call_id=tool_call_id,
         ) as span:
             result = await call_remote(name, args_dict)
             # MCP server-reported tool failure (``isError: true``): the

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -132,6 +132,23 @@ async def mcp_client_span(
         span.end()
 
 
+def mark_span_mcp_error(span: Any, message: str) -> None:
+    """Mark an MCP CLIENT span as a protocol-level failure.
+
+    An MCP server can return a normal ``tools/call`` JSON-RPC response
+    with ``isError: true`` — the wire call succeeds but the tool
+    reports failure. Without this helper the CLIENT span would close
+    with UNSET status, hiding the failure in trace dashboards.
+
+    Pass the span yielded by :func:`mcp_client_span` (which may be
+    ``None`` when OTel isn't installed); no-op on None.
+    """
+    if span is None or not _OTEL_AVAILABLE:
+        return
+    span.set_status(Status(StatusCode.ERROR, message[:256]))
+    span.set_attribute(_ERROR_TYPE, "mcp.is_error")
+
+
 def current_traceparent() -> str | None:
     """Return a W3C ``traceparent`` string for the current span context,
     or ``None`` when there is no active recording span (or OTel is not

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -115,17 +115,29 @@ def _get_tracer(scope_name: str) -> Any:
 # CLIENT span through the parent's owning provider so trace_ids and
 # exporter destination stay consistent (codex round-7).
 #
-# We use a ``ContextVar`` rather than a global dict keyed by
-# ``tool_call_id`` because tool-call ids are provider-local (Faux and
-# OpenAI-style providers commonly mint ``tc1`` / ``call_...`` per
-# conversation), so concurrent agents in one process can collide on the
-# same id and overwrite each other's parent registration. ContextVars
-# scope per-task: each agent run sees its own value, and asyncio's
-# ``create_task`` copies the parent's context — so sequential AND
-# parallel tool execution within the same agent both inherit the right
-# parent (codex round-8).
-_current_tool_entry: contextvars.ContextVar[tuple[Any, Any] | None] = (
-    contextvars.ContextVar("_cubepi_mcp_current_tool_entry", default=None)
+# Lookup uses a per-task ``ContextVar`` holding an opaque handle, with
+# the actual ``(span, provider)`` payload stored in a module-level
+# ``_active_entries`` dict. The dict is the source of truth for
+# cleanup; the contextvar is the per-task pointer.
+#
+# Why both: tool-call ids are provider-local (Faux / OpenAI-style mint
+# ``tc1`` / ``call_...`` per conversation), so a global dict keyed by
+# ``tool_call_id`` lets concurrent agents overwrite each other (codex
+# round-8). ContextVars scope per asyncio task and copy on
+# ``create_task``, so each agent run — and each spawned tool task
+# within it — sees only its own parent. BUT the cubepi agent loop
+# emits ``ToolExecutionStartEvent`` in the parent task and (in
+# ``parallel`` tool mode) ``ToolExecutionEndEvent`` from the per-tool
+# *child* task it spawns. A ``Token`` produced in the parent task
+# cannot be ``reset`` in a child task — ``ContextVar.reset`` raises
+# ``ValueError`` (codex round-9). The dict-handle indirection lets
+# ``unregister_tool_span`` clean up the payload unconditionally (so
+# any later lookup through the stale contextvar returns ``None``),
+# while the contextvar reset is best-effort and skipped silently when
+# the calling task differs from the registering one.
+_active_entries: dict[object, tuple[Any, Any]] = {}
+_current_handle: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+    "_cubepi_mcp_current_tool_handle", default=None
 )
 
 
@@ -133,36 +145,66 @@ def register_tool_span(
     tool_call_id: str,
     span: Any,
     provider: Any = None,
-) -> contextvars.Token[tuple[Any, Any] | None]:
+) -> tuple[object, contextvars.Token[object | None]]:
     """Publish ``span`` (and its owning ``provider``) as the current
-    ``execute_tool`` parent for the calling task. Returns a token that
-    :func:`unregister_tool_span` uses to restore the previous value.
+    ``execute_tool`` parent for the calling task.
 
-    ``tool_call_id`` is accepted for API symmetry / debug context but no
-    longer used as a lookup key — see module-level comment.
+    Returns a ``(handle, cv_token)`` tuple — pass it to
+    :func:`unregister_tool_span` on tool-exec end. The handle is used
+    for dict cleanup (safe across tasks); the cv_token is used for
+    contextvar reset (best-effort, only valid in the registering
+    task).
+
+    ``tool_call_id`` is accepted for API symmetry / future debug attrs
+    but is not used as a lookup key — see module-level comment.
     """
-    del tool_call_id  # reserved: kept in signature for future debug attrs.
-    return _current_tool_entry.set((span, provider))
+    del tool_call_id
+    handle = object()
+    _active_entries[handle] = (span, provider)
+    cv_token = _current_handle.set(handle)
+    return (handle, cv_token)
 
 
 def unregister_tool_span(
-    token: contextvars.Token[tuple[Any, Any] | None] | None,
+    token: tuple[object, contextvars.Token[object | None]] | None,
 ) -> None:
-    """Restore the contextvar to its prior value. ``None`` is a no-op
-    so callers can safely unregister even when the import-time hook
-    failed."""
+    """Clean up a previously-registered entry.
+
+    ``token`` is the value returned from :func:`register_tool_span`,
+    or ``None`` (no-op, for callers that defensively unregister when
+    the corresponding register failed).
+
+    The dict entry is always removed — this is the safety net for
+    cross-task ``unregister`` (parallel tool mode emits
+    ``ToolExecutionEndEvent`` from the child task even though
+    ``register`` ran in the parent). The contextvar reset is
+    attempted but silently skipped if the calling task is not the
+    registering task; the next ``register`` in the parent task will
+    overwrite the stale handle.
+    """
     if token is None:
         return
+    handle, cv_token = token
+    _active_entries.pop(handle, None)
     try:
-        _current_tool_entry.reset(token)
-    except (ValueError, LookupError):  # pragma: no cover — token mismatch
+        _current_handle.reset(cv_token)
+    except (ValueError, LookupError):
         pass
 
 
 def _get_tool_span_entry() -> tuple[Any, Any] | None:
     """Return the (span, provider) entry for the current task, or
-    ``None`` when no ``execute_tool`` is active in this context."""
-    return _current_tool_entry.get()
+    ``None`` when no live ``execute_tool`` is in scope.
+
+    A stale contextvar handle (pointing at an already-cleaned-up dict
+    entry) returns ``None`` — exactly the same outcome as no parent at
+    all, so the MCP CLIENT span starts a new root rather than
+    parenting under an already-ended span.
+    """
+    handle = _current_handle.get()
+    if handle is None:
+        return None
+    return _active_entries.get(handle)
 
 
 def _current_span_via_registered() -> Any:

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -50,41 +50,84 @@ except ImportError:  # pragma: no cover — exercised only without the extra.
 
 
 # When :class:`cubepi.tracing.Tracer` is attached to an agent it
-# registers its private :class:`TracerProvider` here. Without this
-# registration, ``_otel_trace.get_tracer`` falls back to the OTel
+# pushes its private :class:`TracerProvider` onto this stack. Without
+# any registration, ``_otel_trace.get_tracer`` falls back to the OTel
 # global default — which is a no-op provider unless the caller also
-# did ``set_tracer_provider`` themselves. ``Tracer.attach`` calls
-# :func:`register_provider`; the corresponding ``detach`` callable
-# clears it.
-_registered_provider: Any | None = None
+# did ``set_tracer_provider`` themselves.
+#
+# Using a stack rather than a single slot lets one Tracer attach to
+# multiple agents (each attach pushes a token; each detach pops just
+# its own entry) and supports detaches in any order without clearing
+# routing for the still-attached agents.
+_provider_stack: list[tuple[object, Any]] = []
 
 
-def register_provider(provider: Any) -> None:
-    """Register a non-global TracerProvider as the source for MCP CLIENT
-    spans. Called by :meth:`cubepi.tracing.Tracer.attach`.
+def register_provider(provider: Any) -> object:
+    """Push ``provider`` onto the routing stack as the preferred source
+    for MCP spans. Returns an opaque token that
+    :func:`unregister_provider` uses to remove this exact entry.
+
+    Called by :meth:`cubepi.tracing.Tracer.attach`.
     """
-    global _registered_provider
-    _registered_provider = provider
+    token = object()
+    _provider_stack.append((token, provider))
+    return token
 
 
-def unregister_provider() -> None:
-    """Reverse :func:`register_provider`. Called by the detach callable
-    returned from :meth:`cubepi.tracing.Tracer.attach`.
+def unregister_provider(token: object | None = None) -> None:
+    """Remove a previously-registered provider.
+
+    ``token`` is the value returned from :func:`register_provider`.
+    When ``None`` (legacy callers) the most recent entry is popped.
+    Out-of-order detaches affect only their own registration; siblings
+    remain.
     """
-    global _registered_provider
-    _registered_provider = None
+    if not _provider_stack:
+        return
+    if token is None:
+        _provider_stack.pop()
+        return
+    for i, (t, _p) in enumerate(_provider_stack):
+        if t is token:
+            _provider_stack.pop(i)
+            return
 
 
 def _get_tracer(scope_name: str) -> Any:
     """Resolve the tracer to use for emitting an MCP span.
 
-    Prefers the provider registered by ``cubepi.tracing.Tracer`` over
-    OTel's global default (which is a no-op unless the user separately
-    called ``set_tracer_provider``).
+    Prefers the most recently-registered provider over OTel's global
+    default (which is a no-op unless the user separately called
+    ``set_tracer_provider``).
     """
-    if _registered_provider is not None:
-        return _registered_provider.get_tracer(scope_name)
+    if _provider_stack:
+        return _provider_stack[-1][1].get_tracer(scope_name)
     return _otel_trace.get_tracer(scope_name)
+
+
+# When the cubepi Recorder opens an ``execute_tool`` span, it registers
+# it here keyed by ``tool_call_id``. The MCP adapter looks up the
+# parent span by tool_call_id and passes it as an explicit context to
+# :func:`mcp_client_span`, so the MCP CLIENT span becomes a child of
+# the agent's ``execute_tool`` span rather than starting an orphan
+# trace under the OTel "current span" (which the recorder doesn't
+# bother making current — see docs/specs/2026-05-18-cubepi-tracing-
+# design.md §9).
+_active_tool_spans: dict[str, Any] = {}
+
+
+def register_tool_span(tool_call_id: str, span: Any) -> None:
+    _active_tool_spans[tool_call_id] = span
+
+
+def unregister_tool_span(tool_call_id: str) -> None:
+    _active_tool_spans.pop(tool_call_id, None)
+
+
+def _get_tool_span(tool_call_id: str | None) -> Any:
+    if tool_call_id is None:
+        return None
+    return _active_tool_spans.get(tool_call_id)
 
 
 def _current_span_via_registered() -> Any:
@@ -122,6 +165,7 @@ async def mcp_client_span(
     protocol_version: str | None = None,
     server_address: str | None = None,
     server_port: int | None = None,
+    parent_tool_call_id: str | None = None,
 ) -> AsyncIterator[Any]:
     """Open an OTel CLIENT span around an MCP RPC.
 
@@ -135,6 +179,15 @@ async def mcp_client_span(
 
     tracer = _get_tracer(_SCOPE_NAME)
     span_name = f"{method} {tool_name}" if tool_name else method
+    # Resolve explicit parent: if the caller passed a tool_call_id and
+    # the cubepi recorder has an active ``execute_tool`` span for it,
+    # make the MCP CLIENT span its child rather than an orphan trace.
+    parent_span = _get_tool_span(parent_tool_call_id)
+    parent_context = (
+        _otel_trace.set_span_in_context(parent_span)
+        if parent_span is not None
+        else None
+    )
     attrs: dict[str, Any] = {
         _MCP_METHOD_NAME: method,
         _GEN_AI_OPERATION_NAME: "execute_tool",
@@ -150,7 +203,12 @@ async def mcp_client_span(
     if server_port is not None:
         attrs[_SERVER_PORT] = server_port
 
-    span = tracer.start_span(span_name, kind=SpanKind.CLIENT, attributes=attrs)
+    span = tracer.start_span(
+        span_name,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+        context=parent_context,
+    )
     try:
         # Disable use_span's default record_exception / set_status_on_exception
         # so we are the single source of the exception event and ERROR

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -1,0 +1,156 @@
+"""MCP-side OTel CLIENT span instrumentation.
+
+This module is intentionally local to ``cubepi/mcp`` so the core MCP
+adapter has zero hard dependency on ``opentelemetry`` — if the OTel API
+is not installed, every public symbol becomes a no-op pass-through. When
+``cubepi[tracing]`` is installed, MCP ``tools/call`` invocations
+automatically emit CLIENT spans per the OTel GenAI MCP semconv (§14 of
+the tracing design spec).
+
+Span emitted per call::
+
+    tools/call <tool_name>           [CLIENT]
+        mcp.method.name = "tools/call"
+        gen_ai.tool.name = <tool_name>
+        gen_ai.operation.name = "execute_tool"
+        mcp.session.id = <if provided>
+        mcp.protocol.version = <if provided>
+        server.address = <if provided>
+        server.port = <if provided>
+        error.type = <on failure>
+
+The W3C ``traceparent`` for downstream-server propagation is exposed
+via :func:`current_traceparent`; the HTTP loader injects it into the
+session's HTTP headers so an instrumented MCP server can continue the
+trace. The MCP Python SDK does not expose the JSON-RPC ``params._meta``
+slot directly, so we use HTTP headers as the practical wire location —
+W3C trace-context spec §3 permits either.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, AsyncIterator
+
+if TYPE_CHECKING:
+    pass
+
+
+try:
+    from opentelemetry import trace as _otel_trace
+    from opentelemetry.trace import SpanKind, Status, StatusCode
+
+    _OTEL_AVAILABLE = True
+except ImportError:  # pragma: no cover — exercised only without the extra.
+    _OTEL_AVAILABLE = False
+    _otel_trace = None  # type: ignore[assignment]
+    SpanKind = None  # type: ignore[assignment]
+    Status = None  # type: ignore[assignment]
+    StatusCode = None  # type: ignore[assignment]
+
+
+# Public attribute name constants — duplicated from
+# cubepi.tracing.schema so this module can be imported without the
+# tracing extra installed. Keep in sync.
+_MCP_METHOD_NAME = "mcp.method.name"
+_MCP_SESSION_ID = "mcp.session.id"
+_MCP_PROTOCOL_VERSION = "mcp.protocol.version"
+_GEN_AI_TOOL_NAME = "gen_ai.tool.name"
+_GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
+_SERVER_ADDRESS = "server.address"
+_SERVER_PORT = "server.port"
+_ERROR_TYPE = "error.type"
+_SCOPE_NAME = "cubepi.mcp"
+
+
+@asynccontextmanager
+async def mcp_client_span(
+    *,
+    method: str = "tools/call",
+    tool_name: str | None = None,
+    session_id: str | None = None,
+    protocol_version: str | None = None,
+    server_address: str | None = None,
+    server_port: int | None = None,
+) -> AsyncIterator[Any]:
+    """Open an OTel CLIENT span around an MCP RPC.
+
+    When the OTel API is not installed (``cubepi[tracing]`` not
+    selected) this yields ``None`` and the body runs unwrapped — the
+    caller pays no overhead and has no observability impact.
+    """
+    if not _OTEL_AVAILABLE:
+        yield None
+        return
+
+    tracer = _otel_trace.get_tracer(_SCOPE_NAME)
+    span_name = f"{method} {tool_name}" if tool_name else method
+    attrs: dict[str, Any] = {
+        _MCP_METHOD_NAME: method,
+        _GEN_AI_OPERATION_NAME: "execute_tool",
+    }
+    if tool_name is not None:
+        attrs[_GEN_AI_TOOL_NAME] = tool_name
+    if session_id is not None:
+        attrs[_MCP_SESSION_ID] = session_id
+    if protocol_version is not None:
+        attrs[_MCP_PROTOCOL_VERSION] = protocol_version
+    if server_address is not None:
+        attrs[_SERVER_ADDRESS] = server_address
+    if server_port is not None:
+        attrs[_SERVER_PORT] = server_port
+
+    span = tracer.start_span(span_name, kind=SpanKind.CLIENT, attributes=attrs)
+    try:
+        with _otel_trace.use_span(span):
+            yield span
+    except BaseException as exc:
+        try:
+            span.set_status(Status(StatusCode.ERROR, str(exc)[:256]))
+            span.set_attribute(_ERROR_TYPE, _error_type_for(exc))
+            span.record_exception(exc)
+        finally:
+            span.end()
+        raise
+    else:
+        span.end()
+
+
+def current_traceparent() -> str | None:
+    """Return a W3C ``traceparent`` string for the current span context,
+    or ``None`` when there is no active recording span (or OTel is not
+    installed).
+
+    Used by the HTTP loader to inject the header on outgoing MCP
+    requests so an instrumented server can continue the trace.
+    """
+    if not _OTEL_AVAILABLE:
+        return None
+    span = _otel_trace.get_current_span()
+    ctx = span.get_span_context()
+    if not getattr(ctx, "is_valid", False):
+        return None
+    trace_id = ctx.trace_id
+    span_id = ctx.span_id
+    if not trace_id or not span_id:
+        return None
+    # W3C trace context §3.2: traceparent = "00-<32hex>-<16hex>-<flags>"
+    flags = int(getattr(ctx, "trace_flags", 0))
+    return f"00-{trace_id:032x}-{span_id:016x}-{flags:02x}"
+
+
+def _error_type_for(exc: BaseException) -> str:
+    """Local error.type derivation. Mirrors cubepi.tracing.errors but
+    re-implemented here so the MCP module has no hard tracing dep."""
+    import asyncio
+
+    if isinstance(exc, asyncio.CancelledError):
+        return "cubepi.aborted"
+    if isinstance(exc, (asyncio.TimeoutError, TimeoutError)):
+        return "timeout"
+    if isinstance(exc, ConnectionError):
+        return "connection_error"
+    cls = type(exc)
+    if cls.__module__ in {"builtins", "__main__"}:
+        return cls.__qualname__
+    return f"{cls.__module__}.{cls.__qualname__}"

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -114,9 +114,17 @@ async def mcp_client_span(
             yield span
     except BaseException as exc:
         try:
-            span.set_status(Status(StatusCode.ERROR, str(exc)[:256]))
-            span.set_attribute(_ERROR_TYPE, _error_type_for(exc))
-            span.record_exception(exc)
+            error_type = _error_type_for(exc)
+            span.set_attribute(_ERROR_TYPE, error_type)
+            # Cancellation is a control signal, not a failure — match the
+            # convention from the chat / turn / invoke_agent spans: leave
+            # Status UNSET and mark cubepi.aborted=true, do NOT record an
+            # exception event.
+            if error_type == "cubepi.aborted":
+                span.set_attribute("cubepi.aborted", True)
+            else:
+                span.set_status(Status(StatusCode.ERROR, str(exc)[:256]))
+                span.record_exception(exc)
         finally:
             span.end()
         raise

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -49,6 +49,56 @@ except ImportError:  # pragma: no cover — exercised only without the extra.
     StatusCode = None  # type: ignore[assignment]
 
 
+# When :class:`cubepi.tracing.Tracer` is attached to an agent it
+# registers its private :class:`TracerProvider` here. Without this
+# registration, ``_otel_trace.get_tracer`` falls back to the OTel
+# global default — which is a no-op provider unless the caller also
+# did ``set_tracer_provider`` themselves. ``Tracer.attach`` calls
+# :func:`register_provider`; the corresponding ``detach`` callable
+# clears it.
+_registered_provider: Any | None = None
+
+
+def register_provider(provider: Any) -> None:
+    """Register a non-global TracerProvider as the source for MCP CLIENT
+    spans. Called by :meth:`cubepi.tracing.Tracer.attach`.
+    """
+    global _registered_provider
+    _registered_provider = provider
+
+
+def unregister_provider() -> None:
+    """Reverse :func:`register_provider`. Called by the detach callable
+    returned from :meth:`cubepi.tracing.Tracer.attach`.
+    """
+    global _registered_provider
+    _registered_provider = None
+
+
+def _get_tracer(scope_name: str) -> Any:
+    """Resolve the tracer to use for emitting an MCP span.
+
+    Prefers the provider registered by ``cubepi.tracing.Tracer`` over
+    OTel's global default (which is a no-op unless the user separately
+    called ``set_tracer_provider``).
+    """
+    if _registered_provider is not None:
+        return _registered_provider.get_tracer(scope_name)
+    return _otel_trace.get_tracer(scope_name)
+
+
+def _current_span_via_registered() -> Any:
+    """Return the current span — preferring the registered provider's
+    context. Used by :func:`current_traceparent`.
+
+    The OTel context is process-global and shared across providers, so
+    ``get_current_span()`` returns the right answer whether or not we
+    use the registered provider. We expose this indirection so tests
+    can monkeypatch a single helper.
+    """
+    return _otel_trace.get_current_span()
+
+
 # Public attribute name constants — duplicated from
 # cubepi.tracing.schema so this module can be imported without the
 # tracing extra installed. Keep in sync.
@@ -83,7 +133,7 @@ async def mcp_client_span(
         yield None
         return
 
-    tracer = _otel_trace.get_tracer(_SCOPE_NAME)
+    tracer = _get_tracer(_SCOPE_NAME)
     span_name = f"{method} {tool_name}" if tool_name else method
     attrs: dict[str, Any] = {
         _MCP_METHOD_NAME: method,

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -106,25 +106,37 @@ def _get_tracer(scope_name: str) -> Any:
 
 
 # When the cubepi Recorder opens an ``execute_tool`` span, it registers
-# it here keyed by ``tool_call_id``. The MCP adapter looks up the
-# parent span by tool_call_id and passes it as an explicit context to
-# :func:`mcp_client_span`, so the MCP CLIENT span becomes a child of
-# the agent's ``execute_tool`` span rather than starting an orphan
-# trace under the OTel "current span" (which the recorder doesn't
-# bother making current — see docs/specs/2026-05-18-cubepi-tracing-
-# design.md §9).
-_active_tool_spans: dict[str, Any] = {}
+# (span, owning_provider) here keyed by ``tool_call_id``. The MCP
+# adapter looks up the parent span by tool_call_id and passes it as an
+# explicit context to :func:`mcp_client_span`, so the MCP CLIENT span
+# becomes a child of the agent's ``execute_tool`` span rather than
+# starting an orphan trace under the OTel "current span" (which the
+# recorder doesn't bother making current — see docs/specs/2026-05-18-
+# cubepi-tracing-design.md §9).
+#
+# We store the owning provider alongside the span so that when multiple
+# ``Tracer`` instances are attached to different agents in the same
+# process, each MCP CLIENT span is exported through *its parent's*
+# Tracer (matching trace IDs), not whichever Tracer's registration is
+# at the top of the LIFO ``_provider_stack`` (codex round-7 review on
+# PR #86). The stack is now only consulted when there is no parent —
+# e.g., a bare ``mcp_client_span`` outside an agent's tool execution.
+_active_tool_spans: dict[str, tuple[Any, Any]] = {}
 
 
-def register_tool_span(tool_call_id: str, span: Any) -> None:
-    _active_tool_spans[tool_call_id] = span
+def register_tool_span(
+    tool_call_id: str,
+    span: Any,
+    provider: Any = None,
+) -> None:
+    _active_tool_spans[tool_call_id] = (span, provider)
 
 
 def unregister_tool_span(tool_call_id: str) -> None:
     _active_tool_spans.pop(tool_call_id, None)
 
 
-def _get_tool_span(tool_call_id: str | None) -> Any:
+def _get_tool_span_entry(tool_call_id: str | None) -> tuple[Any, Any] | None:
     if tool_call_id is None:
         return None
     return _active_tool_spans.get(tool_call_id)
@@ -177,17 +189,26 @@ async def mcp_client_span(
         yield None
         return
 
-    tracer = _get_tracer(_SCOPE_NAME)
     span_name = f"{method} {tool_name}" if tool_name else method
-    # Resolve explicit parent: if the caller passed a tool_call_id and
-    # the cubepi recorder has an active ``execute_tool`` span for it,
-    # make the MCP CLIENT span its child rather than an orphan trace.
-    parent_span = _get_tool_span(parent_tool_call_id)
-    parent_context = (
-        _otel_trace.set_span_in_context(parent_span)
-        if parent_span is not None
-        else None
-    )
+    # Resolve explicit parent + owning provider: if the caller passed a
+    # tool_call_id and the cubepi recorder has an active
+    # ``execute_tool`` span for it, make the MCP CLIENT span its child
+    # rather than an orphan trace, AND route it through the parent's
+    # owning provider so trace_ids and exporter destination stay
+    # consistent (codex round-7 fix). Fall back to the registered-
+    # provider stack only when there is no parent.
+    entry = _get_tool_span_entry(parent_tool_call_id)
+    if entry is not None:
+        parent_span, parent_provider = entry
+        parent_context = _otel_trace.set_span_in_context(parent_span)
+        tracer = (
+            parent_provider.get_tracer(_SCOPE_NAME)
+            if parent_provider is not None
+            else _get_tracer(_SCOPE_NAME)
+        )
+    else:
+        parent_context = None
+        tracer = _get_tracer(_SCOPE_NAME)
     attrs: dict[str, Any] = {
         _MCP_METHOD_NAME: method,
         _GEN_AI_OPERATION_NAME: "execute_tool",

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -29,6 +29,7 @@ W3C trace-context spec §3 permits either.
 
 from __future__ import annotations
 
+import contextvars
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
@@ -105,41 +106,63 @@ def _get_tracer(scope_name: str) -> Any:
     return _otel_trace.get_tracer(scope_name)
 
 
-# When the cubepi Recorder opens an ``execute_tool`` span, it registers
-# (span, owning_provider) here keyed by ``tool_call_id``. The MCP
-# adapter looks up the parent span by tool_call_id and passes it as an
-# explicit context to :func:`mcp_client_span`, so the MCP CLIENT span
-# becomes a child of the agent's ``execute_tool`` span rather than
-# starting an orphan trace under the OTel "current span" (which the
-# recorder doesn't bother making current — see docs/specs/2026-05-18-
-# cubepi-tracing-design.md §9).
+# When the cubepi Recorder opens an ``execute_tool`` span, it publishes
+# ``(span, owning_provider)`` here so an MCP tool call running inside
+# the AgentTool body can make its CLIENT span a child of this span
+# (rather than starting an orphan root trace — recorder doesn't bother
+# installing ``execute_tool`` as the OTel current span; see
+# docs/specs/2026-05-18-cubepi-tracing-design.md §9), and route the
+# CLIENT span through the parent's owning provider so trace_ids and
+# exporter destination stay consistent (codex round-7).
 #
-# We store the owning provider alongside the span so that when multiple
-# ``Tracer`` instances are attached to different agents in the same
-# process, each MCP CLIENT span is exported through *its parent's*
-# Tracer (matching trace IDs), not whichever Tracer's registration is
-# at the top of the LIFO ``_provider_stack`` (codex round-7 review on
-# PR #86). The stack is now only consulted when there is no parent —
-# e.g., a bare ``mcp_client_span`` outside an agent's tool execution.
-_active_tool_spans: dict[str, tuple[Any, Any]] = {}
+# We use a ``ContextVar`` rather than a global dict keyed by
+# ``tool_call_id`` because tool-call ids are provider-local (Faux and
+# OpenAI-style providers commonly mint ``tc1`` / ``call_...`` per
+# conversation), so concurrent agents in one process can collide on the
+# same id and overwrite each other's parent registration. ContextVars
+# scope per-task: each agent run sees its own value, and asyncio's
+# ``create_task`` copies the parent's context — so sequential AND
+# parallel tool execution within the same agent both inherit the right
+# parent (codex round-8).
+_current_tool_entry: contextvars.ContextVar[tuple[Any, Any] | None] = (
+    contextvars.ContextVar("_cubepi_mcp_current_tool_entry", default=None)
+)
 
 
 def register_tool_span(
     tool_call_id: str,
     span: Any,
     provider: Any = None,
+) -> contextvars.Token[tuple[Any, Any] | None]:
+    """Publish ``span`` (and its owning ``provider``) as the current
+    ``execute_tool`` parent for the calling task. Returns a token that
+    :func:`unregister_tool_span` uses to restore the previous value.
+
+    ``tool_call_id`` is accepted for API symmetry / debug context but no
+    longer used as a lookup key — see module-level comment.
+    """
+    del tool_call_id  # reserved: kept in signature for future debug attrs.
+    return _current_tool_entry.set((span, provider))
+
+
+def unregister_tool_span(
+    token: contextvars.Token[tuple[Any, Any] | None] | None,
 ) -> None:
-    _active_tool_spans[tool_call_id] = (span, provider)
+    """Restore the contextvar to its prior value. ``None`` is a no-op
+    so callers can safely unregister even when the import-time hook
+    failed."""
+    if token is None:
+        return
+    try:
+        _current_tool_entry.reset(token)
+    except (ValueError, LookupError):  # pragma: no cover — token mismatch
+        pass
 
 
-def unregister_tool_span(tool_call_id: str) -> None:
-    _active_tool_spans.pop(tool_call_id, None)
-
-
-def _get_tool_span_entry(tool_call_id: str | None) -> tuple[Any, Any] | None:
-    if tool_call_id is None:
-        return None
-    return _active_tool_spans.get(tool_call_id)
+def _get_tool_span_entry() -> tuple[Any, Any] | None:
+    """Return the (span, provider) entry for the current task, or
+    ``None`` when no ``execute_tool`` is active in this context."""
+    return _current_tool_entry.get()
 
 
 def _current_span_via_registered() -> Any:
@@ -190,14 +213,20 @@ async def mcp_client_span(
         return
 
     span_name = f"{method} {tool_name}" if tool_name else method
-    # Resolve explicit parent + owning provider: if the caller passed a
-    # tool_call_id and the cubepi recorder has an active
-    # ``execute_tool`` span for it, make the MCP CLIENT span its child
-    # rather than an orphan trace, AND route it through the parent's
-    # owning provider so trace_ids and exporter destination stay
-    # consistent (codex round-7 fix). Fall back to the registered-
-    # provider stack only when there is no parent.
-    entry = _get_tool_span_entry(parent_tool_call_id)
+    # Resolve explicit parent + owning provider from the per-task
+    # contextvar published by the cubepi recorder on
+    # ``_on_tool_exec_start``. If present, the MCP CLIENT span becomes a
+    # child of the agent's execute_tool span AND is exported through
+    # the parent's owning provider so trace_ids and exporter
+    # destination stay consistent across concurrent Tracers (codex
+    # round-7 + round-8). When no parent is active, fall back to the
+    # registered-provider stack — used by bare ``mcp_client_span``
+    # calls outside an agent run.
+    #
+    # ``parent_tool_call_id`` is accepted for API symmetry / future
+    # debug attrs; the lookup is purely contextvar-scoped now.
+    del parent_tool_call_id
+    entry = _get_tool_span_entry()
     if entry is not None:
         parent_span, parent_provider = entry
         parent_context = _otel_trace.set_span_in_context(parent_span)

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -102,7 +102,15 @@ async def mcp_client_span(
 
     span = tracer.start_span(span_name, kind=SpanKind.CLIENT, attributes=attrs)
     try:
-        with _otel_trace.use_span(span):
+        # Disable use_span's default record_exception / set_status_on_exception
+        # so we are the single source of the exception event and ERROR
+        # status — otherwise OTel would auto-record on context exit AND
+        # this ``except`` block would record again, double-counting.
+        with _otel_trace.use_span(
+            span,
+            record_exception=False,
+            set_status_on_exception=False,
+        ):
             yield span
     except BaseException as exc:
         try:

--- a/cubepi/mcp/http_loader.py
+++ b/cubepi/mcp/http_loader.py
@@ -109,8 +109,21 @@ async def load_mcp_tools_http(
     """
 
     async def _call_remote(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+        # When an MCP CLIENT span is current (cubepi.mcp._adapter wraps
+        # this call in ``mcp_client_span``), propagate the W3C
+        # ``traceparent`` header so an instrumented MCP server can
+        # continue the trace. The helper returns None when no recording
+        # span is active or OTel isn't installed; merge so caller-
+        # supplied headers aren't clobbered.
+        from cubepi.mcp._tracing import current_traceparent
+
+        call_headers = headers
+        tp = current_traceparent()
+        if tp is not None:
+            call_headers = {**(headers or {}), "traceparent": tp}
+
         async with _open_session(
-            server_url, headers=headers, timeout=timeout, transport=transport
+            server_url, headers=call_headers, timeout=timeout, transport=transport
         ) as session:
             await asyncio.wait_for(session.initialize(), timeout=timeout)
             resp = await asyncio.wait_for(

--- a/cubepi/mcp/http_loader.py
+++ b/cubepi/mcp/http_loader.py
@@ -125,12 +125,19 @@ async def load_mcp_tools_http(
         tools_resp = await asyncio.wait_for(session.list_tools(), timeout=timeout)
         tool_descs = tools_resp.tools
 
+    # Trace attribute sources for the CLIENT spans emitted per call.
+    address, port = _split_address(server_url)
+    protocol_version = _extract_protocol_version(init_result)
+
     tools = [
         make_mcp_agent_tool(
             name=desc.name,
             description=desc.description or "",
             input_schema=desc.inputSchema or {"type": "object", "properties": {}},
             call_remote=_call_remote,
+            server_address=address,
+            server_port=port,
+            protocol_version=protocol_version,
         )
         for desc in tool_descs
     ]
@@ -140,6 +147,32 @@ async def load_mcp_tools_http(
         server=server_info_from_init_result(init_result),
         tool_infos=tool_infos,
     )
+
+
+def _split_address(server_url: str) -> tuple[str | None, int | None]:
+    """Extract ``(host, port)`` from a server URL for the
+    ``server.address`` / ``server.port`` span attributes. Returns
+    ``(None, None)`` on parse failure.
+    """
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(server_url)
+        return parsed.hostname, parsed.port
+    except Exception:
+        return None, None
+
+
+def _extract_protocol_version(init_result: Any) -> str | None:
+    """Read ``protocolVersion`` off the MCP SDK initialize() result.
+
+    The SDK exposes it as ``init_result.protocolVersion``. Defensive
+    against future shape changes.
+    """
+    value = getattr(init_result, "protocolVersion", None)
+    if isinstance(value, str):
+        return value
+    return None
 
 
 def _serialize_call_tool_response(resp: Any) -> dict[str, Any]:

--- a/cubepi/mcp/stdio_loader.py
+++ b/cubepi/mcp/stdio_loader.py
@@ -64,12 +64,18 @@ async def load_mcp_tools_stdio(
             tools_resp = await asyncio.wait_for(session.list_tools(), timeout=timeout)
             tool_descs = tools_resp.tools
 
+    # stdio has no network address; only protocol version is observable.
+    protocol_version = getattr(init_result, "protocolVersion", None)
+    if not isinstance(protocol_version, str):
+        protocol_version = None
+
     tools = [
         make_mcp_agent_tool(
             name=desc.name,
             description=desc.description or "",
             input_schema=desc.inputSchema or {"type": "object", "properties": {}},
             call_remote=_call_remote,
+            protocol_version=protocol_version,
         )
         for desc in tool_descs
     ]

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -219,6 +219,13 @@ class Recorder:
                     d()
                 except Exception:
                     pass
+            # Final cleanup of any leaked tool-span registrations from a
+            # cancelled run (CancelledError bypasses the agent's
+            # Exception handler so _on_agent_end / _on_tool_exec_end
+            # never fire). Without this, _active_entries in
+            # cubepi.mcp._tracing would grow unbounded across aborted
+            # runs (codex round-10).
+            self._sweep_tool_span_tokens(self._run)
             await self._tracer.force_flush()
 
         def detach() -> None:
@@ -228,13 +235,15 @@ class Recorder:
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
-                # No running loop — best-effort sync detach.
+                # No running loop — best-effort sync detach. Sweep
+                # any leaked tool-span registrations (codex round-10).
                 unsub_agent()
                 for d in provider_detachers:
                     try:
                         d()
                     except Exception:
                         pass
+                self._sweep_tool_span_tokens(self._run)
                 return
             # Inside a loop — schedule the async detach.
             loop.create_task(_detach_async())
@@ -274,7 +283,45 @@ class Recorder:
     # invoke_agent
     # ------------------------------------------------------------------
 
+    def _sweep_tool_span_tokens(self, run: "_RunState | None") -> None:
+        """Drain ``run.tool_span_tokens`` through ``unregister_tool_span``.
+
+        The cubepi agent loop emits ``ToolExecutionEndEvent`` for every
+        tool that produced a ``ToolExecutionStartEvent`` *only on the
+        ``Exception`` path*. ``asyncio.CancelledError`` inherits from
+        ``BaseException`` and bypasses that handler, so a run cancelled
+        while an MCP tool was in flight leaves the registration alive
+        in :mod:`cubepi.mcp._tracing._active_entries`. Repeated aborts
+        would leak parent-span/provider pairs for the lifetime of the
+        process.
+
+        We sweep on agent_start (next run reuses this Recorder),
+        agent_end (normal completion + agent-caught errors), and on
+        detach (final safety net for an aborted run that never starts
+        again). This is the cleanup path codex round-10 requested.
+        """
+        if run is None or not run.tool_span_tokens:
+            return
+        try:
+            from cubepi.mcp import _tracing as _mcp_tracing
+        except ImportError:  # pragma: no cover — mcp module always present
+            run.tool_span_tokens.clear()
+            return
+        for token in list(run.tool_span_tokens.values()):
+            try:
+                _mcp_tracing.unregister_tool_span(token)
+            except Exception:
+                pass
+        run.tool_span_tokens.clear()
+
     def _on_agent_start(self) -> None:
+        # Defensive sweep: if a prior run was cancelled (CancelledError
+        # inherits BaseException — cubepi's agent loop doesn't emit
+        # ToolExecutionEndEvent in that path), its tool-span registrations
+        # could still be live in cubepi.mcp._tracing. Clean before
+        # opening the new _RunState.
+        self._sweep_tool_span_tokens(self._run)
+
         run_id = str(uuid.uuid4())
         # Open the root invoke_agent span. Caller-context propagation
         # (parent_trace_id / parent_span_id from a host service) lands
@@ -328,6 +375,10 @@ class Recorder:
                     GEN_AI_OUTPUT_MESSAGES,
                     messages_to_semconv(run.output_messages),
                 )
+        # Final sweep for normal-end (and agent-caught error) paths.
+        # Cancellation skips this hook entirely — see
+        # ``_sweep_tool_span_tokens`` docstring.
+        self._sweep_tool_span_tokens(run)
         run.agent_span.end()
         self._run = None
 

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -212,41 +212,43 @@ class Recorder:
                 provider.subscribe_response(self._on_provider_response)
             )
 
-        async def _detach_async() -> None:
+        def _sync_detach() -> None:
+            """All synchronous cleanup: unsubscribe + sweep leaked
+            registrations. Runs eagerly in ``detach()`` so the
+            cancellation-leak cleanup is observable on the next line —
+            not deferred to a loop tick that may never arrive if the
+            caller immediately awaits ``tracer.shutdown()`` or exits
+            ``asyncio.run`` (codex round-11).
+            """
             unsub_agent()
             for d in provider_detachers:
                 try:
                     d()
                 except Exception:
                     pass
-            # Final cleanup of any leaked tool-span registrations from a
-            # cancelled run (CancelledError bypasses the agent's
-            # Exception handler so _on_agent_end / _on_tool_exec_end
-            # never fire). Without this, _active_entries in
-            # cubepi.mcp._tracing would grow unbounded across aborted
-            # runs (codex round-10).
+            # Final cleanup of any leaked tool-span registrations from
+            # a cancelled run — CancelledError bypasses the agent's
+            # ``except Exception`` handler so _on_agent_end /
+            # _on_tool_exec_end never fire (codex round-10).
             self._sweep_tool_span_tokens(self._run)
+
+        async def _detach_async() -> None:
+            _sync_detach()
             await self._tracer.force_flush()
 
         def detach() -> None:
-            # Synchronous shim. Tests can also call ``detach_async``.
-            import asyncio
-
+            # Synchronous part runs immediately in either path so the
+            # caller can rely on cleanup having happened by the time
+            # ``detach()`` returns.
+            _sync_detach()
             try:
+                import asyncio
+
                 loop = asyncio.get_running_loop()
             except RuntimeError:
-                # No running loop — best-effort sync detach. Sweep
-                # any leaked tool-span registrations (codex round-10).
-                unsub_agent()
-                for d in provider_detachers:
-                    try:
-                        d()
-                    except Exception:
-                        pass
-                self._sweep_tool_span_tokens(self._run)
-                return
-            # Inside a loop — schedule the async detach.
-            loop.create_task(_detach_async())
+                return  # no loop — sync cleanup already done.
+            # Inside a loop — schedule the remaining async flush.
+            loop.create_task(self._tracer.force_flush())
 
         return detach
 

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -439,6 +439,19 @@ class Recorder:
             attributes=attrs,
         )
         run.tool_spans[event.tool_call_id] = span
+        # Expose this execute_tool span to ``cubepi.mcp._tracing`` so an
+        # MCP tool call running inside this span (in the AgentTool body)
+        # can look it up by ``tool_call_id`` and make its CLIENT span a
+        # child. Without this hop, MCP would start its span under the
+        # OTel "current span" — which the recorder doesn't bother making
+        # current — and the CLIENT span would become an orphan root
+        # trace (codex round-6 review on PR #86).
+        try:
+            from cubepi.mcp import _tracing as _mcp_tracing
+
+            _mcp_tracing.register_tool_span(event.tool_call_id, span)
+        except ImportError:  # pragma: no cover — mcp module always present
+            pass
         if self._record_content and event.args is not None:
             self._set_content_attr(
                 span, GEN_AI_TOOL_CALL_ARGUMENTS, _coerce_dict(event.args)
@@ -449,6 +462,12 @@ class Recorder:
         if run is None:
             return
         span = run.tool_spans.pop(event.tool_call_id, None)
+        try:
+            from cubepi.mcp import _tracing as _mcp_tracing
+
+            _mcp_tracing.unregister_tool_span(event.tool_call_id)
+        except ImportError:  # pragma: no cover — mcp module always present
+            pass
         if span is None:
             return
         span.set_attribute(CUBEPI_TOOL_IS_ERROR, event.is_error)

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -129,6 +129,10 @@ class _RunState:
     chat_open_ns: int | None = None
     chat_first_chunk_recorded: bool = False
     tool_spans: dict[str, Any] = field(default_factory=dict)
+    # contextvars.Token per tool_call_id, returned by
+    # ``cubepi.mcp._tracing.register_tool_span``. Passed back on
+    # ``unregister_tool_span`` to restore the prior contextvar state.
+    tool_span_tokens: dict[str, Any] = field(default_factory=dict)
     # Caller-supplied extra attrs for this run (set via run_scope, future).
     extra_attrs: dict[str, Any] = field(default_factory=dict)
     # Counts for invoke_agent attrs.
@@ -439,22 +443,23 @@ class Recorder:
             attributes=attrs,
         )
         run.tool_spans[event.tool_call_id] = span
-        # Expose this execute_tool span to ``cubepi.mcp._tracing`` so an
-        # MCP tool call running inside this span (in the AgentTool body)
-        # can look it up by ``tool_call_id`` and make its CLIENT span a
-        # child. Pass the owning provider alongside so the MCP CLIENT
-        # span is exported through *this* Tracer's exporter rather than
-        # whichever Tracer was attached most recently in the process —
-        # otherwise concurrent Tracers misroute spans across each other
-        # (codex round-6 + round-7 reviews on PR #86).
+        # Expose this execute_tool span (and its owning provider) to
+        # ``cubepi.mcp._tracing`` via a per-task contextvar so an MCP
+        # tool call running inside the AgentTool body inherits the
+        # right parent. Per-task scoping avoids the global-dict
+        # collision when concurrent agents reuse the same tool_call_id
+        # (e.g. Faux/OpenAI-style providers minting ``tc1`` per
+        # conversation — codex round-8). The recorder stashes the
+        # contextvar reset token on _RunState to undo on exec_end.
         try:
             from cubepi.mcp import _tracing as _mcp_tracing
 
-            _mcp_tracing.register_tool_span(
+            cv_token = _mcp_tracing.register_tool_span(
                 event.tool_call_id,
                 span,
                 provider=self._tracer._provider,
             )
+            run.tool_span_tokens[event.tool_call_id] = cv_token
         except ImportError:  # pragma: no cover — mcp module always present
             pass
         if self._record_content and event.args is not None:
@@ -467,10 +472,11 @@ class Recorder:
         if run is None:
             return
         span = run.tool_spans.pop(event.tool_call_id, None)
+        cv_token = run.tool_span_tokens.pop(event.tool_call_id, None)
         try:
             from cubepi.mcp import _tracing as _mcp_tracing
 
-            _mcp_tracing.unregister_tool_span(event.tool_call_id)
+            _mcp_tracing.unregister_tool_span(cv_token)
         except ImportError:  # pragma: no cover — mcp module always present
             pass
         if span is None:

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -442,14 +442,19 @@ class Recorder:
         # Expose this execute_tool span to ``cubepi.mcp._tracing`` so an
         # MCP tool call running inside this span (in the AgentTool body)
         # can look it up by ``tool_call_id`` and make its CLIENT span a
-        # child. Without this hop, MCP would start its span under the
-        # OTel "current span" — which the recorder doesn't bother making
-        # current — and the CLIENT span would become an orphan root
-        # trace (codex round-6 review on PR #86).
+        # child. Pass the owning provider alongside so the MCP CLIENT
+        # span is exported through *this* Tracer's exporter rather than
+        # whichever Tracer was attached most recently in the process —
+        # otherwise concurrent Tracers misroute spans across each other
+        # (codex round-6 + round-7 reviews on PR #86).
         try:
             from cubepi.mcp import _tracing as _mcp_tracing
 
-            _mcp_tracing.register_tool_span(event.tool_call_id, span)
+            _mcp_tracing.register_tool_span(
+                event.tool_call_id,
+                span,
+                provider=self._tracer._provider,
+            )
         except ImportError:  # pragma: no cover — mcp module always present
             pass
         if self._record_content and event.args is not None:

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -135,6 +135,13 @@ class Tracer:
         installed by this attach, then calls :meth:`force_flush` to
         ensure spans produced by the agent's runs are persisted before
         the caller proceeds.
+
+        Also registers this Tracer's private TracerProvider with
+        :mod:`cubepi.mcp._tracing` so MCP CLIENT spans flow through
+        the same exporters — without this step, the MCP module falls
+        back to the OTel global default (a no-op provider when the
+        caller didn't separately call ``trace.set_tracer_provider``).
+        The detach callable unregisters.
         """
         from cubepi.tracing.recorder import Recorder
 
@@ -143,7 +150,25 @@ class Tracer:
             record_content=self._record_content,
             redact=self._redact,
         )
-        return recorder.attach(agent)
+        recorder_detach = recorder.attach(agent)
+
+        # Route MCP spans through this Tracer's provider.
+        try:
+            from cubepi.mcp import _tracing as mcp_tracing
+
+            mcp_tracing.register_provider(self._provider)
+        except ImportError:  # pragma: no cover — mcp module always present
+            mcp_tracing = None
+
+        def detach() -> None:
+            recorder_detach()
+            if mcp_tracing is not None:
+                try:
+                    mcp_tracing.unregister_provider()
+                except Exception:
+                    pass
+
+        return detach
 
     async def force_flush(self, timeout_seconds: float = 30.0) -> bool:
         """Block until all currently buffered spans are exported.

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -152,19 +152,24 @@ class Tracer:
         )
         recorder_detach = recorder.attach(agent)
 
-        # Route MCP spans through this Tracer's provider.
+        # Route MCP spans through this Tracer's provider. Capture the
+        # token returned by register_provider so the detach below only
+        # removes this attach's registration — multiple attaches of the
+        # same Tracer to different agents must not clobber each other
+        # (see codex round-6 review on PR #86).
+        mcp_token: object | None = None
         try:
             from cubepi.mcp import _tracing as mcp_tracing
 
-            mcp_tracing.register_provider(self._provider)
+            mcp_token = mcp_tracing.register_provider(self._provider)
         except ImportError:  # pragma: no cover — mcp module always present
             mcp_tracing = None
 
         def detach() -> None:
             recorder_detach()
-            if mcp_tracing is not None:
+            if mcp_tracing is not None and mcp_token is not None:
                 try:
-                    mcp_tracing.unregister_provider()
+                    mcp_tracing.unregister_provider(mcp_token)
                 except Exception:
                     pass
 

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -857,6 +857,97 @@ class TestMCPSpanParentage:
         assert mcp[0].parent is not None
         assert mcp[0].parent.span_id == execute[0].get_span_context().span_id
 
+    async def test_cancellation_does_not_leak_tool_registrations(self):
+        """``asyncio.CancelledError`` inherits ``BaseException`` and
+        bypasses the cubepi agent loop's ``except Exception`` handler,
+        so a cancelled run never emits ``ToolExecutionEndEvent`` and
+        never reaches the per-event unregister. Without an explicit
+        cleanup path, ``_active_entries`` in ``cubepi.mcp._tracing``
+        would grow unbounded across aborted runs (codex round-10).
+
+        Pin: after a cancelled run + detach, ``_active_entries`` is
+        back to its pre-run size."""
+        import asyncio as _asyncio
+
+        from cubepi.agent.agent import Agent
+        from cubepi.mcp import _tracing as mcp_tracing
+        from cubepi.mcp._adapter import make_mcp_agent_tool
+        from cubepi.providers.base import Model, ToolCall
+        from cubepi.providers.faux import FauxProvider, faux_assistant_message
+        from cubepi.tracing import Tracer
+
+        baseline = len(mcp_tracing._active_entries)
+
+        # Gate the MCP call so we can cancel mid-flight, simulating
+        # the real "agent run cancelled while a tool is awaiting" path.
+        in_call = _asyncio.Event()
+        never = _asyncio.Event()
+
+        async def call_remote(name, args):
+            in_call.set()
+            await never.wait()  # cancellation lands here
+            return {"content": [], "isError": False}
+
+        mcp_tool = make_mcp_agent_tool(
+            name="search",
+            description="search",
+            input_schema={
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+            },
+            call_remote=call_remote,
+        )
+
+        provider = FauxProvider()
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    [ToolCall(id="tc1", name="search", arguments={"q": "x"})],
+                    stop_reason="tool_use",
+                ),
+                faux_assistant_message("done"),
+            ]
+        )
+        agent = Agent(
+            provider=provider,
+            model=Model(id="faux-1", provider="faux"),
+            system_prompt="s",
+            tools=[mcp_tool],
+        )
+
+        exporter = _CaptureExporter()
+        tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+        detach = tracer.attach(agent)
+
+        try:
+            run_task = _asyncio.create_task(agent.prompt("go"))
+            await in_call.wait()
+            # During registration_active = baseline + 1.
+            assert len(mcp_tracing._active_entries) == baseline + 1, (
+                "expected exactly one active MCP tool registration mid-run"
+            )
+            run_task.cancel()
+            try:
+                await run_task
+            except _asyncio.CancelledError:
+                pass
+            # Drain any post-cancel events; agent doesn't emit on cancel
+            # but wait_for_idle is harmless.
+            try:
+                await _asyncio.wait_for(agent.wait_for_idle(), timeout=1.0)
+            except (_asyncio.TimeoutError, _asyncio.CancelledError):
+                pass
+        finally:
+            detach()
+            # detach() may schedule async cleanup; give it a tick to run.
+            await _asyncio.sleep(0)
+            await tracer.shutdown()
+
+        assert len(mcp_tracing._active_entries) == baseline, (
+            "cancelled MCP tool execution leaked a registration in "
+            "_active_entries — detach()'s sweep didn't run"
+        )
+
     async def test_unregister_cleans_dict_even_from_different_task(self):
         """Direct contract test for the dict+contextvar hybrid:
         ``register_tool_span`` in one task, ``unregister_tool_span`` in

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -77,11 +77,11 @@ def _patch_mcp_trace(monkeypatch, provider: TracerProvider) -> None:
     monkeypatch.setattr(mcp_tracing, "_otel_trace", _ShimTraceMod)
     monkeypatch.setattr(mcp_tracing, "_OTEL_AVAILABLE", True)
     # Other tests' Tracer.attach() may have left entries on the provider
-    # stack; clear so this test resolves via the shim above. Also clear
-    # the tool-span registry — leftover entries would make subsequent
-    # mcp spans nest under a stale execute_tool span.
+    # stack; clear so this test resolves via the shim above. The
+    # current-tool contextvar is per-task and won't leak between tests
+    # (pytest-asyncio runs each test in a fresh task), so no reset
+    # needed there.
     monkeypatch.setattr(mcp_tracing, "_provider_stack", [])
-    monkeypatch.setattr(mcp_tracing, "_active_tool_spans", {})
 
 
 async def _make_tool(
@@ -564,7 +564,7 @@ class TestMCPSpanParentage:
 
         tracer = provider.get_tracer("test")
         tool_span = tracer.start_span("execute_tool search")
-        mcp_tracing.register_tool_span("tc1", tool_span)
+        token = mcp_tracing.register_tool_span("tc1", tool_span)
         try:
 
             async def call_remote(name, args):
@@ -573,7 +573,7 @@ class TestMCPSpanParentage:
             tool = await _make_tool(call_remote)
             await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
         finally:
-            mcp_tracing.unregister_tool_span("tc1")
+            mcp_tracing.unregister_tool_span(token)
             tool_span.end()
 
         mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
@@ -676,6 +676,109 @@ class TestMCPSpanParentage:
             assert (
                 execute[0].get_span_context().trace_id
                 == mcp[0].get_span_context().trace_id
+            )
+
+    async def test_concurrent_agents_with_colliding_tool_call_ids(self):
+        """Two agents executing MCP tools concurrently with the SAME
+        tool_call_id (``tc1``, mimicking how Faux/OpenAI-style providers
+        mint ids per conversation). A global dict keyed by tool_call_id
+        would let the second registration overwrite the first; the MCP
+        span lookup could then parent/export agent A's CLIENT span
+        through agent B's owning provider, reintroducing the cross-
+        Tracer misrouting that the sequential test does not cover.
+
+        ContextVars scope per asyncio task, so each agent's run sees
+        only its own parent (codex round-8 review on PR #86)."""
+        import asyncio as _asyncio
+
+        from cubepi.agent.agent import Agent
+        from cubepi.mcp._adapter import make_mcp_agent_tool
+        from cubepi.providers.base import Model, ToolCall
+        from cubepi.providers.faux import FauxProvider, faux_assistant_message
+        from cubepi.tracing import Tracer
+
+        # Gate that holds both agents' MCP calls inside the
+        # ``execute_tool`` span at the same time, so any global-dict
+        # collision would be exercised. Without the gate the calls
+        # would serialize trivially.
+        in_call = _asyncio.Event()
+        release = _asyncio.Event()
+
+        async def call_remote(name, args):
+            in_call.set()
+            await release.wait()
+            return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+        def _make_agent():
+            mcp_tool = make_mcp_agent_tool(
+                name="search",
+                description="search",
+                input_schema={
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+                call_remote=call_remote,
+            )
+            prov = FauxProvider()
+            prov.append_responses(
+                [
+                    faux_assistant_message(
+                        [ToolCall(id="tc1", name="search", arguments={"q": "x"})],
+                        stop_reason="tool_use",
+                    ),
+                    faux_assistant_message("done"),
+                ]
+            )
+            return Agent(
+                provider=prov,
+                model=Model(id="faux-1", provider="faux"),
+                system_prompt="s",
+                tools=[mcp_tool],
+            )
+
+        exporter_a = _CaptureExporter()
+        exporter_b = _CaptureExporter()
+        agent_a = _make_agent()
+        agent_b = _make_agent()
+        tracer_a = Tracer(service_name="a", agent_name="a", exporters=[exporter_a])
+        tracer_b = Tracer(service_name="b", agent_name="b", exporters=[exporter_b])
+        detach_a = tracer_a.attach(agent_a)
+        detach_b = tracer_b.attach(agent_b)
+
+        async def _run(agent):
+            await agent.prompt("go")
+            await agent.wait_for_idle()
+
+        try:
+            task_a = _asyncio.create_task(_run(agent_a))
+            task_b = _asyncio.create_task(_run(agent_b))
+
+            # Both agents have entered their MCP call_remote.
+            await in_call.wait()
+            in_call.clear()
+            # Give the second one a moment to also enter; the gate keeps
+            # it parked there.
+            await _asyncio.sleep(0.05)
+            release.set()
+            await _asyncio.gather(task_a, task_b)
+        finally:
+            detach_a()
+            detach_b()
+            await tracer_a.shutdown()
+            await tracer_b.shutdown()
+
+        for exporter, who in ((exporter_a, "a"), (exporter_b, "b")):
+            execute = [s for s in exporter.spans if s.name.startswith("execute_tool ")]
+            mcp = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+            assert len(execute) == 1, f"agent_{who}: execute_tool count"
+            assert len(mcp) == 1, f"agent_{who}: tools/call count"
+            assert (
+                execute[0].get_span_context().trace_id
+                == mcp[0].get_span_context().trace_id
+            ), f"agent_{who}: MCP span landed in wrong trace"
+            assert mcp[0].parent is not None
+            assert mcp[0].parent.span_id == execute[0].get_span_context().span_id, (
+                f"agent_{who}: MCP span parented to the wrong execute_tool"
             )
 
     async def test_mcp_span_orphan_when_no_registered_parent(self, monkeypatch):

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -240,6 +240,50 @@ class TestTraceparentHelper:
         assert current_traceparent() is None
 
 
+class TestTraceparentInjection:
+    """The HTTP loader must inject ``traceparent`` into outbound
+    session headers whenever the MCP CLIENT span is active so that
+    instrumented MCP servers can continue the trace (codex round 2)."""
+
+    async def test_traceparent_header_set_inside_mcp_span(self, monkeypatch):
+        from cubepi.mcp import _tracing as mcp_tracing
+        from cubepi.mcp._tracing import mcp_client_span
+
+        # Force OTel on with a deterministic tracer.
+        provider, _exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        # Reproduce the http_loader.call_remote injection logic.
+        seen_headers: list[dict] = []
+
+        base_headers = {"x-test": "yes"}
+
+        async def fake_call_remote():
+            # Mirrors http_loader._call_remote header-merge logic.
+            tp = mcp_tracing.current_traceparent()
+            call_headers = base_headers
+            if tp is not None:
+                call_headers = {**base_headers, "traceparent": tp}
+            seen_headers.append(call_headers)
+
+        async with mcp_client_span(method="tools/call", tool_name="search"):
+            await fake_call_remote()
+
+        assert len(seen_headers) == 1
+        assert seen_headers[0]["x-test"] == "yes"  # caller headers preserved
+        assert "traceparent" in seen_headers[0]
+        # Format: 00-<32hex>-<16hex>-<flags>
+        tp = seen_headers[0]["traceparent"]
+        assert tp.startswith("00-") and len(tp.split("-")) == 4
+
+    async def test_no_header_added_when_no_active_span(self, monkeypatch):
+        from cubepi.mcp._tracing import current_traceparent
+
+        # Outside any span: helper returns None and loader must not add
+        # a traceparent header.
+        assert current_traceparent() is None
+
+
 class TestLoaderHelpers:
     def test_split_address_parses_url(self):
         from cubepi.mcp.http_loader import _split_address

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -1,0 +1,249 @@
+"""Phase 5: pin MCP CLIENT span emissions + W3C traceparent propagation.
+
+The MCP adapter wraps every ``call_remote`` invocation in
+:func:`cubepi.mcp._tracing.mcp_client_span`, which opens a CLIENT span
+with the GenAI MCP semconv attributes. When the OTel API is absent the
+context manager is a no-op (verified separately).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from opentelemetry import trace as _trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+from opentelemetry.trace import SpanKind, StatusCode
+
+from cubepi.mcp._adapter import make_mcp_agent_tool
+
+
+class _CaptureExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans):  # noqa: ANN001
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+def _make_provider() -> tuple[TracerProvider, _CaptureExporter]:
+    """Build a fresh TracerProvider with an in-memory exporter.
+
+    Each test gets its own provider; we don't use trace.set_tracer_provider
+    globally, instead we monkeypatch the module-level ``_otel_trace`` in
+    ``cubepi.mcp._tracing`` so MCP fetches the test's tracer.
+    """
+    resource = Resource.create({"service.name": "mcp-span-tests"})
+    provider = TracerProvider(resource=resource)
+    exporter = _CaptureExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+def _patch_mcp_trace(monkeypatch, provider: TracerProvider) -> None:
+    """Swap the cubepi.mcp._tracing module's ``get_tracer`` to use ours."""
+    import cubepi.mcp._tracing as mcp_tracing
+
+    class _ShimTraceMod:
+        @staticmethod
+        def get_tracer(name: str):  # noqa: D401
+            return provider.get_tracer(name)
+
+        @staticmethod
+        def use_span(span):
+            return _trace.use_span(span)
+
+        @staticmethod
+        def get_current_span():
+            return _trace.get_current_span()
+
+    monkeypatch.setattr(mcp_tracing, "_otel_trace", _ShimTraceMod)
+    monkeypatch.setattr(mcp_tracing, "_OTEL_AVAILABLE", True)
+
+
+async def _make_tool(
+    call_remote,
+    *,
+    server_address=None,
+    server_port=None,
+    protocol_version=None,
+    session_id=None,
+):
+    """Build the MCP-adapted AgentTool. Mirrors what loaders produce."""
+    return make_mcp_agent_tool(
+        name="search",
+        description="search the web",
+        input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+        call_remote=call_remote,
+        server_address=server_address,
+        server_port=server_port,
+        protocol_version=protocol_version,
+        session_id=session_id,
+    )
+
+
+def _attrs(span: ReadableSpan) -> dict[str, Any]:
+    return dict(span.attributes or {})
+
+
+class TestMCPClientSpan:
+    async def test_span_emitted_with_required_attrs(self, monkeypatch):
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        async def call_remote(name, args):
+            return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+        tool = await _make_tool(
+            call_remote,
+            server_address="example.com",
+            server_port=443,
+            protocol_version="2025-11-25",
+            session_id="sess-abc",
+        )
+        result = await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
+        assert result.is_error is None  # success path
+
+        # One MCP CLIENT span captured.
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        span = mcp_spans[0]
+        assert span.kind == SpanKind.CLIENT
+        attrs = _attrs(span)
+        assert attrs["mcp.method.name"] == "tools/call"
+        assert attrs["gen_ai.tool.name"] == "search"
+        assert attrs["gen_ai.operation.name"] == "execute_tool"
+        assert attrs["mcp.session.id"] == "sess-abc"
+        assert attrs["mcp.protocol.version"] == "2025-11-25"
+        assert attrs["server.address"] == "example.com"
+        assert attrs["server.port"] == 443
+
+    async def test_span_records_exception_on_failure(self, monkeypatch):
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        async def call_remote(name, args):
+            raise RuntimeError("server unavailable")
+
+        tool = await _make_tool(call_remote)
+        try:
+            await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
+        except RuntimeError:
+            pass
+
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        span = mcp_spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+        attrs = _attrs(span)
+        assert attrs["error.type"] == "RuntimeError"
+        evnames = [e.name for e in span.events]
+        assert "exception" in evnames
+
+    async def test_span_records_cancellation(self, monkeypatch):
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        async def call_remote(name, args):
+            raise asyncio.CancelledError()
+
+        tool = await _make_tool(call_remote)
+        try:
+            await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
+        except asyncio.CancelledError:
+            pass
+
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        attrs = _attrs(mcp_spans[0])
+        assert attrs["error.type"] == "cubepi.aborted"
+
+
+class TestNoOpWhenOTelMissing:
+    async def test_context_manager_yields_none_when_no_otel(self, monkeypatch):
+        import cubepi.mcp._tracing as mcp_tracing
+
+        monkeypatch.setattr(mcp_tracing, "_OTEL_AVAILABLE", False)
+
+        async def call_remote(name, args):
+            return {"content": [], "isError": False}
+
+        tool = await _make_tool(call_remote)
+        # Must run without errors and without emitting any spans.
+        await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
+
+
+class TestTraceparentHelper:
+    async def test_current_traceparent_returns_w3c_string_when_in_span(
+        self, monkeypatch
+    ):
+        provider, _ = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+        from cubepi.mcp._tracing import current_traceparent
+
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test-span"):
+            tp = current_traceparent()
+        assert tp is not None
+        # Format: 00-<32hex>-<16hex>-<flags>
+        parts = tp.split("-")
+        assert len(parts) == 4
+        assert parts[0] == "00"
+        assert len(parts[1]) == 32
+        assert len(parts[2]) == 16
+        assert len(parts[3]) == 2
+
+    async def test_current_traceparent_none_without_span(self, monkeypatch):
+        from cubepi.mcp._tracing import current_traceparent
+
+        # No active span (and no recording context set up).
+        assert current_traceparent() is None
+
+
+class TestLoaderHelpers:
+    def test_split_address_parses_url(self):
+        from cubepi.mcp.http_loader import _split_address
+
+        assert _split_address("https://api.example.com:8443/mcp") == (
+            "api.example.com",
+            8443,
+        )
+        host, port = _split_address("http://localhost/mcp")
+        assert host == "localhost"
+        assert port is None
+
+    def test_split_address_on_empty(self):
+        from cubepi.mcp.http_loader import _split_address
+
+        # urlparse("") returns hostname=None, port=None — both nones is
+        # the documented signal that the helper couldn't extract values.
+        host, port = _split_address("")
+        assert host is None
+        assert port is None
+
+    def test_extract_protocol_version(self):
+        from cubepi.mcp.http_loader import _extract_protocol_version
+
+        class FakeInit:
+            protocolVersion = "2025-11-25"
+
+        assert _extract_protocol_version(FakeInit()) == "2025-11-25"
+        assert _extract_protocol_version(object()) is None
+
+        class FakeBadInit:
+            protocolVersion = 123  # not a string
+
+        assert _extract_protocol_version(FakeBadInit()) is None

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -63,8 +63,8 @@ def _patch_mcp_trace(monkeypatch, provider: TracerProvider) -> None:
             return provider.get_tracer(name)
 
         @staticmethod
-        def use_span(span):
-            return _trace.use_span(span)
+        def use_span(span, **kwargs):
+            return _trace.use_span(span, **kwargs)
 
         @staticmethod
         def get_current_span():
@@ -152,6 +152,33 @@ class TestMCPClientSpan:
         assert attrs["error.type"] == "RuntimeError"
         evnames = [e.name for e in span.events]
         assert "exception" in evnames
+
+    async def test_exception_event_is_recorded_only_once(self, monkeypatch):
+        """OTel's ``use_span`` defaults to record_exception=True; if we
+        leave that on, the auto-recording on context exit and our own
+        ``record_exception`` in the except branch both fire — duplicate
+        exception events double-count errors at the backend.
+
+        We disable auto-recording on ``use_span`` and own the
+        recording. Pin: exactly one ``exception`` event per failure."""
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        async def call_remote(name, args):
+            raise RuntimeError("boom")
+
+        tool = await _make_tool(call_remote)
+        try:
+            await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
+        except RuntimeError:
+            pass
+
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        exception_events = [e for e in mcp_spans[0].events if e.name == "exception"]
+        assert len(exception_events) == 1, (
+            f"expected exactly 1 exception event; got {len(exception_events)}"
+        )
 
     async def test_span_records_cancellation(self, monkeypatch):
         provider, exporter = _make_provider()

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -72,6 +72,9 @@ def _patch_mcp_trace(monkeypatch, provider: TracerProvider) -> None:
 
     monkeypatch.setattr(mcp_tracing, "_otel_trace", _ShimTraceMod)
     monkeypatch.setattr(mcp_tracing, "_OTEL_AVAILABLE", True)
+    # Other tests' Tracer.attach() may have populated _registered_provider;
+    # reset for deterministic per-test resolution via the shim above.
+    monkeypatch.setattr(mcp_tracing, "_registered_provider", None)
 
 
 async def _make_tool(
@@ -338,6 +341,93 @@ class TestTraceparentInjection:
         # Outside any span: helper returns None and loader must not add
         # a traceparent header.
         assert current_traceparent() is None
+
+
+class TestTracerProviderRouting:
+    """When a user constructs a cubepi.tracing.Tracer with its own
+    private provider and calls attach(agent), MCP CLIENT spans must
+    flow through that same provider's exporters — without this, MCP
+    spans would silently land in the OTel global no-op provider
+    (codex round 5)."""
+
+    async def test_mcp_span_lands_in_tracer_exporter(self):
+        from cubepi.agent.agent import Agent
+        from cubepi.providers.base import Model, ToolCall
+        from cubepi.providers.faux import (
+            FauxProvider,
+            faux_assistant_message,
+        )
+        from cubepi.tracing import Tracer
+
+        from pydantic import BaseModel
+
+        # Capture exporter shared by the cubepi Tracer.
+        exporter = _CaptureExporter()
+
+        # Build an MCP-backed tool whose call_remote we can drive.
+        class P(BaseModel):
+            q: str = ""
+
+        async def call_remote(name, args):
+            return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+        from cubepi.mcp._adapter import make_mcp_agent_tool
+
+        mcp_tool = make_mcp_agent_tool(
+            name="search",
+            description="search",
+            input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+            call_remote=call_remote,
+            server_address="api.example.com",
+            protocol_version="2025-11-25",
+        )
+
+        provider = FauxProvider()
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    [ToolCall(id="tc1", name="search", arguments={"q": "x"})],
+                    stop_reason="tool_use",
+                ),
+                faux_assistant_message("done"),
+            ]
+        )
+        agent = Agent(
+            provider=provider,
+            model=Model(id="faux-1", provider="faux"),
+            system_prompt="s",
+            tools=[mcp_tool],
+        )
+
+        tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+        detach = tracer.attach(agent)
+
+        try:
+            await agent.prompt("go")
+            await agent.wait_for_idle()
+        finally:
+            detach()
+            await tracer.shutdown()
+
+        # Exactly one MCP tools/call CLIENT span landed in the Tracer's
+        # exporter — proving the routing worked.
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        attrs = dict(mcp_spans[0].attributes or {})
+        assert attrs["mcp.method.name"] == "tools/call"
+        assert attrs["gen_ai.tool.name"] == "search"
+
+    def test_register_and_unregister_provider(self):
+        from cubepi.mcp import _tracing as mcp_tracing
+
+        assert mcp_tracing._registered_provider is None
+        sentinel = object()
+        mcp_tracing.register_provider(sentinel)
+        try:
+            assert mcp_tracing._registered_provider is sentinel
+        finally:
+            mcp_tracing.unregister_provider()
+        assert mcp_tracing._registered_provider is None
 
 
 class TestLoaderHelpers:

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -586,6 +586,98 @@ class TestMCPSpanParentage:
         assert client_span.parent is not None
         assert client_span.parent.span_id == tool_ctx.span_id
 
+    async def test_two_tracers_route_mcp_by_parent_owner(self):
+        """Two different cubepi.Tracer instances attached to two agents
+        in the same process. An MCP CLIENT span emitted under agent A's
+        execute_tool span must export through Tracer A's exporter — not
+        Tracer B's, even if B was attached more recently (LIFO order on
+        the provider stack).
+
+        Without this routing, agent A's trace would be missing its MCP
+        leg and Tracer B's exporter would receive a stray span with
+        agent A's trace_id (codex round-7 review on PR #86)."""
+        from cubepi.agent.agent import Agent
+        from cubepi.providers.base import Model, ToolCall
+        from cubepi.providers.faux import FauxProvider, faux_assistant_message
+        from cubepi.tracing import Tracer
+
+        from cubepi.mcp._adapter import make_mcp_agent_tool
+
+        async def call_remote(name, args):
+            return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+        def _make_agent():
+            mcp_tool = make_mcp_agent_tool(
+                name="search",
+                description="search",
+                input_schema={
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+                call_remote=call_remote,
+            )
+            provider = FauxProvider()
+            provider.append_responses(
+                [
+                    faux_assistant_message(
+                        [ToolCall(id="tc1", name="search", arguments={"q": "x"})],
+                        stop_reason="tool_use",
+                    ),
+                    faux_assistant_message("done"),
+                ]
+            )
+            return Agent(
+                provider=provider,
+                model=Model(id="faux-1", provider="faux"),
+                system_prompt="s",
+                tools=[mcp_tool],
+            )
+
+        exporter_a = _CaptureExporter()
+        exporter_b = _CaptureExporter()
+
+        agent_a = _make_agent()
+        agent_b = _make_agent()
+
+        tracer_a = Tracer(service_name="a", agent_name="a", exporters=[exporter_a])
+        tracer_b = Tracer(service_name="b", agent_name="b", exporters=[exporter_b])
+
+        # Attach A first then B so B is at the top of the LIFO stack.
+        # The buggy implementation would route both agents' MCP spans
+        # through B; we want A's spans in A's exporter and B's in B's.
+        detach_a = tracer_a.attach(agent_a)
+        detach_b = tracer_b.attach(agent_b)
+
+        try:
+            await agent_a.prompt("go")
+            await agent_a.wait_for_idle()
+            await agent_b.prompt("go")
+            await agent_b.wait_for_idle()
+        finally:
+            detach_a()
+            detach_b()
+            await tracer_a.shutdown()
+            await tracer_b.shutdown()
+
+        # Each exporter saw exactly one tools/call CLIENT span — its
+        # own agent's — with matching trace_id.
+        mcp_a = [s for s in exporter_a.spans if s.name.startswith("tools/call ")]
+        mcp_b = [s for s in exporter_b.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_a) == 1, "agent_a's MCP span did not land in tracer_a"
+        assert len(mcp_b) == 1, "agent_b's MCP span did not land in tracer_b"
+
+        # Cross-check trace_id consistency: each exporter's MCP span
+        # shares trace_id with that exporter's execute_tool span (i.e.,
+        # parent and child went to the same backend together).
+        for exporter in (exporter_a, exporter_b):
+            execute = [s for s in exporter.spans if s.name.startswith("execute_tool ")]
+            mcp = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+            assert len(execute) == 1 and len(mcp) == 1
+            assert (
+                execute[0].get_span_context().trace_id
+                == mcp[0].get_span_context().trace_id
+            )
+
     async def test_mcp_span_orphan_when_no_registered_parent(self, monkeypatch):
         """Without a registered parent, the MCP span starts a new
         root trace. Pinning this so the parented-path test above is

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -939,14 +939,19 @@ class TestMCPSpanParentage:
                 pass
         finally:
             detach()
-            # detach() may schedule async cleanup; give it a tick to run.
-            await _asyncio.sleep(0)
+            # ``detach()`` runs the synchronous sweep eagerly — the
+            # registration must already be gone before we even reach
+            # ``tracer.shutdown()`` (codex round-11). Asserting *before*
+            # shutdown pins that contract; the post-shutdown assertion
+            # below is a belt-and-braces check.
+            assert len(mcp_tracing._active_entries) == baseline, (
+                "detach() did not synchronously sweep the cancelled "
+                "tool's registration; cleanup was deferred to a loop "
+                "tick that may not run before tracer.shutdown()"
+            )
             await tracer.shutdown()
 
-        assert len(mcp_tracing._active_entries) == baseline, (
-            "cancelled MCP tool execution leaked a registration in "
-            "_active_entries — detach()'s sweep didn't run"
-        )
+        assert len(mcp_tracing._active_entries) == baseline
 
     async def test_unregister_cleans_dict_even_from_different_task(self):
         """Direct contract test for the dict+contextvar hybrid:

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -781,6 +781,118 @@ class TestMCPSpanParentage:
                 f"agent_{who}: MCP span parented to the wrong execute_tool"
             )
 
+    async def test_parallel_tool_mode_parents_mcp_span(self):
+        """In ``parallel`` tool execution, the cubepi agent loop emits
+        ``ToolExecutionStartEvent`` in the parent task and
+        ``ToolExecutionEndEvent`` from the per-tool *child* task it
+        spawns. A naive ``ContextVar.reset(token)`` would raise
+        ``ValueError`` in the child task because the Token was minted
+        in a different context. The dict+contextvar hybrid keeps the
+        registry valid until the child task's cleanup runs — pin that
+        an MCP CLIENT span is still correctly parented under
+        ``execute_tool`` in this mode (codex round-9 review)."""
+        from cubepi.agent.agent import Agent
+        from cubepi.agent.types import AgentTool
+        from cubepi.mcp._adapter import make_mcp_agent_tool
+        from cubepi.providers.base import Model, ToolCall
+        from cubepi.providers.faux import FauxProvider, faux_assistant_message
+        from cubepi.tracing import Tracer
+
+        async def call_remote(name, args):
+            return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+        # Build the MCP tool with execution_mode="parallel" so the
+        # agent's _execute_parallel path is taken.
+        base_tool = make_mcp_agent_tool(
+            name="search",
+            description="search",
+            input_schema={
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+            },
+            call_remote=call_remote,
+        )
+        mcp_tool = AgentTool(
+            name=base_tool.name,
+            description=base_tool.description,
+            parameters=base_tool.parameters,
+            execute=base_tool.execute,
+            execution_mode="parallel",
+        )
+
+        provider = FauxProvider()
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    [ToolCall(id="tc1", name="search", arguments={"q": "x"})],
+                    stop_reason="tool_use",
+                ),
+                faux_assistant_message("done"),
+            ]
+        )
+        agent = Agent(
+            provider=provider,
+            model=Model(id="faux-1", provider="faux"),
+            system_prompt="s",
+            tools=[mcp_tool],
+        )
+
+        exporter = _CaptureExporter()
+        tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+        detach = tracer.attach(agent)
+        try:
+            await agent.prompt("go")
+            await agent.wait_for_idle()
+        finally:
+            detach()
+            await tracer.shutdown()
+
+        execute = [s for s in exporter.spans if s.name.startswith("execute_tool ")]
+        mcp = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(execute) == 1
+        assert len(mcp) == 1
+        assert (
+            mcp[0].get_span_context().trace_id == execute[0].get_span_context().trace_id
+        )
+        assert mcp[0].parent is not None
+        assert mcp[0].parent.span_id == execute[0].get_span_context().span_id
+
+    async def test_unregister_cleans_dict_even_from_different_task(self):
+        """Direct contract test for the dict+contextvar hybrid:
+        ``register_tool_span`` in one task, ``unregister_tool_span`` in
+        a different task. The ``ContextVar.reset`` raises and is
+        swallowed; the dict entry must still be cleaned up so any
+        subsequent lookup via a stale contextvar returns ``None``
+        (codex round-9 review)."""
+        import asyncio as _asyncio
+
+        from cubepi.mcp import _tracing as mcp_tracing
+
+        # Build a parent task that registers, then a child task that
+        # unregisters. We assert the dict is empty after cleanup.
+        registered_count_before = len(mcp_tracing._active_entries)
+
+        token_holder: list = []
+
+        async def _register():
+            token = mcp_tracing.register_tool_span("tc1", "span-A", provider="prov-A")
+            token_holder.append(token)
+            # Don't unregister here — let the child task do it.
+
+        async def _unregister(token):
+            mcp_tracing.unregister_tool_span(token)
+
+        await _register()
+        # Confirm the dict gained one entry.
+        assert len(mcp_tracing._active_entries) == registered_count_before + 1
+
+        # Unregister from a different task; ContextVar.reset will
+        # ValueError but the dict cleanup must still happen.
+        await _asyncio.create_task(_unregister(token_holder[0]))
+        assert len(mcp_tracing._active_entries) == registered_count_before, (
+            "_active_entries leaked after cross-task unregister_tool_span"
+        )
+
     async def test_mcp_span_orphan_when_no_registered_parent(self, monkeypatch):
         """Without a registered parent, the MCP span starts a new
         root trace. Pinning this so the parented-path test above is

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -181,6 +181,10 @@ class TestMCPClientSpan:
         )
 
     async def test_span_records_cancellation(self, monkeypatch):
+        """Cancellation is a control signal, not a failure — match the
+        chat / turn / invoke_agent convention: leave Status UNSET,
+        record cubepi.aborted=true + error.type, do NOT add an
+        ``exception`` event."""
         provider, exporter = _make_provider()
         _patch_mcp_trace(monkeypatch, provider)
 
@@ -195,8 +199,14 @@ class TestMCPClientSpan:
 
         mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
         assert len(mcp_spans) == 1
-        attrs = _attrs(mcp_spans[0])
+        span = mcp_spans[0]
+        attrs = _attrs(span)
         assert attrs["error.type"] == "cubepi.aborted"
+        assert attrs["cubepi.aborted"] is True
+        # Status stays UNSET; cancel is not a failure.
+        assert span.status.status_code == StatusCode.UNSET
+        # No exception event — cancel is signaled via cubepi.aborted only.
+        assert not any(e.name == "exception" for e in span.events)
 
 
 class TestNoOpWhenOTelMissing:

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -70,11 +70,18 @@ def _patch_mcp_trace(monkeypatch, provider: TracerProvider) -> None:
         def get_current_span():
             return _trace.get_current_span()
 
+        @staticmethod
+        def set_span_in_context(span, context=None):
+            return _trace.set_span_in_context(span, context)
+
     monkeypatch.setattr(mcp_tracing, "_otel_trace", _ShimTraceMod)
     monkeypatch.setattr(mcp_tracing, "_OTEL_AVAILABLE", True)
-    # Other tests' Tracer.attach() may have populated _registered_provider;
-    # reset for deterministic per-test resolution via the shim above.
-    monkeypatch.setattr(mcp_tracing, "_registered_provider", None)
+    # Other tests' Tracer.attach() may have left entries on the provider
+    # stack; clear so this test resolves via the shim above. Also clear
+    # the tool-span registry — leftover entries would make subsequent
+    # mcp spans nest under a stale execute_tool span.
+    monkeypatch.setattr(mcp_tracing, "_provider_stack", [])
+    monkeypatch.setattr(mcp_tracing, "_active_tool_spans", {})
 
 
 async def _make_tool(
@@ -417,17 +424,184 @@ class TestTracerProviderRouting:
         assert attrs["mcp.method.name"] == "tools/call"
         assert attrs["gen_ai.tool.name"] == "search"
 
-    def test_register_and_unregister_provider(self):
+        # The CLIENT span must be a child of the recorder's
+        # execute_tool span (same trace_id, parent_span_id set), not an
+        # orphan root trace (codex round-6 review on PR #86).
+        client_span = mcp_spans[0]
+        execute_spans = [
+            s for s in exporter.spans if s.name.startswith("execute_tool ")
+        ]
+        assert len(execute_spans) == 1
+        tool_ctx = execute_spans[0].get_span_context()
+        client_ctx = client_span.get_span_context()
+        assert client_ctx.trace_id == tool_ctx.trace_id
+        assert client_span.parent is not None
+        assert client_span.parent.span_id == tool_ctx.span_id
+
+    async def test_two_attaches_detach_one_keeps_other_routing(self):
+        """When a Tracer is attached to two agents and one is detached,
+        the remaining agent's MCP spans must still land in the Tracer's
+        exporter. Refcounted register/unregister is the contract
+        (codex round-6 review on PR #86)."""
+        from cubepi.agent.agent import Agent
+        from cubepi.providers.base import Model, ToolCall
+        from cubepi.providers.faux import FauxProvider, faux_assistant_message
+        from cubepi.tracing import Tracer
+
+        exporter = _CaptureExporter()
+
+        async def call_remote(name, args):
+            return {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+        from cubepi.mcp._adapter import make_mcp_agent_tool
+
+        def _make_agent():
+            mcp_tool = make_mcp_agent_tool(
+                name="search",
+                description="search",
+                input_schema={
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+                call_remote=call_remote,
+            )
+            provider_a = FauxProvider()
+            provider_a.append_responses(
+                [
+                    faux_assistant_message(
+                        [ToolCall(id="tc1", name="search", arguments={"q": "x"})],
+                        stop_reason="tool_use",
+                    ),
+                    faux_assistant_message("done"),
+                ]
+            )
+            return Agent(
+                provider=provider_a,
+                model=Model(id="faux-1", provider="faux"),
+                system_prompt="s",
+                tools=[mcp_tool],
+            )
+
+        agent_a = _make_agent()
+        agent_b = _make_agent()
+
+        tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+        detach_a = tracer.attach(agent_a)
+        detach_b = tracer.attach(agent_b)
+
+        try:
+            # Detach the first attachment; agent_b's runs must still
+            # route MCP spans through the Tracer's exporter.
+            detach_a()
+
+            await agent_b.prompt("go")
+            await agent_b.wait_for_idle()
+        finally:
+            detach_b()
+            await tracer.shutdown()
+
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1, (
+            "MCP routing for the still-attached agent broke when the "
+            "other agent's detach was called"
+        )
+
+    def test_register_and_unregister_provider(self, monkeypatch):
         from cubepi.mcp import _tracing as mcp_tracing
 
-        assert mcp_tracing._registered_provider is None
+        # Start from a clean stack so the assertion below is well-defined
+        # regardless of other tests' attach()/detach() side-effects.
+        monkeypatch.setattr(mcp_tracing, "_provider_stack", [])
+
         sentinel = object()
-        mcp_tracing.register_provider(sentinel)
+        token = mcp_tracing.register_provider(sentinel)
         try:
-            assert mcp_tracing._registered_provider is sentinel
+            assert mcp_tracing._provider_stack[-1][1] is sentinel
         finally:
-            mcp_tracing.unregister_provider()
-        assert mcp_tracing._registered_provider is None
+            mcp_tracing.unregister_provider(token)
+        assert mcp_tracing._provider_stack == []
+
+    def test_unregister_only_removes_own_token(self, monkeypatch):
+        """Two providers registered in sequence; detaching the first
+        must leave the second's registration intact so MCP spans
+        continue flowing through it. Without this, a Tracer attached to
+        agent A and B then detached from A would drop MCP routing for B
+        (codex round-6 review on PR #86)."""
+        from cubepi.mcp import _tracing as mcp_tracing
+
+        monkeypatch.setattr(mcp_tracing, "_provider_stack", [])
+
+        first = object()
+        second = object()
+        t1 = mcp_tracing.register_provider(first)
+        t2 = mcp_tracing.register_provider(second)
+        try:
+            # Detach the first registration; the second must remain
+            # routable. The most-recently-pushed provider wins on lookup.
+            mcp_tracing.unregister_provider(t1)
+            assert len(mcp_tracing._provider_stack) == 1
+            assert mcp_tracing._provider_stack[-1][1] is second
+        finally:
+            mcp_tracing.unregister_provider(t2)
+        assert mcp_tracing._provider_stack == []
+
+
+class TestMCPSpanParentage:
+    """Phase 5 round 6: the MCP CLIENT span must nest under the
+    cubepi recorder's ``execute_tool`` span, not start an orphan root
+    trace. The recorder publishes its execute_tool span by tool_call_id;
+    the adapter passes the id through to ``mcp_client_span`` which uses
+    it as the explicit parent context."""
+
+    async def test_mcp_span_parented_to_registered_tool_span(self, monkeypatch):
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        # Open a synthetic "execute_tool" span and register it as the
+        # parent for tool_call_id "tc1" — the same hook the cubepi
+        # recorder uses.
+        from cubepi.mcp import _tracing as mcp_tracing
+
+        tracer = provider.get_tracer("test")
+        tool_span = tracer.start_span("execute_tool search")
+        mcp_tracing.register_tool_span("tc1", tool_span)
+        try:
+
+            async def call_remote(name, args):
+                return {"content": [], "isError": False}
+
+            tool = await _make_tool(call_remote)
+            await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
+        finally:
+            mcp_tracing.unregister_tool_span("tc1")
+            tool_span.end()
+
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        client_span = mcp_spans[0]
+        tool_ctx = tool_span.get_span_context()
+        client_ctx = client_span.get_span_context()
+        # Same trace_id, parent points at the execute_tool span.
+        assert client_ctx.trace_id == tool_ctx.trace_id
+        assert client_span.parent is not None
+        assert client_span.parent.span_id == tool_ctx.span_id
+
+    async def test_mcp_span_orphan_when_no_registered_parent(self, monkeypatch):
+        """Without a registered parent, the MCP span starts a new
+        root trace. Pinning this so the parented-path test above is
+        meaningful (i.e., parenting only kicks in when we ask for it)."""
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        async def call_remote(name, args):
+            return {"content": [], "isError": False}
+
+        tool = await _make_tool(call_remote)
+        await tool.execute("no-parent-tc", tool.parameters.model_validate({"q": "x"}))
+
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        assert mcp_spans[0].parent is None
 
 
 class TestLoaderHelpers:

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -209,6 +209,52 @@ class TestMCPClientSpan:
         assert not any(e.name == "exception" for e in span.events)
 
 
+class TestMCPIsErrorResponse:
+    """When an MCP server returns ``isError: true``, the CLIENT span
+    must reflect the protocol-level failure — codex round 4."""
+
+    async def test_iserror_response_marks_span_error(self, monkeypatch):
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        async def call_remote(name, args):
+            return {
+                "content": [{"type": "text", "text": "tool failed"}],
+                "isError": True,
+            }
+
+        tool = await _make_tool(call_remote)
+        result = await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
+        # Adapter still surfaces is_error on the AgentToolResult.
+        assert result.is_error is True
+
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        span = mcp_spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+        attrs = _attrs(span)
+        assert attrs["error.type"] == "mcp.is_error"
+
+    async def test_iserror_false_keeps_span_unset(self, monkeypatch):
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+
+        async def call_remote(name, args):
+            return {
+                "content": [{"type": "text", "text": "ok"}],
+                "isError": False,
+            }
+
+        tool = await _make_tool(call_remote)
+        await tool.execute("tc1", tool.parameters.model_validate({"q": "x"}))
+
+        mcp_spans = [s for s in exporter.spans if s.name.startswith("tools/call ")]
+        assert len(mcp_spans) == 1
+        span = mcp_spans[0]
+        assert span.status.status_code == StatusCode.UNSET
+        assert "error.type" not in _attrs(span)
+
+
 class TestNoOpWhenOTelMissing:
     async def test_context_manager_yields_none_when_no_otel(self, monkeypatch):
         import cubepi.mcp._tracing as mcp_tracing


### PR DESCRIPTION
## Summary

Final tracing phase per spec §14. Wraps every cubepi MCP tool execution in an OTel CLIENT span; when \`cubepi[tracing]\` is installed, every \`call_remote\` invocation auto-emits one \`tools/call <tool_name>\` span with:

- \`mcp.method.name = "tools/call"\`
- \`gen_ai.tool.name\`
- \`gen_ai.operation.name = "execute_tool"\`
- \`mcp.session.id\`, \`mcp.protocol.version\` (when known)
- \`server.address\`, \`server.port\` (HTTP transport only)
- \`error.type\` + \`exception\` event on failure / \`cubepi.aborted\` on cancel

### Zero hard dependency on opentelemetry

The MCP module has **no** opentelemetry import without a try/except. New \`cubepi/mcp/_tracing.py\` guards every OTel import; if the tracing extra isn't installed, \`mcp_client_span\` becomes a no-op pass-through context manager. Tested by \`TestNoOpWhenOTelMissing\`.

### W3C traceparent

Exposes \`current_traceparent()\` returning a standard W3C trace-context string for the currently active span. The HTTP loader caller can inject this into outbound MCP request headers so an instrumented MCP server can continue the trace.

Note on the spec's recommended \`params._meta\` injection: the MCP Python SDK doesn't expose the JSON-RPC \`params._meta\` slot through the \`session.call_tool(name, args)\` interface, so HTTP headers are the practical wire location. W3C trace-context spec §3 explicitly permits either.

### Loaders thread server info

- \`http_loader\` parses \`server.address\`/\`server.port\` from the URL and reads \`protocol_version\` from the \`initialize()\` result; passes them into \`make_mcp_agent_tool\`.
- \`stdio_loader\` has no network address; threads only \`protocol_version\`.

## Test plan

- [x] \`uv run pytest tests/\` — 643 passed, 1 skipped (634 baseline from Phase 4 + 9 new)
- [x] \`uv run ruff check cubepi/ tests/\` — clean
- [x] \`uv run ruff format --check cubepi/ tests/\` — clean
- [ ] CI green
- [ ] @codex review

### What the new tests pin
- All required \`mcp.*\` + \`gen_ai.*\` + \`server.*\` attrs on the CLIENT span
- Exception path: \`Status.ERROR\` + \`error.type\` + standard \`exception\` event
- Cancellation: \`error.type = "cubepi.aborted"\` (matches the tracing convention)
- No-op when OTel API is absent (the \`_OTEL_AVAILABLE = False\` branch)
- \`current_traceparent()\` produces \`00-<32hex>-<16hex>-<flags>\`
- \`_split_address\` + \`_extract_protocol_version\` loader helpers

With this PR merged, the tracing feature is fully complete per the design spec §17 Phase 1–5.

@codex please review.