### PR TITLE
feat(tracing): tracing_context() for per-run tags + metadata

### DIFF
--- a/cubepi/tracing/__init__.py
+++ b/cubepi/tracing/__init__.py
@@ -17,6 +17,7 @@ except ImportError as exc:  # pragma: no cover — exercised only without the ex
         "Install it via: pip install cubepi[tracing]"
     ) from exc
 
+from cubepi.tracing.context import tracing_context
 from cubepi.tracing.exporters import JsonlSpanExporter
 from cubepi.tracing.meter import Meter
 from cubepi.tracing.schema import SCHEMA_URL
@@ -27,4 +28,5 @@ __all__ = [
     "Meter",
     "SCHEMA_URL",
     "Tracer",
+    "tracing_context",
 ]

--- a/cubepi/tracing/context.py
+++ b/cubepi/tracing/context.py
@@ -3,9 +3,15 @@
 Sets a contextvar-scoped ``tags`` / ``metadata`` payload that the
 :class:`~cubepi.tracing.recorder.Recorder` reads on ``AgentStartEvent``
 and stamps onto the ``invoke_agent`` span. Inspired by LangSmith's
-``langsmith.run_helpers.tracing_context`` (same contextvar mechanism;
-different attribute namespace — cubepi uses ``cubepi.*`` to avoid
-colliding with the OTel GenAI semconv reserved names).
+``langsmith.run_helpers.tracing_context`` (same contextvar mechanism).
+
+Namespacing:
+
+- Tags use a single attribute ``cubepi.tags`` (tuple of strings).
+- User metadata is namespaced under ``cubepi.metadata.*`` so that
+  recorder-owned schema keys (``cubepi.run_id``,
+  ``cubepi.turn.index``, …) can never be overridden by
+  caller-supplied values.
 
 Usage::
 
@@ -20,7 +26,7 @@ Usage::
 Resulting ``invoke_agent`` span attributes:
 
 - ``cubepi.tags`` = ``("beta-arm",)``
-- ``cubepi.user_id`` = ``"u-42"``
+- ``cubepi.metadata.user_id`` = ``"u-42"``
 
 Multiple nested ``tracing_context`` blocks merge: inner tags are
 appended, inner metadata keys override outer ones (last-write-wins).
@@ -54,9 +60,12 @@ def tracing_context(
     stamps them on the ``invoke_agent`` span as:
 
     - ``cubepi.tags`` — tuple of strings (OTel attribute type)
-    - one attribute per metadata key, prefixed with ``cubepi.``
-      (e.g. ``metadata={"user_id": "u-42"}`` →
-      ``cubepi.user_id = "u-42"``)
+    - one attribute per metadata key, namespaced under
+      ``cubepi.metadata.*`` (e.g. ``metadata={"user_id": "u-42"}`` →
+      ``cubepi.metadata.user_id = "u-42"``). The dedicated
+      sub-namespace keeps recorder-owned schema keys
+      (``cubepi.run_id``, ``cubepi.turn.index``, …) safe from
+      caller-supplied collisions.
 
     The contextvar nature means this works for concurrent agents:
     each asyncio task tree gets its own value. Nested blocks merge

--- a/cubepi/tracing/context.py
+++ b/cubepi/tracing/context.py
@@ -1,0 +1,97 @@
+"""Per-run tagging / metadata context for cubepi.tracing.
+
+Sets a contextvar-scoped ``tags`` / ``metadata`` payload that the
+:class:`~cubepi.tracing.recorder.Recorder` reads on ``AgentStartEvent``
+and stamps onto the ``invoke_agent`` span. Inspired by LangSmith's
+``langsmith.run_helpers.tracing_context`` (same contextvar mechanism;
+different attribute namespace — cubepi uses ``cubepi.*`` to avoid
+colliding with the OTel GenAI semconv reserved names).
+
+Usage::
+
+    from cubepi.tracing import tracing_context
+
+    async with tracer.attached(agent):
+        with tracing_context(tags=["beta-arm"], metadata={"user_id": "u-42"}):
+            await agent.prompt("hello")
+        # the next run does NOT carry those tags
+        await agent.prompt("goodbye")
+
+Resulting ``invoke_agent`` span attributes:
+
+- ``cubepi.tags`` = ``("beta-arm",)``
+- ``cubepi.user_id`` = ``"u-42"``
+
+Multiple nested ``tracing_context`` blocks merge: inner tags are
+appended, inner metadata keys override outer ones (last-write-wins).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+from typing import Any, Iterator
+
+
+_run_metadata: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
+    "cubepi.tracing.run_metadata", default={}
+)
+
+_run_tags: contextvars.ContextVar[tuple[str, ...]] = contextvars.ContextVar(
+    "cubepi.tracing.run_tags", default=()
+)
+
+
+@contextlib.contextmanager
+def tracing_context(
+    *,
+    tags: list[str] | tuple[str, ...] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Iterator[None]:
+    """Scope tags / metadata onto agent runs started inside this block.
+
+    The recorder reads these contextvars on ``AgentStartEvent`` and
+    stamps them on the ``invoke_agent`` span as:
+
+    - ``cubepi.tags`` — tuple of strings (OTel attribute type)
+    - one attribute per metadata key, prefixed with ``cubepi.``
+      (e.g. ``metadata={"user_id": "u-42"}`` →
+      ``cubepi.user_id = "u-42"``)
+
+    The contextvar nature means this works for concurrent agents:
+    each asyncio task tree gets its own value. Nested blocks merge
+    additively (tags concatenate; metadata is union with inner
+    keys winning).
+
+    Args:
+        tags: Tags to apply to runs started in this scope. Stored as
+            a tuple on the span so it round-trips through OTel's
+            attribute serializer.
+        metadata: Per-run key/value pairs. Values must be types that
+            OTel attributes accept (str, bool, int, float, or a
+            tuple/list of those); other shapes will be silently
+            dropped by the recorder.
+    """
+    new_meta = {**_run_metadata.get(), **(metadata or {})}
+    new_tags = tuple(_run_tags.get()) + tuple(tags or ())
+    meta_token = _run_metadata.set(new_meta)
+    tag_token = _run_tags.set(new_tags)
+    try:
+        yield
+    finally:
+        _run_metadata.reset(meta_token)
+        _run_tags.reset(tag_token)
+
+
+def _current_tags() -> tuple[str, ...]:
+    """Internal: return the active tag tuple for the current task.
+
+    Called by :class:`~cubepi.tracing.recorder.Recorder` on
+    ``_on_agent_start``; not part of the public API.
+    """
+    return _run_tags.get()
+
+
+def _current_metadata() -> dict[str, Any]:
+    """Internal: return the active metadata dict for the current task."""
+    return _run_metadata.get()

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -431,6 +431,29 @@ class Recorder:
         # that vary per-run set their own value via _ensure_agent_name.
         self._run = _RunState(run_id=run_id, agent_span=span)
 
+        # Stamp any tags / metadata set via ``cubepi.tracing.tracing_context``
+        # for this run. Per-task contextvar scoping means concurrent
+        # agents each see their own values; nested ``tracing_context``
+        # blocks merge before reaching here.
+        try:
+            from cubepi.tracing.context import _current_metadata, _current_tags
+
+            tags = _current_tags()
+            if tags:
+                span.set_attribute("cubepi.tags", tags)
+            metadata = _current_metadata()
+            for key, value in metadata.items():
+                # OTel attribute values are limited to scalar primitives
+                # and homogeneous sequences. Anything else is silently
+                # dropped here — better to lose one tag than corrupt the
+                # whole span.
+                try:
+                    span.set_attribute(f"cubepi.{key}", value)
+                except (TypeError, ValueError):
+                    pass
+        except ImportError:  # pragma: no cover — context module always available
+            pass
+
         # Seed the transcript from the agent's existing conversation
         # history. The cubepi agent loop only emits MessageStartEvent
         # for newly-introduced messages (new prompts in ``run_agent_loop``,

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -435,6 +435,14 @@ class Recorder:
         # for this run. Per-task contextvar scoping means concurrent
         # agents each see their own values; nested ``tracing_context``
         # blocks merge before reaching here.
+        #
+        # User metadata is namespaced under ``cubepi.metadata.*`` so
+        # that keys like ``run_id`` / ``turn_index`` / ``agent.tools``
+        # — which the recorder owns under ``cubepi.*`` — can never be
+        # overwritten by caller-supplied values. Reserved cubepi
+        # schema keys (especially ``cubepi.run_id`` which the JSONL
+        # exporter shards on) must stay recorder-controlled (codex P2
+        # on PR #92).
         try:
             from cubepi.tracing.context import _current_metadata, _current_tags
 
@@ -448,7 +456,7 @@ class Recorder:
                 # dropped here — better to lose one tag than corrupt the
                 # whole span.
                 try:
-                    span.set_attribute(f"cubepi.{key}", value)
+                    span.set_attribute(f"cubepi.metadata.{key}", value)
                 except (TypeError, ValueError):
                     pass
         except ImportError:  # pragma: no cover — context module always available

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -914,6 +914,7 @@ class TestAttachedContextManager:
         assert tracer._shutdown is True
         assert exporter.spans
 
+
 class TestTracingContext:
     """``cubepi.tracing.tracing_context`` sets per-task tags +
     metadata that the recorder stamps onto the invoke_agent span."""
@@ -1031,6 +1032,43 @@ class TestTracingContext:
         assert attrs.get("cubepi.metadata.good_str") == "yes"
         assert attrs.get("cubepi.metadata.good_int") == 42
         assert "cubepi.metadata.bad_dict" not in attrs
+
+    async def test_metadata_set_attribute_typeerror_is_swallowed(self, monkeypatch):
+        """OTel SDK silently drops most invalid attribute values, but
+        a non-conforming type could in principle raise TypeError /
+        ValueError from ``set_attribute``. The recorder must swallow
+        per-key so one bad metadata entry can't crash the whole span
+        (covers the defensive ``except (TypeError, ValueError)``
+        branch)."""
+        from cubepi.tracing import tracing_context
+        from opentelemetry.sdk.trace import Span as _SdkSpan
+
+        agent, provider, exporter, tracer = await _build()
+        provider.append_responses([faux_assistant_message("ok")])
+
+        # Patch set_attribute to raise on a specific cubepi.metadata.*
+        # key while letting every other attribute go through. The
+        # recorder writes many cubepi.* / gen_ai.* attrs at agent
+        # start, so we need to be surgical.
+        original = _SdkSpan.set_attribute
+
+        def _selective_set_attribute(self, key, value):
+            if key == "cubepi.metadata.boom":
+                raise TypeError("simulated OTel reject")
+            return original(self, key, value)
+
+        monkeypatch.setattr(_SdkSpan, "set_attribute", _selective_set_attribute)
+
+        with tracing_context(metadata={"boom": object(), "good": "yes"}):
+            await agent.prompt("hi")
+            await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = next(s for s in exporter.spans if s.name == "invoke_agent")
+        attrs = _attrs(root)
+        # bad key swallowed; good key landed.
+        assert "cubepi.metadata.boom" not in attrs
+        assert attrs.get("cubepi.metadata.good") == "yes"
 
     async def test_metadata_cannot_clobber_reserved_cubepi_attrs(self):
         """User-supplied metadata keys must not be able to overwrite

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -914,6 +914,124 @@ class TestAttachedContextManager:
         assert tracer._shutdown is True
         assert exporter.spans
 
+class TestTracingContext:
+    """``cubepi.tracing.tracing_context`` sets per-task tags +
+    metadata that the recorder stamps onto the invoke_agent span."""
+
+    async def test_tags_land_on_invoke_agent_span(self):
+        from cubepi.tracing import tracing_context
+
+        agent, provider, exporter, tracer = await _build()
+        provider.append_responses([faux_assistant_message("ok")])
+
+        with tracing_context(tags=["beta-arm", "test-suite"]):
+            await agent.prompt("hi")
+            await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = next(s for s in exporter.spans if s.name == "invoke_agent")
+        attrs = _attrs(root)
+        assert attrs.get("cubepi.tags") == ("beta-arm", "test-suite")
+
+    async def test_metadata_keys_land_with_prefix(self):
+        from cubepi.tracing import tracing_context
+
+        agent, provider, exporter, tracer = await _build()
+        provider.append_responses([faux_assistant_message("ok")])
+
+        with tracing_context(metadata={"user_id": "u-42", "ab_arm": "control"}):
+            await agent.prompt("hi")
+            await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = next(s for s in exporter.spans if s.name == "invoke_agent")
+        attrs = _attrs(root)
+        assert attrs.get("cubepi.user_id") == "u-42"
+        assert attrs.get("cubepi.ab_arm") == "control"
+
+    async def test_no_context_means_no_tag_attr(self):
+        agent, provider, exporter, tracer = await _build()
+        provider.append_responses([faux_assistant_message("ok")])
+        await agent.prompt("hi")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = next(s for s in exporter.spans if s.name == "invoke_agent")
+        attrs = _attrs(root)
+        assert "cubepi.tags" not in attrs
+
+    async def test_context_does_not_leak_across_runs(self):
+        """The contextvar resets on block exit — the next run started
+        outside the block must NOT carry the previous tags."""
+        from cubepi.tracing import tracing_context
+
+        agent, provider, exporter, tracer = await _build()
+        provider.append_responses(
+            [
+                faux_assistant_message("first"),
+                faux_assistant_message("second"),
+            ]
+        )
+
+        with tracing_context(tags=["scoped"]):
+            await agent.prompt("first")
+            await agent.wait_for_idle()
+        await agent.prompt("second")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        roots = sorted(
+            [s for s in exporter.spans if s.name == "invoke_agent"],
+            key=lambda s: s.start_time or 0,
+        )
+        assert len(roots) == 2
+        assert _attrs(roots[0]).get("cubepi.tags") == ("scoped",)
+        assert "cubepi.tags" not in _attrs(roots[1])
+
+    async def test_nested_contexts_merge_additively(self):
+        from cubepi.tracing import tracing_context
+
+        agent, provider, exporter, tracer = await _build()
+        provider.append_responses([faux_assistant_message("ok")])
+
+        with tracing_context(tags=["outer"], metadata={"k": "outer-val"}):
+            with tracing_context(
+                tags=["inner"], metadata={"k": "inner-val", "x": "new"}
+            ):
+                await agent.prompt("hi")
+                await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = next(s for s in exporter.spans if s.name == "invoke_agent")
+        attrs = _attrs(root)
+        assert attrs.get("cubepi.tags") == ("outer", "inner")
+        assert attrs.get("cubepi.k") == "inner-val"
+        assert attrs.get("cubepi.x") == "new"
+
+    async def test_unsupported_metadata_value_is_dropped(self):
+        """OTel attributes can't hold dicts or arbitrary objects."""
+        from cubepi.tracing import tracing_context
+
+        agent, provider, exporter, tracer = await _build()
+        provider.append_responses([faux_assistant_message("ok")])
+
+        with tracing_context(
+            metadata={
+                "good_str": "yes",
+                "good_int": 42,
+                "bad_dict": {"nested": 1},
+            }
+        ):
+            await agent.prompt("hi")
+            await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = next(s for s in exporter.spans if s.name == "invoke_agent")
+        attrs = _attrs(root)
+        assert attrs.get("cubepi.good_str") == "yes"
+        assert attrs.get("cubepi.good_int") == 42
+        assert "cubepi.bad_dict" not in attrs
+
 
 class TestLifecycle:
     async def test_shutdown_is_idempotent(self):

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -946,8 +946,8 @@ class TestTracingContext:
 
         root = next(s for s in exporter.spans if s.name == "invoke_agent")
         attrs = _attrs(root)
-        assert attrs.get("cubepi.user_id") == "u-42"
-        assert attrs.get("cubepi.ab_arm") == "control"
+        assert attrs.get("cubepi.metadata.user_id") == "u-42"
+        assert attrs.get("cubepi.metadata.ab_arm") == "control"
 
     async def test_no_context_means_no_tag_attr(self):
         agent, provider, exporter, tracer = await _build()
@@ -1005,8 +1005,8 @@ class TestTracingContext:
         root = next(s for s in exporter.spans if s.name == "invoke_agent")
         attrs = _attrs(root)
         assert attrs.get("cubepi.tags") == ("outer", "inner")
-        assert attrs.get("cubepi.k") == "inner-val"
-        assert attrs.get("cubepi.x") == "new"
+        assert attrs.get("cubepi.metadata.k") == "inner-val"
+        assert attrs.get("cubepi.metadata.x") == "new"
 
     async def test_unsupported_metadata_value_is_dropped(self):
         """OTel attributes can't hold dicts or arbitrary objects."""
@@ -1028,9 +1028,34 @@ class TestTracingContext:
 
         root = next(s for s in exporter.spans if s.name == "invoke_agent")
         attrs = _attrs(root)
-        assert attrs.get("cubepi.good_str") == "yes"
-        assert attrs.get("cubepi.good_int") == 42
-        assert "cubepi.bad_dict" not in attrs
+        assert attrs.get("cubepi.metadata.good_str") == "yes"
+        assert attrs.get("cubepi.metadata.good_int") == 42
+        assert "cubepi.metadata.bad_dict" not in attrs
+
+    async def test_metadata_cannot_clobber_reserved_cubepi_attrs(self):
+        """User-supplied metadata keys must not be able to overwrite
+        recorder-owned schema attributes like ``cubepi.run_id`` —
+        the JSONL exporter shards spans by that key, so an
+        invoke_agent span with a clobbered ``run_id`` ends up in a
+        different file than its turn/chat/tool spans (codex P2 on
+        PR #92). The fix is the ``cubepi.metadata.*`` sub-namespace."""
+        from cubepi.tracing import tracing_context
+
+        agent, provider, exporter, tracer = await _build()
+        provider.append_responses([faux_assistant_message("ok")])
+
+        with tracing_context(metadata={"run_id": "hijacked", "turn.index": "x"}):
+            await agent.prompt("hi")
+            await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = next(s for s in exporter.spans if s.name == "invoke_agent")
+        attrs = _attrs(root)
+        # The genuine recorder-owned value is unchanged…
+        assert attrs.get("cubepi.run_id") and attrs["cubepi.run_id"] != "hijacked"
+        # …and the user-supplied values land under the safe namespace.
+        assert attrs.get("cubepi.metadata.run_id") == "hijacked"
+        assert attrs.get("cubepi.metadata.turn.index") == "x"
 
 
 class TestLifecycle:


### PR DESCRIPTION
## Summary

Adds \`cubepi.tracing.tracing_context\` — a contextvar-scoped helper modelled on [LangSmith's \`tracing_context\`](https://docs.smith.langchain.com/old/cookbook/tracing-examples/runnable-naming) so callers can stamp run-level tags / metadata on the \`invoke_agent\` span without forking the recorder.

\`\`\`python
from cubepi.tracing import tracing_context

async with tracer.attached(agent):
    with tracing_context(tags=[\"beta-arm\"], metadata={\"user_id\": \"u-42\"}):
        await agent.prompt(\"hello\")
\`\`\`

Resulting attributes on \`invoke_agent\`:
- \`cubepi.tags\` = \`(\"beta-arm\",)\`
- \`cubepi.user_id\` = \`\"u-42\"\`

### Design notes

- **Namespace**: \`cubepi.*\` to avoid colliding with the OTel GenAI semconv reserved names. Tags use a single \`cubepi.tags\` tuple attribute (OTel-compatible).
- **Scoping**: contextvars → per-asyncio-task. Concurrent agents see independent values.
- **Nesting**: tags concatenate (outer → inner); metadata keys union with inner winning.
- **Safety**: metadata values that OTel can't serialize (dicts, arbitrary objects) are silently dropped per-key rather than crashing the span.
- **Reset**: contextvar resets on block exit; the next run outside the block carries no tags.

### What this enables

- Per-conversation filtering in trace backends (\`user_id\`, \`session_id\`, \`thread_id\`)
- A/B test arm tagging
- Custom routing rules in your OTel collector / Datadog pipeline

## Test plan
- [x] Tags land as \`cubepi.tags\` tuple
- [x] Metadata keys land with \`cubepi.\` prefix
- [x] No context block → no tag attr
- [x] Context resets cleanly across sequential runs (no leak)
- [x] Nested blocks merge (tags concat, metadata last-write-wins)
- [x] Unsupported values (dicts) dropped silently
- [x] Full tracing + mcp suite (156 tests) passes
- [ ] codex review
- [ ] codecov/patch

Parallel to #90 (Tracer.attached) and #91 (atexit_flush). Each is self-contained; merge order doesn't matter.