### PR TITLE
feat(package): expose cubepi.__version__ from installed distribution

### DIFF
--- a/cubepi/__init__.py
+++ b/cubepi/__init__.py
@@ -1,5 +1,13 @@
 """cubepi — Pythonic async-native agent framework."""
 
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("cubepi")
+except PackageNotFoundError:  # pragma: no cover — non-installed checkout
+    __version__ = "0.0.0+unknown"
+
+
 from cubepi.agent import (
     Agent,
     AgentState,
@@ -29,6 +37,7 @@ from cubepi.providers import (
 )
 
 __all__ = [
+    "__version__",
     "Agent",
     "AgentState",
     "AgentTool",

--- a/cubepi/tracing/meter.py
+++ b/cubepi/tracing/meter.py
@@ -111,7 +111,7 @@ class Meter:
         self._provider = MeterProvider(resource=self._resource, metric_readers=readers)
         self._otel_meter = self._provider.get_meter(
             name=SCOPE_NAME,
-            version=cubepi.__version__ if hasattr(cubepi, "__version__") else None,
+            version=cubepi.__version__,
             schema_url=SCHEMA_URL,
         )
         self._duration_hist = self._otel_meter.create_histogram(

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -98,9 +98,7 @@ class Tracer:
 
         self._otel_tracer = self._provider.get_tracer(
             instrumenting_module_name=SCOPE_NAME,
-            instrumenting_library_version=cubepi.__version__
-            if hasattr(cubepi, "__version__")
-            else None,
+            instrumenting_library_version=cubepi.__version__,
             schema_url=SCHEMA_URL,
         )
         self._shutdown = False

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,51 @@
+"""Top-level package contract tests.
+
+Things every release must satisfy: importable, has a sane
+``__version__`` matching the installed distribution metadata, doesn't
+silently regress the public surface.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib.metadata import version as _pkg_version
+
+
+def test_version_attribute_present_and_matches_metadata() -> None:
+    """``cubepi.__version__`` must exist and match the version pip
+    sees for the installed distribution.
+
+    Several integrations read it (``cubepi.tracing.Tracer`` /
+    ``Meter`` use it for OTel ``instrumenting_library_version`` so
+    spans/metrics carry the cubepi version). A drift between
+    ``cubepi.__version__`` and the installed distribution would
+    make trace metadata lie about what produced the spans.
+    """
+    import cubepi
+
+    assert hasattr(cubepi, "__version__"), "cubepi must expose __version__"
+    assert cubepi.__version__ == _pkg_version("cubepi"), (
+        f"cubepi.__version__ ({cubepi.__version__!r}) drifted from the "
+        f"installed distribution version ({_pkg_version('cubepi')!r}) — "
+        "check pyproject.toml's [project].version field."
+    )
+
+
+def test_version_string_shape() -> None:
+    """Version should look like a PEP 440 release (e.g. ``0.4.0``,
+    ``0.4.1.dev0``). Catches accidental ``unknown`` fallbacks landing
+    in a published package."""
+    import cubepi
+
+    assert re.match(r"^\d+\.\d+", cubepi.__version__), (
+        f"cubepi.__version__ {cubepi.__version__!r} doesn't look like a "
+        f"PEP 440 version — fallback path may have been hit."
+    )
+
+
+def test_version_listed_in_dunder_all() -> None:
+    """``__version__`` must be in ``__all__`` so ``from cubepi import *``
+    surfaces it and editors auto-complete it."""
+    import cubepi
+
+    assert "__version__" in cubepi.__all__


### PR DESCRIPTION
## Summary

\`Tracer\` and \`Meter\` both read \`cubepi.__version__\` for the OTel \`instrumenting_library_version\` attribute on the providers they build — so trace backends know which cubepi version produced the spans / metrics. But \`cubepi/__init__.py\` never defined it: the call sites used \`getattr(cubepi, \"__version__\", None) if hasattr(...) else None\`, and every cubepi user's traces went out with \`library_version=None\`.

Fix: derive at import time from the installed distribution metadata, then drop the \`hasattr\` defensive bits.

\`\`\`python
# cubepi/__init__.py
from importlib.metadata import PackageNotFoundError, version as _pkg_version

try:
    __version__ = _pkg_version(\"cubepi\")
except PackageNotFoundError:
    __version__ = \"0.0.0+unknown\"
\`\`\`

Single-source-of-truth is \`pyproject.toml\`'s \`[project].version\`. \`__version__\` tracks it automatically on package releases — no separate bump needed.

## Test plan
- [x] \`tests/test_package.py\` (3 tests): \`__version__\` matches \`importlib.metadata.version('cubepi')\`, PEP 440 shape, listed in \`__all__\`
- [x] Local sanity: \`python -c \"import cubepi; print(cubepi.__version__)\"\` → \`0.4.0\`
- [ ] CI green
- [ ] codex review