### PR TITLE
docs(tracing): add Tracing guide section + API reference

### DIFF
--- a/website/docs/api/index.mdx
+++ b/website/docs/api/index.mdx
@@ -11,6 +11,7 @@ Auto-generated from CubePi's public modules.
 - `cubepi.checkpointer`
 - `cubepi.middleware`
 - `cubepi.mcp`
+- `cubepi.tracing`
 - `cubepi.utils`
 
 The module pages above are generated at build time from docstrings and are not editable by hand.

--- a/website/docs/guides/tracing/content-recording.md
+++ b/website/docs/guides/tracing/content-recording.md
@@ -1,0 +1,128 @@
+---
+title: Content & Redaction
+sidebar_position: 4
+---
+
+# Recording Prompts, Responses, and Tool Payloads
+
+By default cubepi's tracing emits structural attributes only — operation
+names, models, token counts, finish reasons, durations. **No prompt content,
+no model output, no tool arguments or results leave the process.** This is
+deliberate: many agent setups handle PII, customer data, or trade-secret
+prompts that don't belong in a third-party observability backend.
+
+When you _do_ want content captured — for offline evaluation, debugging a
+flaky tool call, or building a labelled dataset — opt in explicitly with
+`record_content=True`, and combine it with a `redact` callback to strip the
+sensitive parts before they leave the process.
+
+## Turning content recording on
+
+```python
+tracer = Tracer(
+    service_name="my-bot",
+    agent_name="assistant",
+    record_content=True,            # ← opt-in
+    exporters=[JsonlSpanExporter(directory="./cubepi-traces")],
+)
+```
+
+With `record_content=True`, each span layer carries the relevant content
+attributes per the OTel GenAI semconv:
+
+| Span | Content attributes added |
+|---|---|
+| `invoke_agent` | `gen_ai.system_instructions`, `gen_ai.input.messages`, `gen_ai.output.messages` |
+| `cubepi.turn` | `gen_ai.input.messages` (per-turn slice), `gen_ai.output.messages` (per-turn slice) |
+| `chat <model>` | `gen_ai.system_instructions`, `gen_ai.input.messages`, `gen_ai.tool.definitions`, `cubepi.llm.raw_request`, `cubepi.llm.raw_response` |
+| `execute_tool <tool_name>` | `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` |
+
+The `chat` span's `gen_ai.input.messages` contains the **full chronological
+context** the provider request actually carried — including prior assistant
+turns and tool results — not just the new user prompt. This matters for
+multi-turn tool-using runs: trace consumers can reconstruct exactly what
+the model saw at each call.
+
+## Redacting before export
+
+`redact` is a `(key, value) -> value | None` callback invoked at every
+content-attribute set site. Return:
+
+- The original value unchanged → keep as-is
+- A modified value of the same shape → substitute
+- `None` → drop the attribute entirely
+
+```python
+def redact(key: str, value):
+    # Strip secrets from prompts before they leave the process.
+    if key in ("gen_ai.input.messages", "gen_ai.output.messages"):
+        return _scrub_messages(value)
+    # Don't ship raw bodies at all in prod — keep only the normalised shape.
+    if key in ("cubepi.llm.raw_request", "cubepi.llm.raw_response"):
+        return None
+    return value
+
+
+tracer = Tracer(
+    service_name="my-bot",
+    record_content=True,
+    redact=redact,
+    exporters=[…],
+)
+```
+
+`redact` is the single chokepoint for content — the recorder calls it once
+per attribute before serializing into the OTel attribute, so anything the
+function returns is what hits the wire. Exceptions inside `redact` are
+swallowed (the attribute is dropped in that case), so a buggy redactor
+fails closed rather than leaking.
+
+### Common patterns
+
+Drop everything but per-message length so dashboards still work without
+shipping content:
+
+```python
+def redact(key, value):
+    if key in ("gen_ai.input.messages", "gen_ai.output.messages"):
+        return [{"role": m["role"], "parts": [{"type": "text", "content": "<redacted>",
+                                               "length": sum(len(p.get("content", "")) for p in m["parts"])}]}
+                for m in value]
+    return value
+```
+
+Tag-based selective recording — strip everything unless a thread is opted in:
+
+```python
+import contextvars
+RECORD = contextvars.ContextVar("trace.record_content", default=False)
+
+def redact(key, value):
+    return value if RECORD.get() else None
+```
+
+then `RECORD.set(True)` for the runs you want captured.
+
+## Size budgets
+
+OTel attribute values are JSON-serialized inside the recorder. Most backends
+truncate or reject attributes over a few hundred KB. If you're recording
+the raw provider response on every chat span, multi-turn agentic runs can
+get large fast. Drop or summarise via `redact` for any field over your
+budget.
+
+## Auditing what's recorded
+
+The recorder always sets `service.name`, `gen_ai.agent.name`, and
+`cubepi.run_id` on every span — regardless of `record_content`. Use these
+to filter the trace backend to a single run and visually confirm what
+landed.
+
+For deeper audits, `JsonlSpanExporter` writes one line per span, so you can
+grep / `jq` the local files before pointing the same exporter at a remote
+backend:
+
+```bash
+jq -r 'select(.attributes["gen_ai.input.messages"]) | .attributes["gen_ai.input.messages"]' \
+   cubepi-traces/2026-05-19/*.jsonl
+```

--- a/website/docs/guides/tracing/getting-started.md
+++ b/website/docs/guides/tracing/getting-started.md
@@ -46,11 +46,8 @@ async def main() -> None:
         await agent.prompt("Say hello.")
         await agent.wait_for_idle()
     finally:
-        # Either is enough on its own:
-        #   await detach()                  # awaits the post-detach flush
-        #   await tracer.shutdown()          # flushes + closes exporters
-        detach()
-        await tracer.shutdown()
+        detach()                # unsubscribe hooks (sync, no flush)
+        await tracer.shutdown()  # flush + close exporters
 
 
 asyncio.run(main())
@@ -160,8 +157,12 @@ Optional, opt-in via `Tracer(record_content=True)`:
 `Tracer` is fine to share across agents — call `attach(agent)` multiple
 times. Each attach gets its own recorder so concurrent agents don't share
 span state, and MCP CLIENT spans route through the right Tracer based on
-which agent's `execute_tool` span is the parent. The same applies to
-`Meter`.
+which agent's `execute_tool` span is the parent.
+
+`Meter` is **not** yet safe to share across concurrent agents — its
+timing state lives on the instance, so overlapping runs can corrupt each
+other's metrics. Give each concurrent agent its own `Meter` for now;
+see the [Metrics guide](./metrics) for the workaround.
 
 ## Next
 

--- a/website/docs/guides/tracing/getting-started.md
+++ b/website/docs/guides/tracing/getting-started.md
@@ -46,8 +46,11 @@ async def main() -> None:
         await agent.prompt("Say hello.")
         await agent.wait_for_idle()
     finally:
-        detach()                # unsubscribe hooks (sync, no flush)
-        await tracer.shutdown()  # flush + close exporters
+        # Either is enough on its own:
+        #   await detach()                  # awaits the scheduled flush
+        #   await tracer.shutdown()          # flushes + closes exporters
+        detach()
+        await tracer.shutdown()
 
 
 asyncio.run(main())
@@ -154,15 +157,11 @@ Optional, opt-in via `Tracer(record_content=True)`:
 
 ## Multiple agents, one process
 
-`Tracer` is fine to share across agents — call `attach(agent)` multiple
-times. Each attach gets its own recorder so concurrent agents don't share
-span state, and MCP CLIENT spans route through the right Tracer based on
-which agent's `execute_tool` span is the parent.
-
-`Meter` is **not** yet safe to share across concurrent agents — its
-timing state lives on the instance, so overlapping runs can corrupt each
-other's metrics. Give each concurrent agent its own `Meter` for now;
-see the [Metrics guide](./metrics) for the workaround.
+Both `Tracer` and `Meter` are fine to share across agents — call
+`attach(agent)` multiple times. Each attach gets its own recorder /
+metric state so concurrent agents don't share span or histogram state,
+and MCP CLIENT spans route through the right Tracer based on which
+agent's `execute_tool` span is the parent.
 
 ## Next
 

--- a/website/docs/guides/tracing/getting-started.md
+++ b/website/docs/guides/tracing/getting-started.md
@@ -1,0 +1,170 @@
+---
+title: Getting Started
+sidebar_position: 2
+---
+
+# Getting Started with Tracing
+
+## Install the extra
+
+CubePi keeps OpenTelemetry an optional dependency:
+
+```bash
+pip install "cubepi[tracing]"
+```
+
+This pulls in `opentelemetry-sdk` and friends. Without the extra, the
+`cubepi.tracing` import raises a clear error so you find out at import time
+rather than mid-run.
+
+## Attach a Tracer
+
+The minimal end-to-end setup — local JSONL export:
+
+```python
+import asyncio
+from cubepi import Agent, Model
+from cubepi.providers.anthropic import AnthropicProvider
+from cubepi.tracing import Tracer
+from cubepi.tracing.exporters import JsonlSpanExporter
+
+
+async def main() -> None:
+    agent = Agent(
+        provider=AnthropicProvider(api_key="…"),
+        model=Model(id="claude-sonnet-4-5-20250929", provider="anthropic"),
+        system_prompt="Be helpful.",
+    )
+
+    tracer = Tracer(
+        service_name="my-bot",
+        agent_name="assistant",
+        exporters=[JsonlSpanExporter(directory="./cubepi-traces")],
+    )
+    detach = tracer.attach(agent)
+    try:
+        await agent.prompt("Say hello.")
+        await agent.wait_for_idle()
+    finally:
+        # Either is enough on its own:
+        #   await detach()                  # awaits the post-detach flush
+        #   await tracer.shutdown()          # flushes + closes exporters
+        detach()
+        await tracer.shutdown()
+
+
+asyncio.run(main())
+```
+
+The run produces one JSONL file per agent run:
+
+```text
+./cubepi-traces/
+  2026-05-19/
+    8e1c…-…-…-….jsonl       ← one run, one file, one span per line
+```
+
+Open it with any tool that reads OTLP/JSON or with `jq` directly:
+
+```bash
+jq -r '"\(.name)  \(.attributes."gen_ai.operation.name" // "")"' \
+   cubepi-traces/2026-05-19/*.jsonl
+# invoke_agent  invoke_agent
+# cubepi.turn
+# chat claude-sonnet-4-5-20250929  chat
+```
+
+## Span hierarchy
+
+For a single prompt with one LLM round-trip, the recorder produces three spans:
+
+```text
+invoke_agent assistant              [INTERNAL]   gen_ai.operation.name=invoke_agent
+└── cubepi.turn                     [INTERNAL]   cubepi.turn.index=0
+    └── chat <model>                [CLIENT]     gen_ai.operation.name=chat
+```
+
+When the model calls a tool, you get an extra layer per tool:
+
+```text
+invoke_agent assistant
+└── cubepi.turn                     ← turn index 0
+    ├── chat <model>                ← first round trip
+    └── execute_tool <tool_name>    ← gen_ai.tool.name, gen_ai.tool.call.id
+└── cubepi.turn                     ← turn index 1 (response after tool result)
+    └── chat <model>
+```
+
+For MCP tools the `execute_tool` span gets a CLIENT child:
+
+```text
+execute_tool <tool_name>            [INTERNAL]   cubepi-side wrapper
+└── tools/call <tool_name>          [CLIENT]     gen_ai.operation.name=execute_tool
+                                                  mcp.method.name=tools/call
+                                                  mcp.session.id=…
+                                                  server.address / server.port
+```
+
+The CLIENT span injects W3C `traceparent` into outgoing HTTP headers, so an
+instrumented MCP server can continue the trace.
+
+## Cancellation, errors, aborts
+
+The recorder treats cancellation as a control signal, not a failure:
+
+- `agent.abort()` mid-stream → spans close with `cubepi.aborted=true` and
+  `error.type=cubepi.aborted`, **status UNSET** (per OTel guidance — cancellation
+  isn't an error).
+- A provider raising → chat/turn/root close with **status ERROR**, an
+  `exception` event on the chat span, and `error.type` derived from the
+  exception class (`timeout`, `connection_error`, fully-qualified class name, …).
+- An MCP `tools/call` returning `isError=true` → CLIENT span closes
+  ERROR + `error.type=mcp.is_error`.
+
+Either way, `detach()` and `tracer.shutdown()` always close any span the run
+left open, so cancelled runs are still visible in your backend rather than
+silently disappearing.
+
+## What's on each span
+
+Defaults (no opt-in needed):
+
+- `invoke_agent` (root) — `gen_ai.operation.name`, `gen_ai.provider.name`,
+  `gen_ai.agent.name`, `cubepi.run_id`, `cubepi.agent.system_prompt.sha256`,
+  `cubepi.agent.tools` (names list), `cubepi.input_messages.count`,
+  `cubepi.output_messages.count`
+- `cubepi.turn` — `cubepi.turn.index`, `cubepi.turn.stop_reason`,
+  `cubepi.turn.tool_calls.count`, `cubepi.turn.terminated_by_tool`,
+  `cubepi.run_id`
+- `chat <model>` — `gen_ai.operation.name`, `gen_ai.provider.name`,
+  `gen_ai.request.model`, `gen_ai.request.max_tokens` / `temperature` /
+  `top_p`, `gen_ai.request.stream`, `gen_ai.usage.input_tokens` /
+  `output_tokens` / `cache_read_input_tokens` / `cache_creation_input_tokens` /
+  `reasoning_output_tokens`, `gen_ai.response.model` /
+  `finish_reasons` / `id`, `gen_ai.response.time_to_first_chunk`, plus
+  OpenAI-specific extras (`openai.api.type`, service tier, system fingerprint)
+- `execute_tool <tool_name>` — `gen_ai.operation.name=execute_tool`,
+  `gen_ai.tool.name`, `gen_ai.tool.call.id`, `gen_ai.tool.description`,
+  `gen_ai.tool.type`, `cubepi.tool.is_error`, `cubepi.tool.execution_mode`
+- `tools/call <tool_name>` (MCP only) — `mcp.method.name`, `mcp.session.id`,
+  `mcp.protocol.version`, `server.address`, `server.port`, `gen_ai.tool.name`
+
+Optional, opt-in via `Tracer(record_content=True)`:
+`gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`,
+`gen_ai.tool.definitions`, `gen_ai.tool.call.arguments`,
+`gen_ai.tool.call.result`, `cubepi.llm.raw_request`,
+`cubepi.llm.raw_response`. See [Content & Redaction](./content-recording).
+
+## Multiple agents, one process
+
+`Tracer` is fine to share across agents — call `attach(agent)` multiple
+times. Each attach gets its own recorder so concurrent agents don't share
+span state, and MCP CLIENT spans route through the right Tracer based on
+which agent's `execute_tool` span is the parent. The same applies to
+`Meter`.
+
+## Next
+
+- [OTLP & Backends](./otlp) — Jaeger, Tempo, Honeycomb, Datadog, …
+- [Content Recording & Redaction](./content-recording)
+- [Metrics](./metrics)

--- a/website/docs/guides/tracing/metrics.md
+++ b/website/docs/guides/tracing/metrics.md
@@ -68,18 +68,23 @@ boundaries (in seconds):
 OTel exposes these as the `_advisory` boundaries; backends are free to use
 them as-is or override.
 
-## One agent per Meter, for now
+## Concurrent agents on one Meter
 
-Today `Meter` keeps its timing and attribute state (`_chat_open_ns`,
-`_chat_attrs`, `_agent_open_ns`, etc.) on the instance, not per attach.
-Two agents attached to the same `Meter` running concurrently can overwrite
-each other's open-ns timestamps and corrupt the recorded durations or
-token counts.
+Like `Tracer`, one `Meter` instance is safe to attach to multiple agents
+in the same process. Each `attach()` call gets its own internal
+`_MeterState` holding the open-ns timestamps and attribute dicts, so
+overlapping runs from two agents never share or overwrite each other's
+metric state.
 
-If you have several concurrent agents in one process, give each its own
-`Meter` (they can share a `Resource` so service-level attributes match).
-A future change will scope state per `attach()` so a single `Meter` is
-safe across agents.
+```python
+meter = Meter(resource=tracer.resource, exporters=[exporter])
+meter.attach(agent_a)
+meter.attach(agent_b)
+```
+
+Both agents emit independent duration / token / TTFC observations,
+filterable by `gen_ai.agent.name` (set at the `Resource` level when
+`Tracer(agent_name=…)` is used) or by `gen_ai.request.model`.
 
 ## Shutting down
 

--- a/website/docs/guides/tracing/metrics.md
+++ b/website/docs/guides/tracing/metrics.md
@@ -1,0 +1,110 @@
+---
+title: Metrics
+sidebar_position: 5
+---
+
+# Metrics with `Meter`
+
+Spans tell you the shape of one run; histograms tell you the shape of the
+fleet. `cubepi.tracing.Meter` mirrors `Tracer` and emits the OTel GenAI
+metric set so dashboards work out of the box.
+
+## What it emits
+
+| Instrument | Description |
+|---|---|
+| `gen_ai.client.operation.duration` | Histogram (seconds) — recorded for `chat`, `execute_tool`, and `invoke_agent` on close |
+| `gen_ai.client.operation.time_to_first_chunk` | Histogram (seconds) — recorded for `chat` when at least one content chunk arrived |
+| `gen_ai.client.token.usage` | Histogram (`{token}`) — one observation per `gen_ai.token.type` (`input`, `output`) per chat response |
+
+Each point carries the operation, provider, and request model attributes
+so failed / cancelled requests (where no response body / response model
+landed) are still groupable by what was asked for:
+
+- `gen_ai.operation.name` — `chat` / `execute_tool` / `invoke_agent`
+- `gen_ai.provider.name` — `anthropic`, `openai`, `openai_responses`, …
+- `gen_ai.request.model` — e.g. `claude-sonnet-4-5-20250929`
+- `gen_ai.response.model` — e.g. `claude-sonnet-4-5-20250929` (success only)
+- `gen_ai.token.type` — `input` or `output` (token usage only)
+
+## Attaching a Meter
+
+```python
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter,
+)
+from cubepi.tracing import Tracer, Meter
+from cubepi.tracing.exporters import JsonlSpanExporter
+
+tracer = Tracer(
+    service_name="my-bot",
+    agent_name="assistant",
+    exporters=[JsonlSpanExporter(directory="./cubepi-traces")],
+)
+meter = Meter(
+    resource=tracer.resource,        # share Resource so service.* matches spans
+    exporters=[
+        OTLPMetricExporter(endpoint="http://otel-collector:4318/v1/metrics"),
+    ],
+)
+
+tracer.attach(agent)
+meter.attach(agent)
+```
+
+`Meter.attach()` is independent from `Tracer.attach()`. You can run either
+on its own; the recommended setup is both, sharing one Resource so the
+backend treats them as the same service.
+
+## Bucket boundaries
+
+The duration histograms ship with the OTel GenAI semconv's recommended
+boundaries (in seconds):
+
+```text
+0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60, 120, 300
+```
+
+OTel exposes these as the `_advisory` boundaries; backends are free to use
+them as-is or override.
+
+## Concurrent agents on one Meter
+
+Like `Tracer`, one `Meter` instance is safe to attach to multiple agents in
+the same process. Each `attach()` gets its own internal state so concurrent
+agents never share timing or attribute dicts.
+
+## Shutting down
+
+```python
+finally:
+    detach()                  # detach from Tracer + Meter
+    await tracer.shutdown()
+    await meter.shutdown()
+```
+
+`Meter.shutdown()` awaits a flush of the metric reader, then closes it.
+`PeriodicExportingMetricReader` exports on a fixed interval (60 s by
+default) — `shutdown` is the only way to guarantee the final window lands
+before the process exits.
+
+## Querying example (Honeycomb)
+
+p95 chat latency by provider over the last hour:
+
+```text
+VISUALIZE  P95(duration_s)
+GROUP BY   gen_ai.provider.name
+WHERE      gen_ai.operation.name = "chat"
+TIME       last 1 hour
+```
+
+Token usage by model:
+
+```text
+VISUALIZE  SUM(token_count)
+GROUP BY   gen_ai.request.model, gen_ai.token.type
+WHERE      gen_ai.operation.name = "chat"
+```
+
+Substitute your backend's query DSL — same attributes, same aggregations.

--- a/website/docs/guides/tracing/metrics.md
+++ b/website/docs/guides/tracing/metrics.md
@@ -68,11 +68,18 @@ boundaries (in seconds):
 OTel exposes these as the `_advisory` boundaries; backends are free to use
 them as-is or override.
 
-## Concurrent agents on one Meter
+## One agent per Meter, for now
 
-Like `Tracer`, one `Meter` instance is safe to attach to multiple agents in
-the same process. Each `attach()` gets its own internal state so concurrent
-agents never share timing or attribute dicts.
+Today `Meter` keeps its timing and attribute state (`_chat_open_ns`,
+`_chat_attrs`, `_agent_open_ns`, etc.) on the instance, not per attach.
+Two agents attached to the same `Meter` running concurrently can overwrite
+each other's open-ns timestamps and corrupt the recorded durations or
+token counts.
+
+If you have several concurrent agents in one process, give each its own
+`Meter` (they can share a `Resource` so service-level attributes match).
+A future change will scope state per `attach()` so a single `Meter` is
+safe across agents.
 
 ## Shutting down
 

--- a/website/docs/guides/tracing/metrics.md
+++ b/website/docs/guides/tracing/metrics.md
@@ -48,13 +48,14 @@ meter = Meter(
     ],
 )
 
-tracer.attach(agent)
-meter.attach(agent)
+tracer_detach = tracer.attach(agent)
+meter_detach = meter.attach(agent)
 ```
 
-`Meter.attach()` is independent from `Tracer.attach()`. You can run either
-on its own; the recommended setup is both, sharing one Resource so the
-backend treats them as the same service.
+`Meter.attach()` is independent from `Tracer.attach()`. Each returns its
+own detach callable — capture both. You can run either on its own; the
+recommended setup is both, sharing one Resource so the backend treats
+them as the same service.
 
 ## Bucket boundaries
 
@@ -90,10 +91,15 @@ filterable by `gen_ai.agent.name` (set at the `Resource` level when
 
 ```python
 finally:
-    detach()                  # detach from Tracer + Meter
+    tracer_detach()           # closes any spans a cancelled run left open
+    meter_detach()            # unsubscribes the meter's listeners
     await tracer.shutdown()
     await meter.shutdown()
 ```
+
+Order matters: run `tracer_detach()` before `tracer.shutdown()` so any
+spans an in-flight cancellation left open get closed and exported in
+the same flush.
 
 `Meter.shutdown()` awaits a flush of the metric reader, then closes it.
 `PeriodicExportingMetricReader` exports on a fixed interval (60 s by

--- a/website/docs/guides/tracing/otlp.md
+++ b/website/docs/guides/tracing/otlp.md
@@ -141,11 +141,20 @@ the background. To make sure buffered spans land before your process exits:
 
 ```python
 finally:
-    detach()                    # unsubscribes; does NOT block on flush
+    detach()                    # closes any spans a cancelled run left open
     await tracer.shutdown()     # awaits force_flush, then shuts the SDK down
 ```
 
-`detach()` returns `None` — it unsubscribes the recorder synchronously but
-does not flush. Always pair it with `await tracer.shutdown()` (or
-`await tracer.force_flush()`) so buffered spans land before the process
-exits. `shutdown()` is idempotent; calling it twice is a no-op.
+`detach()` runs its synchronous cleanup (unsubscribe + close any spans an
+in-flight cancellation left open) immediately, then schedules a flush as
+an `asyncio.Task` on the running loop and returns it. Two valid patterns:
+
+- **Both** `detach(); await tracer.shutdown()` — the safest belt-and-braces
+  approach; `shutdown()` is idempotent.
+- **Awaited detach** `await detach()` — the returned Task awaits
+  `force_flush`, so this single call is enough when you're not also
+  shutting down the Tracer.
+
+Outside an async context (no running loop) `detach()` returns `None` — the
+sync part has run, but the flush is the caller's responsibility via
+`await tracer.shutdown()`.

--- a/website/docs/guides/tracing/otlp.md
+++ b/website/docs/guides/tracing/otlp.md
@@ -102,26 +102,22 @@ OTLP target.
 
 ## Continuing an upstream trace
 
-When cubepi runs inside a service that already has its own traces — e.g. an
-HTTP handler — you usually want the agent run rooted under the inbound trace
-rather than starting a new one. Pass the parent context when attaching:
+`Tracer.attach(agent)` currently roots every agent run in its own trace —
+there is no public API yet for passing an inbound `traceparent` so that
+spans nest under a caller's HTTP handler trace. The internal hook
+(`Tracer._make_parent_context`) exists for a future `run_scope` feature;
+until that ships, agent runs and the surrounding service trace are linked
+only by their resource attributes (`service.name`, `gen_ai.agent.name`,
+`cubepi.run_id`).
 
-```python
-from opentelemetry import trace
+If you need the upstream trace to continue into cubepi today, the
+workaround is to set the OTel current span yourself before calling
+`agent.prompt(...)` and let the agent's spans inherit it via OTel's
+ambient context — cubepi never overrides an active parent.
 
-parent_span = trace.get_current_span()  # set by your web framework's middleware
-parent_ctx = parent_span.get_span_context()
-
-tracer = Tracer(service_name="my-bot", exporters=[exporter])
-
-# Pass parent_trace_id / parent_span_id to root the agent's spans under it.
-# (See cubepi.tracing.Tracer for the internal helper used by run_scope.)
-detach = tracer.attach(agent)
-```
-
-On the way out, MCP `tools/call` automatically injects W3C `traceparent` as
-an HTTP header so an instrumented MCP server can continue the trace
-through to its own backend.
+On the way out, MCP `tools/call` does inject W3C `traceparent` as an HTTP
+header automatically, so an instrumented MCP server downstream of the
+agent can continue the trace through to its own backend.
 
 ## Combining exporters
 
@@ -145,12 +141,11 @@ the background. To make sure buffered spans land before your process exits:
 
 ```python
 finally:
-    detach()                    # closes any spans a cancelled run left open
+    detach()                    # unsubscribes; does NOT block on flush
     await tracer.shutdown()     # awaits force_flush, then shuts the SDK down
 ```
 
-`shutdown()` is idempotent; calling it twice is a no-op.
-
-Alternatively, `await detach()` directly — the Task it returns awaits the
-flush, so a `finally: await detach()` block is enough without calling
-`shutdown()` separately. The two together is the safest pattern.
+`detach()` returns `None` — it unsubscribes the recorder synchronously but
+does not flush. Always pair it with `await tracer.shutdown()` (or
+`await tracer.force_flush()`) so buffered spans land before the process
+exits. `shutdown()` is idempotent; calling it twice is a no-op.

--- a/website/docs/guides/tracing/otlp.md
+++ b/website/docs/guides/tracing/otlp.md
@@ -1,0 +1,156 @@
+---
+title: OTLP & Backends
+sidebar_position: 3
+---
+
+# Exporting to OTLP Backends
+
+`cubepi.tracing.Tracer` accepts any `opentelemetry.sdk.trace.export.SpanExporter`,
+so anything in the OpenTelemetry ecosystem works. Pick the wire format
+(HTTP or gRPC), point it at your collector, hand the exporter to the Tracer.
+
+## HTTP (OTLP/HTTP)
+
+```bash
+pip install "cubepi[tracing]" opentelemetry-exporter-otlp-proto-http
+```
+
+```python
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)
+from cubepi.tracing import Tracer
+
+tracer = Tracer(
+    service_name="my-bot",
+    service_version="1.4.2",
+    deployment_environment="prod",
+    agent_name="assistant",
+    exporters=[
+        OTLPSpanExporter(
+            endpoint="http://otel-collector:4318/v1/traces",
+            headers={"x-api-key": "…"},  # backend-specific
+        ),
+    ],
+)
+```
+
+`service_name`, `service_version`, `deployment_environment`, and `agent_name`
+flow through as OTel Resource attributes (`service.*`, `gen_ai.agent.name`,
+`deployment.environment.name`) so backends can group runs without further
+config.
+
+## gRPC (OTLP/gRPC)
+
+```bash
+pip install "cubepi[tracing]" opentelemetry-exporter-otlp-proto-grpc
+```
+
+```python
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+    OTLPSpanExporter,
+)
+
+exporter = OTLPSpanExporter(endpoint="otel-collector:4317", insecure=True)
+tracer = Tracer(service_name="my-bot", exporters=[exporter])
+```
+
+## Backend recipes
+
+These all consume OTLP — the only thing that differs is the endpoint and
+auth header.
+
+### Jaeger (>=1.50)
+
+Jaeger natively accepts OTLP/HTTP on port 4318:
+
+```python
+OTLPSpanExporter(endpoint="http://jaeger:4318/v1/traces")
+```
+
+### Grafana Tempo
+
+Send to your collector, or directly to Tempo's OTLP endpoint:
+
+```python
+OTLPSpanExporter(endpoint="http://tempo:4318/v1/traces")
+```
+
+### Honeycomb
+
+```python
+OTLPSpanExporter(
+    endpoint="https://api.honeycomb.io/v1/traces",
+    headers={"x-honeycomb-team": HONEYCOMB_API_KEY},
+)
+```
+
+### Datadog (via the OTel collector)
+
+Configure the collector with the Datadog exporter, then ship to it:
+
+```python
+OTLPSpanExporter(endpoint="http://otel-collector:4318/v1/traces")
+```
+
+Datadog also accepts native OTLP HTTP directly — same shape, different URL.
+
+### AWS X-Ray (via collector)
+
+The OTel collector includes the AWS X-Ray exporter; treat it like any other
+OTLP target.
+
+## Continuing an upstream trace
+
+When cubepi runs inside a service that already has its own traces — e.g. an
+HTTP handler — you usually want the agent run rooted under the inbound trace
+rather than starting a new one. Pass the parent context when attaching:
+
+```python
+from opentelemetry import trace
+
+parent_span = trace.get_current_span()  # set by your web framework's middleware
+parent_ctx = parent_span.get_span_context()
+
+tracer = Tracer(service_name="my-bot", exporters=[exporter])
+
+# Pass parent_trace_id / parent_span_id to root the agent's spans under it.
+# (See cubepi.tracing.Tracer for the internal helper used by run_scope.)
+detach = tracer.attach(agent)
+```
+
+On the way out, MCP `tools/call` automatically injects W3C `traceparent` as
+an HTTP header so an instrumented MCP server can continue the trace
+through to its own backend.
+
+## Combining exporters
+
+You can pass multiple exporters and they'll receive every span. Common
+pattern — JSONL for local debugging plus OTLP for the production backend:
+
+```python
+tracer = Tracer(
+    service_name="my-bot",
+    exporters=[
+        JsonlSpanExporter(directory="./cubepi-traces"),
+        OTLPSpanExporter(endpoint="https://api.honeycomb.io/v1/traces", headers={…}),
+    ],
+)
+```
+
+## Flushing
+
+`Tracer` uses `BatchSpanProcessor` under the hood, so spans are exported in
+the background. To make sure buffered spans land before your process exits:
+
+```python
+finally:
+    detach()                    # closes any spans a cancelled run left open
+    await tracer.shutdown()     # awaits force_flush, then shuts the SDK down
+```
+
+`shutdown()` is idempotent; calling it twice is a no-op.
+
+Alternatively, `await detach()` directly — the Task it returns awaits the
+flush, so a `finally: await detach()` block is enough without calling
+`shutdown()` separately. The two together is the safest pattern.

--- a/website/docs/guides/tracing/overview.md
+++ b/website/docs/guides/tracing/overview.md
@@ -1,0 +1,74 @@
+---
+title: Tracing Overview
+sidebar_position: 1
+---
+
+# Tracing Overview
+
+CubePi emits [OpenTelemetry](https://opentelemetry.io/) spans that follow the
+[GenAI Semantic Conventions v1.41](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+so any OTel-compatible backend (Jaeger, Tempo, Honeycomb, Datadog, AWS X-Ray,
+Azure Monitor, …) can ingest agent runs without custom instrumentation.
+
+Attach a `Tracer` to an `Agent` and every prompt produces a tree of spans you
+can pivot, query, and join with the rest of your service traces:
+
+```text
+invoke_agent <agent_name>              [INTERNAL]    one per agent.prompt()
+└── cubepi.turn                        [INTERNAL]    one per LLM round-trip
+    ├── chat <model>                   [CLIENT]      the LLM call itself
+    └── execute_tool <tool_name>       [INTERNAL]    each tool invocation
+        └── tools/call <tool_name>     [CLIENT]      (MCP tools only)
+```
+
+Each layer carries standard `gen_ai.*` attributes — `gen_ai.operation.name`,
+`gen_ai.request.model`, `gen_ai.provider.name`, `gen_ai.usage.input_tokens`,
+`gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`, …
+
+## What ships out of the box
+
+- **Tracer** — builds an SDK `TracerProvider`, attaches one
+  `BatchSpanProcessor` per exporter, wires the cubepi event stream into spans.
+- **Meter** — sibling for OTel histograms:
+  `gen_ai.client.operation.duration`, `gen_ai.client.operation.time_to_first_chunk`,
+  `gen_ai.client.token.usage`.
+- **JsonlSpanExporter** — write one JSON line per span to
+  `./cubepi-traces/<date>/<run_id>.jsonl`. Useful for local dev and offline
+  debugging; works with any OTel viewer that reads JSONL.
+- **OTLP** — bring your own exporter via `opentelemetry-exporter-otlp-proto-http`
+  (HTTP) or `…-grpc` and hand it to `Tracer(exporters=[…])`.
+- **W3C trace context propagation** — outgoing MCP calls inject the active
+  `traceparent` as an HTTP header so an instrumented MCP server can continue
+  the trace.
+
+## What it costs
+
+- One pure-Python recorder per agent run subscribing to the agent's event
+  stream and the provider's listener registry — no monkey-patching, no extra
+  threads.
+- One OTel SDK span per layer above. `BatchSpanProcessor` batches export off
+  the hot path.
+- **No payloads are recorded by default.** `gen_ai.input.messages`,
+  `gen_ai.output.messages`, raw request/response, and tool args/results all
+  require explicit opt-in via `record_content=True` so you don't accidentally
+  ship PII to your backend. See [Content & Redaction](./content-recording).
+
+## When to use each piece
+
+| You want | Use |
+|---|---|
+| Trace one local agent run and inspect a JSONL file | `Tracer` + `JsonlSpanExporter` |
+| Ship to Jaeger / Tempo / Honeycomb / Datadog | `Tracer` + OTLP exporter |
+| Latency + token histograms next to the spans | `Meter` alongside `Tracer` |
+| Record prompts / model outputs for evaluation | `Tracer(record_content=True)` |
+| Redact PII before it leaves the process | `Tracer(redact=…)` |
+| Continue a trace from an upstream service | `Tracer(resource=…)` + W3C `traceparent` (auto for MCP, manual for HTTP) |
+
+## Where to go next
+
+- [Getting Started](./getting-started) — install the extra and emit your
+  first spans
+- [OTLP & Backends](./otlp) — point cubepi at Jaeger, Tempo, Honeycomb, …
+- [Content Recording & Redaction](./content-recording) — record prompts and
+  responses safely
+- [Metrics](./metrics) — histograms via `Meter`

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -39,6 +39,11 @@ working tool-using agent in under five minutes.
 - **MCP loaders.** Point at any
   [Model Context Protocol](https://modelcontextprotocol.io) server
   (HTTP or stdio) and get back a list of `AgentTool`s.
+- **OpenTelemetry built in.** Attach a `Tracer` and every prompt
+  produces a tree of OTel spans aligned with the GenAI Semantic
+  Conventions — works with Jaeger, Tempo, Honeycomb, Datadog, or any
+  OTLP-compatible backend. No payloads recorded by default; opt in
+  with `record_content=True` and a `redact` callback.
 
 ## Where to go next
 
@@ -48,6 +53,7 @@ working tool-using agent in under five minutes.
 | Understand the building blocks | [Getting Started → Core Concepts](./getting-started/core-concepts) |
 | Wire a real tool-using agent | [Guides → Building Your First Agent](./guides/agents/first-agent) |
 | Persist a conversation across restarts | [Guides → SQLite Checkpointing](./guides/checkpointing/sqlite) |
+| Ship traces to Jaeger / Tempo / Honeycomb | [Guides → Tracing](./guides/tracing/overview) |
 | Look up a specific symbol | [API Reference](./api/) |
 | See full working examples | [Recipes](./recipes/weather-agent) |
 | Port an existing langgraph agent | [Migration → From langgraph](./migration/from-langgraph) |

--- a/website/scripts/build_api_reference.py
+++ b/website/scripts/build_api_reference.py
@@ -18,7 +18,8 @@ MODULES = [
     ("cubepi.checkpointer", "Checkpointing", 3),
     ("cubepi.middleware",   "Middleware",    4),
     ("cubepi.mcp",          "MCP",           5),
-    ("cubepi.utils",        "Utils",         6),
+    ("cubepi.tracing",      "Tracing",       6),
+    ("cubepi.utils",        "Utils",         7),
 ]
 
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -42,6 +42,13 @@ const sidebars: SidebarsConfig = {
           'guides/mcp/loading',
           'guides/mcp/auth',
         ]},
+        { type: 'category', label: 'Tracing', items: [
+          'guides/tracing/overview',
+          'guides/tracing/getting-started',
+          'guides/tracing/otlp',
+          'guides/tracing/content-recording',
+          'guides/tracing/metrics',
+        ]},
       ],
     },
     {
@@ -54,6 +61,7 @@ const sidebars: SidebarsConfig = {
         'api/cubepi-checkpointer',
         'api/cubepi-middleware',
         'api/cubepi-mcp',
+        'api/cubepi-tracing',
         'api/cubepi-utils',
       ],
     },


### PR DESCRIPTION
## Summary

The OpenTelemetry tracing feature shipped through PRs #82–#88 but the website still had no user-facing docs for it. This PR adds the missing section.

**New guide pages** under \`docs/guides/tracing/\`:

| Page | What it covers |
|---|---|
| \`overview.md\` | What cubepi.tracing emits, span hierarchy, opt-in content note, when-to-use matrix |
| \`getting-started.md\` | Install \`cubepi[tracing]\`, JSONL exporter, default vs opt-in attrs, cancellation/error handling |
| \`otlp.md\` | OTLP HTTP+gRPC setup, recipes for Jaeger / Tempo / Honeycomb / Datadog / AWS X-Ray, parent-context propagation |
| \`content-recording.md\` | \`record_content=True\` opt-in, per-span payload table, \`redact\` callback patterns, size budgets |
| \`metrics.md\` | \`Meter\` setup, three histograms emitted, concurrent-agent safety, example Honeycomb queries |

**Infrastructure**:

- \`website/scripts/build_api_reference.py\` — add \`cubepi.tracing\` to \`MODULES\` so the API reference page is auto-generated at build time (the \`.mdx\` itself is gitignored — generated)
- \`website/sidebars.ts\` — new Tracing category under Guides + \`cubepi-tracing\` under API Reference
- \`website/docs/api/index.mdx\` — list \`cubepi.tracing\` in the module inventory
- \`website/docs/intro.md\` — promote OpenTelemetry support in the feature list + add a \"ship traces\" row to the where-to-next table

## Test plan
- [x] Apiref generator runs cleanly and writes \`cubepi-tracing.mdx\` (4 symbols)
- [ ] CI \`build-and-check\` workflow succeeds (local build OOMs but the same script ran fine on prior PRs)
- [ ] Visual check of the rendered pages once Cloudflare preview deploys