### PR TITLE
docs: refresh observability story from "BYO tracing" to "native OpenTelemetry"

### DIFF
--- a/website/docs/migration/from-langgraph.md
+++ b/website/docs/migration/from-langgraph.md
@@ -196,8 +196,11 @@ There's no built-in branching primitive; flow control happens through
   line anyway.
 - **Time travel / fork** at arbitrary checkpoints. The Postgres schema
   has fork columns but no API surface in v0.3.
-- **LangSmith / Langfuse integrations.** Bring your own tracing via
-  middleware + `on_response`.
+- **LangSmith / Langfuse vendor SDKs.** CubePi ships native
+  OpenTelemetry tracing instead — see [Tracing →
+  Overview](../guides/tracing/overview). Anything that speaks OTLP
+  (LangSmith's OTel endpoint, Langfuse v3, Jaeger, Tempo, Honeycomb,
+  Datadog, …) drops in via `Tracer(exporters=[OTLPSpanExporter(...)])`.
 
 ## What CubePi does that langgraph doesn't
 

--- a/website/src/components/Home/WhyTable.tsx
+++ b/website/src/components/Home/WhyTable.tsx
@@ -9,7 +9,7 @@ const ROWS: { label: string; langgraph: string; cubepi: string }[] = [
   { label: 'Tool execution',  langgraph: 'Tools are graph nodes with manual wiring',                cubepi: 'Declare tools as functions; framework routes and parallelizes' },
   { label: 'Multi-provider',  langgraph: 'Via langchain chat model adapters',                       cubepi: 'Native Provider protocol — Anthropic, OpenAI built in' },
   { label: 'Middleware',      langgraph: 'Graph-level middleware on node entry/exit',               cubepi: '5 typed hooks with declarative composition rules' },
-  { label: 'Observability',   langgraph: 'LangSmith / Langfuse integration',                        cubepi: 'Events + middleware hooks — bring your own tracing' },
+  { label: 'Observability',   langgraph: 'LangSmith / Langfuse integration',                        cubepi: 'Native OpenTelemetry — Tracer, Meter, GenAI semconv, OTLP / JSONL out of the box' },
 ];
 
 export default function WhyTable() {


### PR DESCRIPTION
## Summary

Two stale spots that still pitched cubepi's observability as \"events + middleware hooks; bring your own tracing\" — accurate at v0.3.0 but obsolete after PRs #82–#92 shipped the full OpenTelemetry tracing module.

- \`website/src/components/Home/WhyTable.tsx\` — homepage \"Why CubePi\" table, Observability row
- \`website/docs/migration/from-langgraph.md\` — \"things langgraph has and cubepi doesn't\" bullet

Both now say cubepi ships native OTel and point readers at the [Tracing guide](https://github.com/cubeplexai/cubepi/tree/main/website/docs/guides/tracing). The LangSmith / Langfuse story is no longer \"BYO\" — both vendors expose OTLP endpoints, so \`Tracer(exporters=[OTLPSpanExporter(endpoint=\"...\")])\` ships traces straight to them.

\`website/versioned_docs/version-0.3/migration/from-langgraph.md\` is intentionally **not** touched — that's the frozen 0.3.0 snapshot and reflects what actually shipped in that release.

## Test plan
- [x] No code change; only Why-table TS + one bullet in migration .md
- [ ] CI \`build-and-check\` succeeds
- [ ] codex review