### PR TITLE
feat(providers): self-describing errors with provider/model/cause context

### DIFF
--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -206,15 +206,18 @@ class AnthropicProvider(BaseProvider):
 
             except BaseException as e:
                 exc = e
+                err_text = self._error_message(e, model)
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
-                    error_message=str(e),
+                    error_message=err_text,
                     usage=Usage(),
                     timestamp=time.time(),
+                    provider_id=model.provider,
+                    model_id=model.id,
                 )
                 await self._emit(
-                    ms, StreamEvent(type="error", error_message=str(e)), model
+                    ms, StreamEvent(type="error", error_message=err_text), model
                 )
                 ms.set_result(error_msg)
                 if not isinstance(e, Exception):

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -175,6 +175,37 @@ class StreamEvent(BaseModel):
     error_message: str | None = None
 
 
+def format_provider_error(
+    exc: BaseException,
+    model: "Model",
+    base_url: str | None = None,
+) -> str:
+    """Build a self-describing error string for a failed provider call.
+
+    SDK exceptions like openai's ``APIConnectionError`` stringify to bare
+    ``"Connection error."`` and drop the transport failure into ``__cause__``
+    / ``__context__``. Without provider/model/cause context, a logged or
+    persisted error tells you nothing about *which* model failed or *why*.
+    """
+    target = f"{model.provider}/{model.id}"
+    if base_url:
+        target = f"{target} @ {base_url}"
+
+    chain: list[str] = [f"{type(exc).__name__}: {exc}"]
+    seen: set[int] = {id(exc)}
+    cur: BaseException | None = exc
+    while cur is not None:
+        nxt = cur.__cause__ or cur.__context__
+        if nxt is None or id(nxt) in seen:
+            break
+        seen.add(id(nxt))
+        chain.append(f"{type(nxt).__name__}: {nxt}")
+        cur = nxt
+
+    detail = " <- ".join(chain)
+    return f"[{target}] {detail}"
+
+
 class MessageStream:
     def __init__(self) -> None:
         self._queue: asyncio.Queue[StreamEvent | None] = asyncio.Queue()
@@ -582,6 +613,14 @@ class BaseProvider:
         options: StreamOptions | None = None,
     ) -> MessageStream:
         raise NotImplementedError
+
+    def _error_message(self, exc: BaseException, model: Model) -> str:
+        """Format a failed-call error with provider/model/base_url + cause."""
+        base_url: str | None = None
+        client = getattr(self, "_client", None)
+        if client is not None:
+            base_url = str(getattr(client, "base_url", "") or "") or None
+        return format_provider_error(exc, model, base_url)
 
     def subscribe_request(self, cb: OnRequestCallback) -> Callable[[], None]:
         """Register a persistent observer for request payloads.

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -461,15 +461,18 @@ class OpenAIProvider(BaseProvider):
 
             except BaseException as e:
                 exc = e
+                err_text = self._error_message(e, model)
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
-                    error_message=str(e),
+                    error_message=err_text,
                     usage=Usage(),
                     timestamp=time.time(),
+                    provider_id=model.provider,
+                    model_id=model.id,
                 )
                 await self._emit(
-                    ms, StreamEvent(type="error", error_message=str(e)), model
+                    ms, StreamEvent(type="error", error_message=err_text), model
                 )
                 ms.set_result(error_msg)
                 if not isinstance(e, Exception):

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -518,15 +518,18 @@ class OpenAIResponsesProvider(BaseProvider):
 
             except BaseException as e:
                 exc = e
+                err_text = self._error_message(e, model)
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
-                    error_message=str(e),
+                    error_message=err_text,
                     usage=Usage(),
                     timestamp=time.time(),
+                    provider_id=model.provider,
+                    model_id=model.id,
                 )
                 await self._emit(
-                    ms, StreamEvent(type="error", error_message=str(e)), model
+                    ms, StreamEvent(type="error", error_message=err_text), model
                 )
                 ms.set_result(error_msg)
                 if not isinstance(e, Exception):

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -825,6 +825,26 @@ class TestAnthropicStreamError:
         assert "error" in event_types
 
     @pytest.mark.asyncio
+    async def test_error_result_carries_provider_and_model(self):
+        provider = _make_provider("none")
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock()
+        mock_client.messages.stream = MagicMock(side_effect=RuntimeError("API down"))
+        provider._client = mock_client
+
+        model = _anthropic_model()
+        ms = await provider.stream(
+            model, [UserMessage(content=[TextContent(text="hi")])]
+        )
+        async for _ in ms:
+            pass
+        result = await ms.result()
+
+        assert result.provider_id == "anthropic"
+        assert result.model_id == model.id
+        assert f"anthropic/{model.id}" in (result.error_message or "")
+
+    @pytest.mark.asyncio
     async def test_base_exception_reraises(self):
         """When the SDK raises BaseException (not Exception), it should be re-raised on the task."""
 

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -16,7 +16,54 @@ from cubepi.providers.base import (
     ToolResultMessage,
     Usage,
     UserMessage,
+    format_provider_error,
 )
+
+
+class TestFormatProviderError:
+    @staticmethod
+    def _model() -> Model:
+        return Model(id="gpt-4o", provider="openai")
+
+    def test_includes_provider_model_and_exception(self):
+        msg = format_provider_error(RuntimeError("boom"), self._model())
+        assert "openai/gpt-4o" in msg
+        assert "RuntimeError" in msg
+        assert "boom" in msg
+
+    def test_includes_base_url_when_given(self):
+        msg = format_provider_error(
+            RuntimeError("boom"),
+            self._model(),
+            base_url="https://api.deepseek.com/anthropic",
+        )
+        assert "https://api.deepseek.com/anthropic" in msg
+
+    def test_surfaces_underlying_cause_chain(self):
+        # Mirrors openai's APIConnectionError("Connection error.") wrapping the
+        # real transport failure in __cause__ — the part users actually need.
+        try:
+            try:
+                raise OSError("Cannot connect to proxy 192.168.1.111:7892")
+            except OSError as root:
+                raise RuntimeError("Connection error.") from root
+        except RuntimeError as exc:
+            msg = format_provider_error(exc, self._model())
+        assert "Connection error." in msg
+        assert "Cannot connect to proxy 192.168.1.111:7892" in msg
+        assert "OSError" in msg
+
+    def test_surfaces_implicit_context_cause(self):
+        # Exceptions raised during handling without `from` keep the original in
+        # __context__; that must still be surfaced.
+        try:
+            try:
+                raise OSError("network down")
+            except OSError:
+                raise RuntimeError("wrapper")
+        except RuntimeError as exc:
+            msg = format_provider_error(exc, self._model())
+        assert "network down" in msg
 
 
 class TestMessageTypes:

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -571,6 +571,65 @@ class TestOpenAIStreamError:
             assert "error" in types
 
     @pytest.mark.asyncio
+    async def test_error_result_carries_provider_and_model(self):
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
+            mock_client.chat = MagicMock()
+            mock_client.chat.completions = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(
+                side_effect=RuntimeError("API down")
+            )
+
+            provider = OpenAIProvider(api_key="test-key")
+            provider._client = mock_client
+
+            ms = await provider.stream(
+                _model(),
+                [UserMessage(content=[TextContent(text="hi")])],
+            )
+            error_events = [e async for e in ms if e.type == "error"]
+            result = await ms.result()
+
+            assert result.provider_id == "openai"
+            assert result.model_id == "gpt-4o"
+            assert "openai/gpt-4o" in (result.error_message or "")
+            assert error_events and "openai/gpt-4o" in (
+                error_events[0].error_message or ""
+            )
+
+    @pytest.mark.asyncio
+    async def test_error_message_surfaces_underlying_cause(self):
+        try:
+            raise OSError("Cannot connect to proxy 192.168.1.111:7892")
+        except OSError as root:
+            api_err = RuntimeError("Connection error.")
+            api_err.__cause__ = root
+
+        with patch("openai.AsyncOpenAI") as mock_openai:
+            mock_client = MagicMock()
+            mock_openai.return_value = mock_client
+            mock_client.chat = MagicMock()
+            mock_client.chat.completions = MagicMock()
+            mock_client.chat.completions.create = AsyncMock(side_effect=api_err)
+
+            provider = OpenAIProvider(api_key="test-key")
+            provider._client = mock_client
+
+            ms = await provider.stream(
+                _model(),
+                [UserMessage(content=[TextContent(text="hi")])],
+            )
+            async for _ in ms:
+                pass
+            result = await ms.result()
+
+            assert "Connection error." in (result.error_message or "")
+            assert "Cannot connect to proxy 192.168.1.111:7892" in (
+                result.error_message or ""
+            )
+
+    @pytest.mark.asyncio
     async def test_base_exception_reraised(self):
         """BaseException subclass (non-Exception) should set error result and re-raise."""
 


### PR DESCRIPTION
## Summary
- Provider call failures stringified to bare messages like `Connection error.` (openai's `APIConnectionError.__str__`), and the error `AssistantMessage` carried empty `provider_id`/`model_id`. A logged or persisted error told you nothing about **which** model failed or **why**.
- Add `format_provider_error()` (base.py) that walks the `__cause__`/`__context__` chain and prefixes it with `provider/model[ @ base_url]`, surfaced via a new `BaseProvider._error_message()` helper.
- Stamp `provider_id`/`model_id` on the error result across all three providers (openai, anthropic, openai_responses).

### Before / After
A failed call that previously persisted as `Connection error.` (provider_id="", model_id="") now reads:
```
[deepseek/deepseek-v4-flash @ http://127.0.0.1:1/v1/] APIConnectionError: Connection error. <- ConnectError: All connection attempts failed <- ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 1)
```
with `provider_id="deepseek"`, `model_id="deepseek-v4-flash"`.

## Test plan
- [x] `format_provider_error` unit tests: provider/model, base_url, explicit `__cause__` chain, implicit `__context__` (test_base.py)
- [x] openai error path: provider/model stamped, cause surfaced (test_openai.py)
- [x] anthropic error path: provider/model stamped (test_anthropic.py)
- [x] Verified against a **real** openai SDK `APIConnectionError` (connection refused) — root `ConnectionRefusedError` with address surfaces
- [x] `tests/providers/` 324 passed; ruff clean