### PR TITLE
feat(tracing): add best-effort trace() scope helper

### DIFF
--- a/cubepi/tracing/__init__.py
+++ b/cubepi/tracing/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     "Meter",
     "SCHEMA_URL",
     "Tracer",
+    "trace",
     "tracing_context",
 ]
 
@@ -30,7 +31,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from cubepi.tracing.exporters import JsonlSpanExporter
     from cubepi.tracing.meter import Meter
     from cubepi.tracing.schema import SCHEMA_URL
-    from cubepi.tracing.tracer import Tracer
+    from cubepi.tracing.tracer import Tracer, trace
 
 _LAZY = {
     "tracing_context": ("cubepi.tracing.context", "tracing_context"),
@@ -38,6 +39,7 @@ _LAZY = {
     "Meter": ("cubepi.tracing.meter", "Meter"),
     "SCHEMA_URL": ("cubepi.tracing.schema", "SCHEMA_URL"),
     "Tracer": ("cubepi.tracing.tracer", "Tracer"),
+    "trace": ("cubepi.tracing.tracer", "trace"),
 }
 
 

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import logging
 import uuid
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable
 
@@ -379,3 +380,66 @@ def _build_resource(
         attrs["gen_ai.agent.version"] = agent_version
     # The SDK adds telemetry.sdk.* automatically.
     return Resource.create(attrs, schema_url=SCHEMA_URL)
+
+
+@contextlib.asynccontextmanager
+async def trace(
+    tracer: "Tracer | None",
+    agent: "Agent",
+) -> AsyncIterator[None]:
+    """Best-effort tracing scope for one agent run.
+
+    Attaches ``tracer`` to ``agent`` on enter and detaches + flushes its
+    buffered spans on exit. Every tracing fault — a failed attach, detach, or
+    flush — is logged and swallowed, so tracing can never break or fail the
+    work inside the ``async with`` block. Passing ``tracer=None`` makes the
+    block a no-op, which lets callers gate tracing on config without branching
+    at the call site.
+
+    This does **not** shut the tracer down: the tracer is reusable across runs,
+    so build it once (e.g. per process) and call ``await tracer.shutdown()``
+    when the owning process stops.
+
+    Unlike :meth:`Tracer.attached`, which surfaces flush failures to the caller,
+    this helper swallows them — use it when tracing is auxiliary to the work and
+    must never affect its outcome.
+
+    Example
+    -------
+    ::
+
+        async with trace(tracer, agent):
+            await agent.prompt("...")
+    """
+    if tracer is None:
+        yield
+        return
+
+    detach: "Callable[[], Any] | None" = None
+    try:
+        detach = tracer.attach(agent)
+    except Exception as exc:  # noqa: BLE001 — tracing must never break the run
+        _log_tracing_warning("attach failed; running untraced", exc)
+        detach = None
+
+    try:
+        yield
+    finally:
+        if detach is not None:
+            try:
+                result = detach()
+                # In an async context ``detach()`` returns a flush Task; await
+                # it so this run's spans are exported before the block exits.
+                if result is not None and hasattr(result, "__await__"):
+                    await result
+            except Exception as exc:  # noqa: BLE001 — flush/detach must never break the run
+                _log_tracing_warning("detach/flush failed", exc)
+
+
+def _log_tracing_warning(message: str, exc: BaseException) -> None:
+    """Log a swallowed tracing fault via stdlib ``logging`` — cubepi does not
+    depend on loguru. Hosts that use loguru can intercept stdlib logging to
+    route these records through it."""
+    logging.getLogger("cubepi.tracing").warning(
+        "cubepi tracing: %s", message, exc_info=exc
+    )

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -209,13 +209,17 @@ class Tracer:
             # an async context it's an ``asyncio.Task`` for the
             # flush; callers can ``await detach()`` to wait for
             # buffered spans to land (codex overall-review MAJOR).
-            flush_task = recorder_detach()
-            if mcp_tracing is not None and mcp_token is not None:
-                try:
-                    mcp_tracing.unregister_provider(mcp_token)
-                except Exception:
-                    pass
-            return flush_task
+            #
+            # Unregister MCP in a ``finally`` so a raising recorder detach
+            # can't leak the provider registration.
+            try:
+                return recorder_detach()
+            finally:
+                if mcp_tracing is not None and mcp_token is not None:
+                    try:
+                        mcp_tracing.unregister_provider(mcp_token)
+                    except Exception:
+                        pass
 
         return detach
 
@@ -439,7 +443,11 @@ async def trace(
 def _log_tracing_warning(message: str, exc: BaseException) -> None:
     """Log a swallowed tracing fault via stdlib ``logging`` — cubepi does not
     depend on loguru. Hosts that use loguru can intercept stdlib logging to
-    route these records through it."""
-    logging.getLogger("cubepi.tracing").warning(
-        "cubepi tracing: %s", message, exc_info=exc
-    )
+    route these records through it. The log call itself is guarded so a raising
+    logging handler can't defeat the best-effort guarantee."""
+    try:
+        logging.getLogger("cubepi.tracing").warning(
+            "cubepi tracing: %s", message, exc_info=exc
+        )
+    except Exception:  # noqa: BLE001 — logging must never break the run  # pragma: no cover
+        pass

--- a/tests/tracing/test_trace_scope.py
+++ b/tests/tracing/test_trace_scope.py
@@ -1,0 +1,114 @@
+"""The ``trace`` best-effort scope helper.
+
+``trace(tracer, agent)`` is a context manager that attaches the tracer on
+enter and detaches + flushes on exit, swallowing every tracing fault so that
+tracing can never break or fail the wrapped work. ``tracer=None`` is a no-op.
+These tests pin that contract: attach/detach lifecycle on the happy path, and
+silent fallback on attach / flush failures.
+"""
+
+from __future__ import annotations
+
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from cubepi.agent.agent import Agent
+from cubepi.providers.base import Model
+from cubepi.providers.faux import FauxProvider
+from cubepi.tracing import Tracer, trace
+
+MODEL = Model(id="faux-1", provider="faux")
+
+
+class _NullExporter(SpanExporter):
+    def export(self, spans):  # noqa: ANN001
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+def _build() -> tuple[Agent, FauxProvider, Tracer]:
+    provider = FauxProvider()
+    agent = Agent(provider=provider, model=MODEL, system_prompt="t")
+    tracer = Tracer(
+        service_name="t",
+        agent_name="t",
+        exporters=[_NullExporter()],
+        atexit_flush=False,
+    )
+    return agent, provider, tracer
+
+
+async def test_trace_none_is_noop():
+    agent, _provider, tracer = _build()
+    try:
+        ran = False
+        async with trace(None, agent):
+            ran = True
+        assert ran
+        assert agent._listeners == [], (
+            "no listeners should be attached when tracer is None"
+        )
+    finally:
+        await tracer.shutdown()
+
+
+async def test_trace_attaches_within_scope_and_detaches_after():
+    agent, provider, tracer = _build()
+    try:
+        assert agent._listeners == []
+        async with trace(tracer, agent):
+            assert len(agent._listeners) == 1, (
+                "recorder should be attached inside the scope"
+            )
+            assert len(provider._request_listeners) == 1
+            assert len(provider._chunk_listeners) == 1
+            assert len(provider._response_listeners) == 1
+        assert agent._listeners == [], "recorder should be detached after the scope"
+        assert provider._request_listeners == []
+        assert provider._chunk_listeners == []
+        assert provider._response_listeners == []
+    finally:
+        await tracer.shutdown()
+
+
+async def test_trace_swallows_attach_failure(monkeypatch):
+    agent, _provider, tracer = _build()
+    try:
+
+        def _boom(_listener):  # noqa: ANN202
+            raise RuntimeError("attach boom")
+
+        monkeypatch.setattr(agent, "subscribe", _boom)
+
+        ran = False
+        async with trace(tracer, agent):  # must not raise
+            ran = True
+        assert ran, "body must run even when attach fails"
+    finally:
+        await tracer.shutdown()
+
+
+async def test_trace_swallows_flush_failure(monkeypatch):
+    agent, provider, tracer = _build()
+    try:
+
+        async def _boom_flush(*_args, **_kwargs):  # noqa: ANN202
+            raise RuntimeError("flush boom")
+
+        monkeypatch.setattr(tracer, "force_flush", _boom_flush)
+
+        ran = False
+        async with trace(tracer, agent):
+            ran = True
+        assert ran, "body must run even when flush fails on exit"
+        # Synchronous detach still ran before the flush failure.
+        assert agent._listeners == []
+        assert provider._request_listeners == []
+    finally:
+        # Restore the real force_flush so shutdown() can clean up.
+        monkeypatch.undo()
+        await tracer.shutdown()

--- a/tests/tracing/test_trace_scope.py
+++ b/tests/tracing/test_trace_scope.py
@@ -9,6 +9,9 @@ silent fallback on attach / flush failures.
 
 from __future__ import annotations
 
+import asyncio
+
+import pytest
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
 from cubepi.agent.agent import Agent
@@ -112,3 +115,94 @@ async def test_trace_swallows_flush_failure(monkeypatch):
         # Restore the real force_flush so shutdown() can clean up.
         monkeypatch.undo()
         await tracer.shutdown()
+
+
+async def test_trace_swallows_detach_failure(monkeypatch):
+    agent, _provider, tracer = _build()
+    try:
+
+        def _raising_detach():  # noqa: ANN202
+            raise RuntimeError("detach boom")
+
+        monkeypatch.setattr(tracer, "attach", lambda _agent: _raising_detach)
+
+        ran = False
+        async with trace(tracer, agent):  # must not raise
+            ran = True
+        assert ran, "body must run even when the detach callable itself raises"
+    finally:
+        await tracer.shutdown()
+
+
+async def test_trace_awaits_flush_task_on_exit(monkeypatch):
+    agent, _provider, tracer = _build()
+    flushed = {"done": False}
+
+    async def _flush() -> None:
+        await asyncio.sleep(0)
+        flushed["done"] = True
+
+    def _detach():  # noqa: ANN202
+        return asyncio.get_running_loop().create_task(_flush())
+
+    monkeypatch.setattr(tracer, "attach", lambda _agent: _detach)
+    try:
+        async with trace(tracer, agent):
+            pass
+        assert flushed["done"], "trace must await the flush task before the scope exits"
+    finally:
+        await tracer.shutdown()
+
+
+async def test_trace_preserves_body_exception_when_cleanup_fails(monkeypatch):
+    agent, _provider, tracer = _build()
+
+    class _Sentinel(Exception):
+        pass
+
+    def _raising_detach():  # noqa: ANN202
+        raise RuntimeError("detach boom")
+
+    monkeypatch.setattr(tracer, "attach", lambda _agent: _raising_detach)
+    try:
+        with pytest.raises(_Sentinel):
+            async with trace(tracer, agent):
+                raise _Sentinel("body failed")
+    finally:
+        await tracer.shutdown()
+
+
+async def test_trace_swallows_mcp_unregister_failure(monkeypatch):
+    # Real attach registers the MCP provider; make unregister blow up on detach.
+    # The body must still run and the failure must not propagate.
+    agent, _provider, tracer = _build()
+    try:
+        import cubepi.mcp._tracing as mcp_tracing
+
+        def _boom(_token):  # noqa: ANN202
+            raise RuntimeError("unregister boom")
+
+        monkeypatch.setattr(mcp_tracing, "unregister_provider", _boom)
+
+        ran = False
+        async with trace(tracer, agent):
+            ran = True
+        assert ran, "body must run even when MCP unregister fails on detach"
+    finally:
+        await tracer.shutdown()
+
+
+async def test_trace_does_not_shutdown_tracer(monkeypatch):
+    agent, _provider, tracer = _build()
+    calls = {"n": 0}
+
+    async def _spy_shutdown(*_args, **_kwargs) -> None:  # noqa: ANN202
+        calls["n"] += 1
+
+    monkeypatch.setattr(tracer, "shutdown", _spy_shutdown)
+    async with trace(tracer, agent):
+        pass
+    assert calls["n"] == 0, "trace must not shut the tracer down — the owner does"
+    # Real cleanup.
+    monkeypatch.undo()
+    await tracer.shutdown()

--- a/tests/tracing/test_trace_scope.py
+++ b/tests/tracing/test_trace_scope.py
@@ -176,8 +176,10 @@ async def test_trace_swallows_mcp_unregister_failure(monkeypatch):
     # Real attach registers the MCP provider; make unregister blow up on detach.
     # The body must still run and the failure must not propagate.
     agent, _provider, tracer = _build()
+    import cubepi.mcp._tracing as mcp_tracing
+
+    baseline = len(mcp_tracing._provider_stack)
     try:
-        import cubepi.mcp._tracing as mcp_tracing
 
         def _boom(_token):  # noqa: ANN202
             raise RuntimeError("unregister boom")
@@ -189,6 +191,9 @@ async def test_trace_swallows_mcp_unregister_failure(monkeypatch):
             ran = True
         assert ran, "body must run even when MCP unregister fails on detach"
     finally:
+        # The patched unregister raised before popping, so restore the
+        # module-level provider stack to avoid polluting later tests.
+        del mcp_tracing._provider_stack[baseline:]
         await tracer.shutdown()
 
 


### PR DESCRIPTION
## Summary
Adds a public best-effort tracing scope so callers don't have to hand-roll `AsyncExitStack` + `try/except` to trace one agent run safely.

```python
from cubepi.tracing import trace

async with trace(tracer, agent):
    await agent.prompt("...")
```

`trace(tracer, agent)`:
- attaches the tracer on enter, detaches + awaits the flush task on exit;
- **swallows every tracing fault** (attach, detach, or flush) — tracing can never break or fail the wrapped work;
- treats `tracer=None` as a no-op, so callers can gate tracing on config without branching at the call site;
- does **not** `shutdown()` the tracer — it's reusable; the owner shuts it down once at process stop;
- logs swallowed faults via stdlib `logging` (no loguru dependency; hosts that use loguru can intercept stdlib logging).

Unlike `Tracer.attached`, which surfaces flush failures to the caller, `trace()` is best-effort and never does.

Also hardens `Tracer.attach`'s `detach()` closure: MCP unregister now runs in a `finally`, so a raising recorder-detach can't leak the provider registration.

## Tests
`tests/tracing/test_trace_scope.py` (10 tests): None no-op; attach/detach lifecycle; attach failure swallowed; flush failure swallowed; detach-callable raising swallowed; flush Task actually awaited; body exception preserved when cleanup also fails; MCP-unregister failure swallowed; `trace()` never calls `shutdown()`.

## Local Codex review
Two rounds: caught a latent MCP-unregister leak in `detach()` and an unguarded log call (both fixed), plus test-coverage gaps (all added), plus a test-pollution nit on the MCP provider stack (fixed). Re-review confirmed all resolved.

## Test plan
- [x] New tests pass (10)
- [x] Full `tests/tracing/` suite passes (the 2 OTLP failures are pre-existing in this env from the missing `tracing-otlp` optional dep)
- [x] `ruff check` + `ruff format --check` clean