### PR TITLE
docs: surface tracing across homepage + getting-started + migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ invoke_agent <agent_name>              [INTERNAL]
 No prompts / model outputs are recorded by default. Opt in with
 `Tracer(record_content=True)` plus a `redact` callback for PII. Pair
 with `Meter(...)` for `gen_ai.client.operation.duration` / TTFC /
-token-usage histograms. Full guide: https://cubepi.pages.dev/guides/tracing/overview
+token-usage histograms. Full guide: https://cubepi.pages.dev/docs/guides/tracing/overview
 
 ## Requirements
 

--- a/website/docs/getting-started/core-concepts.md
+++ b/website/docs/getting-started/core-concepts.md
@@ -143,6 +143,44 @@ on the first `prompt()`. Built-in backends: `MemoryCheckpointer`,
 `SQLiteCheckpointer`, `PostgresCheckpointer`. See
 [Checkpointing → SQLite](../guides/checkpointing/sqlite).
 
+## Tracer (optional)
+
+`Tracer` produces OpenTelemetry spans aligned with the
+[GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/),
+so any OTLP backend (Jaeger, Tempo, Honeycomb, Datadog, AWS X-Ray, …)
+can ingest agent runs without custom instrumentation. Install the
+extra:
+
+```bash
+pip install "cubepi[tracing]"           # OTel SDK
+pip install "cubepi[tracing-otlp]"      # + OTLP/HTTP exporter
+```
+
+then wrap your agent in an `async with`:
+
+```python
+from cubepi.tracing import Tracer
+from cubepi.tracing.exporters import JsonlSpanExporter
+
+async with (
+    Tracer(
+        service_name="my-bot",
+        agent_name="assistant",
+        exporters=[JsonlSpanExporter(directory="./cubepi-traces")],
+    ) as tracer,
+    tracer.attached(agent),
+):
+    await agent.prompt("…")
+```
+
+Each run emits an `invoke_agent` root span containing one
+`cubepi.turn` per LLM round-trip, plus `chat` (CLIENT) and
+`execute_tool` children. By default **no prompt content or model
+output is recorded** — opt in with `Tracer(record_content=True)` and
+a `redact` callback for PII. Pair with `Meter(...)` for token /
+duration / TTFC histograms. Full guide:
+[Tracing → Overview](../guides/tracing/overview).
+
 ## Putting it together
 
 ```

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -6,8 +6,8 @@ title: Installation
 
 CubePi runs on **Python 3.11+**. The core has three runtime
 dependencies: `pydantic`, `anthropic`, `openai`. Optional features
-(SQLite, Postgres, MCP) are gated behind extras so you only install
-what you use.
+(SQLite, Postgres, MCP, OpenTelemetry tracing) are gated behind extras
+so you only install what you use.
 
 ## With pip
 
@@ -18,10 +18,12 @@ pip install cubepi
 Optional extras:
 
 ```bash
-pip install "cubepi[sqlite]"     # adds aiosqlite for SQLiteCheckpointer
-pip install "cubepi[postgres]"   # adds asyncpg + sqlalchemy + msgpack
-pip install "cubepi[mcp]"        # adds the MCP SDK for tool loaders
-pip install "cubepi[sqlite,mcp]" # combine
+pip install "cubepi[sqlite]"        # adds aiosqlite for SQLiteCheckpointer
+pip install "cubepi[postgres]"      # adds asyncpg + sqlalchemy + msgpack
+pip install "cubepi[mcp]"           # adds the MCP SDK for tool loaders
+pip install "cubepi[tracing]"       # adds opentelemetry-sdk for Tracer / Meter
+pip install "cubepi[tracing-otlp]"  # adds the OTLP/HTTP span exporter
+pip install "cubepi[sqlite,mcp,tracing]"  # combine
 ```
 
 ## With uv
@@ -31,7 +33,7 @@ pip and is the recommended workflow:
 
 ```bash
 uv add cubepi
-uv add "cubepi[sqlite,postgres,mcp]"
+uv add "cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]"
 ```
 
 In an existing uv project, `uv sync` re-locks the environment after
@@ -41,7 +43,7 @@ edits to `pyproject.toml`.
 
 ```bash
 poetry add cubepi
-poetry add "cubepi[sqlite,postgres,mcp]"
+poetry add "cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]"
 ```
 
 ## Verifying the install
@@ -79,10 +81,12 @@ For the [FauxProvider](../guides/providers/custom#using-fauxprovider-in-tests)
 
 | Extra | Pulls in | Install when |
 |---|---|---|
-| (none) | core only | You only need in-memory state, no MCP |
+| (none) | core only | You only need in-memory state, no MCP, no tracing |
 | `[sqlite]` | `aiosqlite` | Single-process app needs disk persistence |
 | `[postgres]` | `asyncpg`, `sqlalchemy`, `msgpack` | Multi-instance / production — see [Postgres guide](../guides/checkpointing/postgres) |
 | `[mcp]` | `mcp` | You want to mount MCP server tools into your agent |
+| `[tracing]` | `opentelemetry-sdk` | You want OpenTelemetry traces (and optionally metrics) — see [Tracing guide](../guides/tracing/overview) |
+| `[tracing-otlp]` | `opentelemetry-exporter-otlp-proto-http` | Ship traces to an OTLP/HTTP backend (Jaeger ≥1.50, Tempo, Honeycomb, Datadog, …) |
 | `[docs]` | `griffe` | You're building the docs site (contributors only) |
 
 ## Next steps

--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -5,6 +5,8 @@ slug: /
 sidebar_position: 0
 ---
 
+import PackageVersion from '@site/src/components/PackageVersion';
+
 # CubePi
 
 **CubePi** is a Pythonic, async-native agent framework — a leaner, more
@@ -64,11 +66,11 @@ You are reading the **Next 🚧** channel — unreleased docs that track
 the `main` branch. APIs documented here can still change before they
 ship in a tagged release.
 
-The latest released version is `v0.4.0` ([switch to it from the
-version picker, top-right](pathname:///)). New since 0.3: a native
+The latest released version is `v<PackageVersion/>` ([switch to it
+from the version picker, top-right](pathname:///)). The native
 OpenTelemetry tracing module ([guide →](./guides/tracing/overview))
-with `Tracer`, `Meter`, content recording, MCP CLIENT spans, and
-per-run `tracing_context` tags.
+— `Tracer`, `Meter`, content recording, MCP CLIENT spans, per-run
+`tracing_context` tags — landed in 0.4.
 
 Source, issues, and discussion live on
 [GitHub](https://github.com/cubeplexai/cubepi).

--- a/website/docs/migration/from-langgraph.md
+++ b/website/docs/migration/from-langgraph.md
@@ -195,15 +195,20 @@ There's no built-in branching primitive; flow control happens through
   equivalent. CubePi's flow is linear so the picture would be a single
   line anyway.
 - **Time travel / fork** at arbitrary checkpoints. The Postgres schema
-  has fork columns but no API surface in v0.3.
-- **LangSmith / Langfuse vendor SDKs.** CubePi ships native
-  OpenTelemetry tracing instead — see [Tracing →
-  Overview](../guides/tracing/overview). Anything that speaks OTLP
-  (LangSmith's OTel endpoint, Langfuse v3, Jaeger, Tempo, Honeycomb,
-  Datadog, …) drops in via `Tracer(exporters=[OTLPSpanExporter(...)])`.
+  has fork columns but no API surface in v0.4.
+- **First-party UI for traces.** CubePi doesn't render its own trace
+  visualizer the way LangSmith / Langfuse do; instead it emits
+  vendor-neutral OpenTelemetry — point any OTLP backend
+  (LangSmith's OTel endpoint, Langfuse v3, Jaeger, Tempo,
+  Honeycomb, Datadog, …) at it via
+  `Tracer(exporters=[OTLPSpanExporter(...)])`. See
+  [Tracing → OTLP & Backends](../guides/tracing/otlp).
 
 ## What CubePi does that langgraph doesn't
 
+- **Native OpenTelemetry tracing** — `Tracer` + `Meter` emit OTel
+  spans + GenAI-semconv attributes out of the box, ingestible by
+  any OTLP backend. See [Tracing → Overview](../guides/tracing/overview).
 - **Native async-first** — every entry point is async. No
   `app.invoke` vs. `app.ainvoke` split.
 - **Append-only persistence** — O(1) DB writes, JSONB-queryable

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 import type { Config } from '@docusaurus/types';
 import type { Options as ClassicOptions } from '@docusaurus/preset-classic';
 import { themes as prismThemes } from 'prism-react-renderer';
@@ -9,6 +12,17 @@ import { themes as prismThemes } from 'prism-react-renderer';
 const POSTHOG_KEY = process.env.POSTHOG_KEY || '';
 const POSTHOG_HOST = process.env.POSTHOG_HOST || 'https://us.i.posthog.com';
 const GIT_SHA = process.env.GITHUB_SHA?.slice(0, 7) ?? 'dev';
+
+// Single source of truth for the package version shown in the homepage
+// MetaBar: read pyproject.toml at config-load time so the site never
+// drifts from the actual released version. Plain regex parse — avoids
+// a TOML-parser dep just for one field.
+const PYPROJECT_TOML = fs.readFileSync(
+  path.join(__dirname, '..', 'pyproject.toml'),
+  'utf-8',
+);
+const VERSION_MATCH = PYPROJECT_TOML.match(/^version\s*=\s*"([^"]+)"/m);
+const PACKAGE_VERSION = VERSION_MATCH ? VERSION_MATCH[1] : 'dev';
 
 const classicOptions: ClassicOptions = {
   docs: {
@@ -50,7 +64,7 @@ const config: Config = {
     },
   },
 
-  customFields: { POSTHOG_KEY, POSTHOG_HOST, GIT_SHA },
+  customFields: { POSTHOG_KEY, POSTHOG_HOST, GIT_SHA, PACKAGE_VERSION },
 
   clientModules: [require.resolve('./src/clientModules/posthog.ts')],
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/core-concepts.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/core-concepts.md
@@ -134,6 +134,41 @@ class Checkpointer(Protocol):
 `MemoryCheckpointer`、`SQLiteCheckpointer`、`PostgresCheckpointer`。
 见 [Checkpointing → SQLite](../guides/checkpointing/sqlite)。
 
+## Tracer（可选）
+
+`Tracer` 输出符合 [OpenTelemetry GenAI 语义约定](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+的 span,任何 OTLP 后端（Jaeger、Tempo、Honeycomb、Datadog、AWS
+X-Ray 等）都能直接接收,无需额外 instrumentation。先装 extra：
+
+```bash
+pip install "cubepi[tracing]"           # OTel SDK
+pip install "cubepi[tracing-otlp]"      # + OTLP/HTTP 导出器
+```
+
+然后用 `async with` 包住 Agent：
+
+```python
+from cubepi.tracing import Tracer
+from cubepi.tracing.exporters import JsonlSpanExporter
+
+async with (
+    Tracer(
+        service_name="my-bot",
+        agent_name="assistant",
+        exporters=[JsonlSpanExporter(directory="./cubepi-traces")],
+    ) as tracer,
+    tracer.attached(agent),
+):
+    await agent.prompt("…")
+```
+
+每次 run 会发出一个 `invoke_agent` 根 span,其下每轮 LLM 往返对应
+一个 `cubepi.turn`,再嵌套 `chat`（CLIENT）和 `execute_tool` 子
+span。**默认不记录任何 prompt 内容或模型输出** —— 需要的话用
+`Tracer(record_content=True)` 显式打开,搭配 `redact` 回调脱敏。配
+合 `Meter(...)` 还能拿到 token / 时延 / TTFC 直方图。完整指南：
+[追踪 → 概览](../guides/tracing/overview)。
+
 ## 拼起来
 
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -5,8 +5,8 @@ title: 安装
 # 安装
 
 CubePi 需要 **Python 3.11 或以上**。核心运行时只有三个依赖：`pydantic`、
-`anthropic`、`openai`。可选功能（SQLite、Postgres、MCP）通过 extras
-按需安装,不用的话不会被拉进来。
+`anthropic`、`openai`。可选功能（SQLite、Postgres、MCP、OpenTelemetry
+追踪）通过 extras 按需安装,不用的话不会被拉进来。
 
 ## 使用 pip
 
@@ -17,10 +17,12 @@ pip install cubepi
 可选 extras:
 
 ```bash
-pip install "cubepi[sqlite]"     # 安装 aiosqlite,启用 SQLiteCheckpointer
-pip install "cubepi[postgres]"   # 安装 asyncpg + sqlalchemy + msgpack
-pip install "cubepi[mcp]"        # 安装 MCP SDK,启用 MCP 工具加载器
-pip install "cubepi[sqlite,mcp]" # 组合
+pip install "cubepi[sqlite]"        # 安装 aiosqlite,启用 SQLiteCheckpointer
+pip install "cubepi[postgres]"      # 安装 asyncpg + sqlalchemy + msgpack
+pip install "cubepi[mcp]"           # 安装 MCP SDK,启用 MCP 工具加载器
+pip install "cubepi[tracing]"       # 安装 opentelemetry-sdk,启用 Tracer / Meter
+pip install "cubepi[tracing-otlp]"  # 加上 OTLP/HTTP 导出器
+pip install "cubepi[sqlite,mcp,tracing]"  # 组合
 ```
 
 ## 使用 uv
@@ -29,7 +31,7 @@ pip install "cubepi[sqlite,mcp]" # 组合
 
 ```bash
 uv add cubepi
-uv add "cubepi[sqlite,postgres,mcp]"
+uv add "cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]"
 ```
 
 在已有 uv 项目里,改完 `pyproject.toml` 后 `uv sync` 会重新锁定环境。
@@ -38,7 +40,7 @@ uv add "cubepi[sqlite,postgres,mcp]"
 
 ```bash
 poetry add cubepi
-poetry add "cubepi[sqlite,postgres,mcp]"
+poetry add "cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]"
 ```
 
 ## 验证安装
@@ -75,10 +77,12 @@ LiteLLM、vLLM）。
 
 | Extra | 拉入什么 | 什么时候装 |
 |---|---|---|
-| (无) | 仅核心 | 只需要内存里的状态,不用 MCP |
+| (无) | 仅核心 | 只需要内存里的状态,不用 MCP,不用追踪 |
 | `[sqlite]` | `aiosqlite` | 单进程应用需要落盘 |
 | `[postgres]` | `asyncpg`、`sqlalchemy`、`msgpack` | 多实例 / 生产环境——见 [Postgres 指南](../guides/checkpointing/postgres) |
 | `[mcp]` | `mcp` | 想把 MCP server 工具挂到 Agent 上 |
+| `[tracing]` | `opentelemetry-sdk` | 想要 OpenTelemetry 追踪（含可选指标）——见 [追踪指南](../guides/tracing/overview) |
+| `[tracing-otlp]` | `opentelemetry-exporter-otlp-proto-http` | 把 trace 发往 OTLP/HTTP 后端（Jaeger ≥1.50、Tempo、Honeycomb、Datadog 等）|
 | `[docs]` | `griffe` | 仅文档站构建（贡献者用） |
 
 ## 下一步

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro.mdx
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/intro.mdx
@@ -5,6 +5,8 @@ slug: /
 sidebar_position: 0
 ---
 
+import PackageVersion from '@site/src/components/PackageVersion';
+
 # CubePi
 
 **CubePi** 是一个 Pythonic、原生异步的 Agent 框架——相对于
@@ -38,6 +40,10 @@ pip install cubepi
 - **MCP 加载器。** 指向任意
   [Model Context Protocol](https://modelcontextprotocol.io) 服务器
   （HTTP 或 stdio),就能拿回一组 `AgentTool`。
+- **原生 OpenTelemetry。** 挂一个 `Tracer`,每次 prompt 就产生符合
+  GenAI 语义约定的 OTel span 树 —— Jaeger、Tempo、Honeycomb、
+  Datadog 等任意 OTLP 后端都能直接接收。默认不记录任何 payload；
+  需要时用 `record_content=True` 配合 `redact` 回调显式开启。
 
 ## 接下来去哪儿
 
@@ -56,10 +62,10 @@ pip install cubepi
 你正在浏览的是 **Next 🚧** 频道 —— 跟踪 `main` 分支的未发布文档。
 这里描述的 API 在打 tag 发布之前还可能变动。
 
-最新已发布版本是 `v0.4.0`（[从右上角版本选择器切换](pathname:///)）。
-相比 0.3 新增了原生 OpenTelemetry 追踪模块
-（[指南 →](./guides/tracing/overview)）：包含 `Tracer`、`Meter`、
-内容录制、MCP CLIENT span，以及按 run 打标签的 `tracing_context`。
+最新已发布版本是 `v<PackageVersion/>`（[从右上角版本选择器切换](pathname:///)）。
+原生 OpenTelemetry 追踪模块（[指南 →](./guides/tracing/overview)）——
+`Tracer`、`Meter`、内容录制、MCP CLIENT span、按 run 打标签的
+`tracing_context` —— 已在 0.4 发布。
 
 源代码、Issue 和讨论都在
 [GitHub](https://github.com/cubeplexai/cubepi)。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.4/getting-started/core-concepts.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.4/getting-started/core-concepts.md
@@ -134,6 +134,41 @@ class Checkpointer(Protocol):
 `MemoryCheckpointer`、`SQLiteCheckpointer`、`PostgresCheckpointer`。
 见 [Checkpointing → SQLite](../guides/checkpointing/sqlite)。
 
+## Tracer（可选）
+
+`Tracer` 输出符合 [OpenTelemetry GenAI 语义约定](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+的 span,任何 OTLP 后端（Jaeger、Tempo、Honeycomb、Datadog、AWS
+X-Ray 等）都能直接接收,无需额外 instrumentation。先装 extra：
+
+```bash
+pip install "cubepi[tracing]"           # OTel SDK
+pip install "cubepi[tracing-otlp]"      # + OTLP/HTTP 导出器
+```
+
+然后用 `async with` 包住 Agent：
+
+```python
+from cubepi.tracing import Tracer
+from cubepi.tracing.exporters import JsonlSpanExporter
+
+async with (
+    Tracer(
+        service_name="my-bot",
+        agent_name="assistant",
+        exporters=[JsonlSpanExporter(directory="./cubepi-traces")],
+    ) as tracer,
+    tracer.attached(agent),
+):
+    await agent.prompt("…")
+```
+
+每次 run 会发出一个 `invoke_agent` 根 span,其下每轮 LLM 往返对应
+一个 `cubepi.turn`,再嵌套 `chat`（CLIENT）和 `execute_tool` 子
+span。**默认不记录任何 prompt 内容或模型输出** —— 需要的话用
+`Tracer(record_content=True)` 显式打开,搭配 `redact` 回调脱敏。配
+合 `Meter(...)` 还能拿到 token / 时延 / TTFC 直方图。完整指南：
+[追踪 → 概览](../guides/tracing/overview)。
+
 ## 拼起来
 
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.4/getting-started/installation.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.4/getting-started/installation.md
@@ -5,8 +5,8 @@ title: 安装
 # 安装
 
 CubePi 需要 **Python 3.11 或以上**。核心运行时只有三个依赖：`pydantic`、
-`anthropic`、`openai`。可选功能（SQLite、Postgres、MCP）通过 extras
-按需安装,不用的话不会被拉进来。
+`anthropic`、`openai`。可选功能（SQLite、Postgres、MCP、OpenTelemetry
+追踪）通过 extras 按需安装,不用的话不会被拉进来。
 
 ## 使用 pip
 
@@ -17,10 +17,12 @@ pip install cubepi
 可选 extras:
 
 ```bash
-pip install "cubepi[sqlite]"     # 安装 aiosqlite,启用 SQLiteCheckpointer
-pip install "cubepi[postgres]"   # 安装 asyncpg + sqlalchemy + msgpack
-pip install "cubepi[mcp]"        # 安装 MCP SDK,启用 MCP 工具加载器
-pip install "cubepi[sqlite,mcp]" # 组合
+pip install "cubepi[sqlite]"        # 安装 aiosqlite,启用 SQLiteCheckpointer
+pip install "cubepi[postgres]"      # 安装 asyncpg + sqlalchemy + msgpack
+pip install "cubepi[mcp]"           # 安装 MCP SDK,启用 MCP 工具加载器
+pip install "cubepi[tracing]"       # 安装 opentelemetry-sdk,启用 Tracer / Meter
+pip install "cubepi[tracing-otlp]"  # 加上 OTLP/HTTP 导出器
+pip install "cubepi[sqlite,mcp,tracing]"  # 组合
 ```
 
 ## 使用 uv
@@ -29,7 +31,7 @@ pip install "cubepi[sqlite,mcp]" # 组合
 
 ```bash
 uv add cubepi
-uv add "cubepi[sqlite,postgres,mcp]"
+uv add "cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]"
 ```
 
 在已有 uv 项目里,改完 `pyproject.toml` 后 `uv sync` 会重新锁定环境。
@@ -38,7 +40,7 @@ uv add "cubepi[sqlite,postgres,mcp]"
 
 ```bash
 poetry add cubepi
-poetry add "cubepi[sqlite,postgres,mcp]"
+poetry add "cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]"
 ```
 
 ## 验证安装
@@ -75,10 +77,12 @@ LiteLLM、vLLM）。
 
 | Extra | 拉入什么 | 什么时候装 |
 |---|---|---|
-| (无) | 仅核心 | 只需要内存里的状态,不用 MCP |
+| (无) | 仅核心 | 只需要内存里的状态,不用 MCP,不用追踪 |
 | `[sqlite]` | `aiosqlite` | 单进程应用需要落盘 |
 | `[postgres]` | `asyncpg`、`sqlalchemy`、`msgpack` | 多实例 / 生产环境——见 [Postgres 指南](../guides/checkpointing/postgres) |
 | `[mcp]` | `mcp` | 想把 MCP server 工具挂到 Agent 上 |
+| `[tracing]` | `opentelemetry-sdk` | 想要 OpenTelemetry 追踪（含可选指标）——见 [追踪指南](../guides/tracing/overview) |
+| `[tracing-otlp]` | `opentelemetry-exporter-otlp-proto-http` | 把 trace 发往 OTLP/HTTP 后端（Jaeger ≥1.50、Tempo、Honeycomb、Datadog 等）|
 | `[docs]` | `griffe` | 仅文档站构建（贡献者用） |
 
 ## 下一步

--- a/website/src/components/Home/FeatureGrid.tsx
+++ b/website/src/components/Home/FeatureGrid.tsx
@@ -36,6 +36,14 @@ const IconMcp: Icon = (p) => (
     <path d="M2 8h12M8 2v12" />
   </svg>
 );
+const IconTrace: Icon = (p) => (
+  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round" {...p}>
+    <path d="M2 3h9M5 7h9M3 11h11" />
+    <circle cx="2" cy="3" r="1" fill="currentColor" />
+    <circle cx="5" cy="7" r="1" fill="currentColor" />
+    <circle cx="3" cy="11" r="1" fill="currentColor" />
+  </svg>
+);
 
 const CARDS = [
   { Icon: IconBox,    title: 'Agents',        body: 'One async loop, fully typed events.',     href: '/docs/guides/agents/first-agent' },
@@ -44,6 +52,7 @@ const CARDS = [
   { Icon: IconPlug,   title: 'Providers',     body: 'Anthropic, OpenAI, or write your own.',   href: '/docs/guides/providers/anthropic' },
   { Icon: IconDisk,   title: 'Checkpointing', body: 'Append-only, O(1) per turn.',             href: '/docs/guides/checkpointing/sqlite' },
   { Icon: IconMcp,    title: 'MCP',           body: 'Load remote tools at startup.',           href: '/docs/guides/mcp/loading' },
+  { Icon: IconTrace,  title: 'Tracing',       body: 'OpenTelemetry, OTLP / JSONL, GenAI semconv.', href: '/docs/guides/tracing/overview' },
 ];
 
 export default function FeatureGrid() {

--- a/website/src/components/Home/Hero.tsx
+++ b/website/src/components/Home/Hero.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './Hero.module.css';
 
 export default function Hero() {
   const social = useBaseUrl('/img/brand/cubepi-social-preview.png');
   const installCmd = 'pip install cubepi';
+  const { siteConfig } = useDocusaurusContext();
+  // Sourced from siteConfig.customFields.PACKAGE_VERSION (parsed from
+  // pyproject.toml at config-load time) so the eyebrow tracks the
+  // released version automatically.
+  const version =
+    (siteConfig.customFields?.PACKAGE_VERSION as string | undefined) ?? 'dev';
 
   return (
     <section className={styles.hero}>
@@ -16,7 +23,7 @@ export default function Hero() {
         width={1280}
         height={640}
       />
-      <div className={styles.eyebrow}>cubepi · v0.3.0 · alpha</div>
+      <div className={styles.eyebrow}>cubepi · v{version} · alpha</div>
       <h1 className={styles.h1}>A Pythonic, async-native agent framework.</h1>
       <p className={styles.lead}>
         Plain async functions instead of graph nodes. 3 deps. Append-only checkpointing.

--- a/website/src/components/Home/InstallMatrix.tsx
+++ b/website/src/components/Home/InstallMatrix.tsx
@@ -5,7 +5,7 @@ const ROWS: { tool: string; cmd: string }[] = [
   { tool: 'pip',    cmd: 'pip install cubepi' },
   { tool: 'uv',     cmd: 'uv add cubepi' },
   { tool: 'poetry', cmd: 'poetry add cubepi' },
-  { tool: 'extras', cmd: 'pip install cubepi[sqlite,postgres,mcp]' },
+  { tool: 'extras', cmd: 'pip install cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]' },
 ];
 
 export default function InstallMatrix() {

--- a/website/src/components/Home/MetaBar.tsx
+++ b/website/src/components/Home/MetaBar.tsx
@@ -5,9 +5,14 @@ import styles from './MetaBar.module.css';
 export default function MetaBar() {
   const { siteConfig } = useDocusaurusContext();
   const sha = (siteConfig.customFields?.GIT_SHA as string | undefined) ?? 'dev';
+  // Sourced from siteConfig.customFields.PACKAGE_VERSION so the homepage
+  // stops drifting from pyproject.toml — bumped at release time in
+  // docusaurus.config.ts (single source of truth alongside lastVersion).
+  const version =
+    (siteConfig.customFields?.PACKAGE_VERSION as string | undefined) ?? 'dev';
   return (
     <section className={styles.bar}>
-      <span>v0.3.0</span>
+      <span>v{version}</span>
       <span className={styles.sep}>·</span>
       <span>py 3.11+</span>
       <span className={styles.sep}>·</span>

--- a/website/src/components/PackageVersion/index.tsx
+++ b/website/src/components/PackageVersion/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+/**
+ * Inline component that renders the current cubepi package version,
+ * sourced from `siteConfig.customFields.PACKAGE_VERSION` which
+ * `docusaurus.config.ts` parses out of `pyproject.toml` at
+ * config-load time.
+ *
+ * Use in MDX:
+ *
+ *     import PackageVersion from '@site/src/components/PackageVersion';
+ *     The latest released version is `v<PackageVersion />`.
+ *
+ * Falls back to `dev` if the custom field is missing (e.g. the
+ * pyproject.toml read failed during config load).
+ */
+export default function PackageVersion(): React.ReactElement {
+  const { siteConfig } = useDocusaurusContext();
+  const version =
+    (siteConfig.customFields?.PACKAGE_VERSION as string | undefined) ?? 'dev';
+  return <>{version}</>;
+}

--- a/website/versioned_docs/version-0.4/getting-started/core-concepts.md
+++ b/website/versioned_docs/version-0.4/getting-started/core-concepts.md
@@ -143,6 +143,44 @@ on the first `prompt()`. Built-in backends: `MemoryCheckpointer`,
 `SQLiteCheckpointer`, `PostgresCheckpointer`. See
 [Checkpointing → SQLite](../guides/checkpointing/sqlite).
 
+## Tracer (optional)
+
+`Tracer` produces OpenTelemetry spans aligned with the
+[GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/),
+so any OTLP backend (Jaeger, Tempo, Honeycomb, Datadog, AWS X-Ray, …)
+can ingest agent runs without custom instrumentation. Install the
+extra:
+
+```bash
+pip install "cubepi[tracing]"           # OTel SDK
+pip install "cubepi[tracing-otlp]"      # + OTLP/HTTP exporter
+```
+
+then wrap your agent in an `async with`:
+
+```python
+from cubepi.tracing import Tracer
+from cubepi.tracing.exporters import JsonlSpanExporter
+
+async with (
+    Tracer(
+        service_name="my-bot",
+        agent_name="assistant",
+        exporters=[JsonlSpanExporter(directory="./cubepi-traces")],
+    ) as tracer,
+    tracer.attached(agent),
+):
+    await agent.prompt("…")
+```
+
+Each run emits an `invoke_agent` root span containing one
+`cubepi.turn` per LLM round-trip, plus `chat` (CLIENT) and
+`execute_tool` children. By default **no prompt content or model
+output is recorded** — opt in with `Tracer(record_content=True)` and
+a `redact` callback for PII. Pair with `Meter(...)` for token /
+duration / TTFC histograms. Full guide:
+[Tracing → Overview](../guides/tracing/overview).
+
 ## Putting it together
 
 ```

--- a/website/versioned_docs/version-0.4/getting-started/installation.md
+++ b/website/versioned_docs/version-0.4/getting-started/installation.md
@@ -6,8 +6,8 @@ title: Installation
 
 CubePi runs on **Python 3.11+**. The core has three runtime
 dependencies: `pydantic`, `anthropic`, `openai`. Optional features
-(SQLite, Postgres, MCP) are gated behind extras so you only install
-what you use.
+(SQLite, Postgres, MCP, OpenTelemetry tracing) are gated behind extras
+so you only install what you use.
 
 ## With pip
 
@@ -18,10 +18,12 @@ pip install cubepi
 Optional extras:
 
 ```bash
-pip install "cubepi[sqlite]"     # adds aiosqlite for SQLiteCheckpointer
-pip install "cubepi[postgres]"   # adds asyncpg + sqlalchemy + msgpack
-pip install "cubepi[mcp]"        # adds the MCP SDK for tool loaders
-pip install "cubepi[sqlite,mcp]" # combine
+pip install "cubepi[sqlite]"        # adds aiosqlite for SQLiteCheckpointer
+pip install "cubepi[postgres]"      # adds asyncpg + sqlalchemy + msgpack
+pip install "cubepi[mcp]"           # adds the MCP SDK for tool loaders
+pip install "cubepi[tracing]"       # adds opentelemetry-sdk for Tracer / Meter
+pip install "cubepi[tracing-otlp]"  # adds the OTLP/HTTP span exporter
+pip install "cubepi[sqlite,mcp,tracing]"  # combine
 ```
 
 ## With uv
@@ -31,7 +33,7 @@ pip and is the recommended workflow:
 
 ```bash
 uv add cubepi
-uv add "cubepi[sqlite,postgres,mcp]"
+uv add "cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]"
 ```
 
 In an existing uv project, `uv sync` re-locks the environment after
@@ -41,7 +43,7 @@ edits to `pyproject.toml`.
 
 ```bash
 poetry add cubepi
-poetry add "cubepi[sqlite,postgres,mcp]"
+poetry add "cubepi[sqlite,postgres,mcp,tracing,tracing-otlp]"
 ```
 
 ## Verifying the install
@@ -79,10 +81,12 @@ For the [FauxProvider](../guides/providers/custom#using-fauxprovider-in-tests)
 
 | Extra | Pulls in | Install when |
 |---|---|---|
-| (none) | core only | You only need in-memory state, no MCP |
+| (none) | core only | You only need in-memory state, no MCP, no tracing |
 | `[sqlite]` | `aiosqlite` | Single-process app needs disk persistence |
 | `[postgres]` | `asyncpg`, `sqlalchemy`, `msgpack` | Multi-instance / production — see [Postgres guide](../guides/checkpointing/postgres) |
 | `[mcp]` | `mcp` | You want to mount MCP server tools into your agent |
+| `[tracing]` | `opentelemetry-sdk` | You want OpenTelemetry traces (and optionally metrics) — see [Tracing guide](../guides/tracing/overview) |
+| `[tracing-otlp]` | `opentelemetry-exporter-otlp-proto-http` | Ship traces to an OTLP/HTTP backend (Jaeger ≥1.50, Tempo, Honeycomb, Datadog, …) |
 | `[docs]` | `griffe` | You're building the docs site (contributors only) |
 
 ## Next steps

--- a/website/versioned_docs/version-0.4/migration/from-langgraph.md
+++ b/website/versioned_docs/version-0.4/migration/from-langgraph.md
@@ -195,15 +195,20 @@ There's no built-in branching primitive; flow control happens through
   equivalent. CubePi's flow is linear so the picture would be a single
   line anyway.
 - **Time travel / fork** at arbitrary checkpoints. The Postgres schema
-  has fork columns but no API surface in v0.3.
-- **LangSmith / Langfuse vendor SDKs.** CubePi ships native
-  OpenTelemetry tracing instead — see [Tracing →
-  Overview](../guides/tracing/overview). Anything that speaks OTLP
-  (LangSmith's OTel endpoint, Langfuse v3, Jaeger, Tempo, Honeycomb,
-  Datadog, …) drops in via `Tracer(exporters=[OTLPSpanExporter(...)])`.
+  has fork columns but no API surface in v0.4.
+- **First-party UI for traces.** CubePi doesn't render its own trace
+  visualizer the way LangSmith / Langfuse do; instead it emits
+  vendor-neutral OpenTelemetry — point any OTLP backend
+  (LangSmith's OTel endpoint, Langfuse v3, Jaeger, Tempo,
+  Honeycomb, Datadog, …) at it via
+  `Tracer(exporters=[OTLPSpanExporter(...)])`. See
+  [Tracing → OTLP & Backends](../guides/tracing/otlp).
 
 ## What CubePi does that langgraph doesn't
 
+- **Native OpenTelemetry tracing** — `Tracer` + `Meter` emit OTel
+  spans + GenAI-semconv attributes out of the box, ingestible by
+  any OTLP backend. See [Tracing → Overview](../guides/tracing/overview).
 - **Native async-first** — every entry point is async. No
   `app.invoke` vs. `app.ainvoke` split.
 - **Append-only persistence** — O(1) DB writes, JSONB-queryable


### PR DESCRIPTION
## Summary

Multiple pre-tracing pitches remained even after the v0.4 release. User-reported gaps:

1. **Homepage Tracing card** — \`FeatureGrid\` had 6 cards, added a 7th
2. **Homepage Install matrix** — extras row missing \`tracing\` / \`tracing-otlp\`
3. **Homepage MetaBar version** — hardcoded \`v0.3.0\`
4. **Homepage Hero eyebrow** — also hardcoded \`v0.3.0 · alpha\`
5. **Installation page** — no \`[tracing]\` extras anywhere
6. **Core Concepts page** — no Tracer section
7. **Migration page** — OTel item still listed under \"What langgraph does that CubePi doesn't (yet)\"

Single fix for #3 + #4: parse \`pyproject.toml\` in \`docusaurus.config.ts\` once and expose as \`customFields.PACKAGE_VERSION\`. Single source of truth; homepage tracks releases automatically.

All four doc files mirrored into \`versioned_docs/version-0.4/\` and zh-Hans translations.

## Test plan
- [x] Manual edits done in one worktree (\`../cubepi.tracing-home\`)
- [ ] CI \`build-and-check\` succeeds (both en + zh-Hans build, all three versions render)
- [ ] codex review
- [ ] Cloudflare preview: homepage shows 7 cards, MetaBar/Hero say \`v0.4.0\`