### PR TITLE
fix(anthropic): carry parsed tool args in streaming toolcall_end

### DIFF
--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from typing import Any, Literal, Protocol, runtime_checkable
 
@@ -271,6 +272,10 @@ class AnthropicProvider(BaseProvider):
                         model,
                     )
 
+                    # Accumulate streamed tool-call args JSON per content index
+                    # so toolcall_end can carry parsed arguments (the Anthropic
+                    # stream only delivers them as incremental partial_json).
+                    tool_args_buffers: dict[int, str] = {}
                     async for event in stream:
                         if opts.signal and opts.signal.is_set():
                             aborted = partial.model_copy(
@@ -290,7 +295,9 @@ class AnthropicProvider(BaseProvider):
                             ms.set_result(aborted)
                             return
 
-                        await self._handle_event(event, partial, ms, model)
+                        await self._handle_event(
+                            event, partial, ms, model, tool_args_buffers
+                        )
 
                     final_msg = await stream.get_final_message()
                     result = self._convert_response(final_msg, model)
@@ -502,6 +509,7 @@ class AnthropicProvider(BaseProvider):
         partial: AssistantMessage,
         ms: MessageStream,
         model: Model,
+        tool_args_buffers: dict[int, str],
     ) -> None:
         etype = getattr(event, "type", "")
         if etype == "content_block_start":
@@ -576,6 +584,9 @@ class AnthropicProvider(BaseProvider):
                     model,
                 )
             elif hasattr(delta, "partial_json"):
+                tool_args_buffers[idx] = (
+                    tool_args_buffers.get(idx, "") + delta.partial_json
+                )
                 await self._emit(
                     ms,
                     StreamEvent(
@@ -611,6 +622,19 @@ class AnthropicProvider(BaseProvider):
                         model,
                     )
                 elif isinstance(last, ToolCall):
+                    # Parse the accumulated args JSON onto the block so the
+                    # toolcall_end partial exposes real arguments (not the empty
+                    # dict from toolcall_start). Malformed/empty JSON falls back
+                    # to {} — the final message still carries authoritative args.
+                    raw = tool_args_buffers.get(idx, "")
+                    try:
+                        parsed = json.loads(raw) if raw.strip() else {}
+                    except json.JSONDecodeError:
+                        parsed = {}
+                    if isinstance(parsed, dict) and parsed:
+                        partial.content[-1] = ToolCall(
+                            id=last.id, name=last.name, arguments=parsed
+                        )
                     await self._emit(
                         ms,
                         StreamEvent(

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -576,6 +576,110 @@ class TestAnthropicStreamToolCall:
         assert result.content[0].id == "toolu_abc"
         assert result.content[0].arguments == {"q": "test"}
 
+    @pytest.mark.asyncio
+    async def test_toolcall_end_partial_carries_parsed_arguments(self):
+        """The streaming toolcall_end event must expose the parsed arguments.
+
+        Live consumers (the SSE tool_call event → frontend tool cards showing
+        the web_search query / web_fetch url) read the toolcall_end partial. If
+        args are only assembled in the final message, the card stays blank until
+        reload.
+        """
+        events = [
+            _make_event(
+                "content_block_start",
+                index=0,
+                content_block=_make_content_block(
+                    "tool_use", id="toolu_abc", name="search"
+                ),
+            ),
+            _make_event(
+                "content_block_delta",
+                index=0,
+                delta=SimpleNamespace(partial_json='{"q": '),
+            ),
+            _make_event(
+                "content_block_delta",
+                index=0,
+                delta=SimpleNamespace(partial_json='"test"}'),
+            ),
+            _make_event("content_block_stop", index=0),
+        ]
+        final = _make_final_message(
+            content=[
+                SimpleNamespace(
+                    type="tool_use", id="toolu_abc", name="search", input={"q": "test"}
+                )
+            ],
+            stop_reason="tool_use",
+        )
+        provider = _make_provider("none")
+        _inject_mock_stream(provider, _MockAnthropicStream(events, final))
+
+        ms = await provider.stream(
+            _anthropic_model(),
+            [UserMessage(content=[TextContent(text="search for test")])],
+        )
+        stream_events = []
+        async for event in ms:
+            stream_events.append(event)
+        await ms.result()
+
+        end_events = [e for e in stream_events if e.type == "toolcall_end"]
+        assert end_events, "expected a toolcall_end event"
+        partial = end_events[-1].partial
+        tool_blocks = [b for b in partial.content if isinstance(b, ToolCall)]
+        assert tool_blocks, "toolcall_end partial should contain the ToolCall block"
+        assert tool_blocks[-1].arguments == {"q": "test"}
+
+    @pytest.mark.asyncio
+    async def test_toolcall_end_partial_tolerates_malformed_args_json(self):
+        """Incomplete/garbled partial_json falls back to {} without raising;
+        the final message still carries authoritative args."""
+        events = [
+            _make_event(
+                "content_block_start",
+                index=0,
+                content_block=_make_content_block(
+                    "tool_use", id="toolu_x", name="search"
+                ),
+            ),
+            _make_event(
+                "content_block_delta",
+                index=0,
+                delta=SimpleNamespace(
+                    partial_json='{"q": "te'
+                ),  # truncated, invalid JSON
+            ),
+            _make_event("content_block_stop", index=0),
+        ]
+        final = _make_final_message(
+            content=[
+                SimpleNamespace(
+                    type="tool_use", id="toolu_x", name="search", input={"q": "te"}
+                )
+            ],
+            stop_reason="tool_use",
+        )
+        provider = _make_provider("none")
+        _inject_mock_stream(provider, _MockAnthropicStream(events, final))
+
+        ms = await provider.stream(
+            _anthropic_model(),
+            [UserMessage(content=[TextContent(text="x")])],
+        )
+        stream_events = []
+        async for event in ms:
+            stream_events.append(event)
+        await ms.result()
+
+        end_events = [e for e in stream_events if e.type == "toolcall_end"]
+        assert end_events
+        tool_blocks = [
+            b for b in end_events[-1].partial.content if isinstance(b, ToolCall)
+        ]
+        assert tool_blocks[-1].arguments == {}
+
 
 class TestAnthropicStreamKwargsBuilding:
     """Verify kwargs sent to the Anthropic SDK."""


### PR DESCRIPTION
## Summary
- During streaming, the Anthropic provider set `ToolCall.arguments={}` at `toolcall_start` and emitted the args only as incremental `partial_json` deltas — it never folded them back onto the block. So the `toolcall_end` event's `partial` carried **empty** arguments.
- Live consumers read that partial: the cubebox SSE `tool_call` event ships `arguments: {}`, so the UI tool cards (web_search query / web_fetch URL) stayed **blank during the run** and only filled in after reload (when the final message's authoritative args — `block.input` — load from history).
- Fix: accumulate `partial_json` per content index and parse it onto the `ToolCall` block at `content_block_stop`, before emitting `toolcall_end`. Malformed/empty JSON falls back to `{}` (the final message still carries authoritative args, so no regression).

## How it was found
Captured the live SSE stream in a browser run: every `tool_call` event had `"arguments": {}`, while the reloaded conversation showed the real query/URL. Traced to the streaming partial never accumulating tool args.

## Test plan
- [x] New `test_toolcall_end_partial_carries_parsed_arguments` — toolcall_end partial exposes parsed `{"q": "test"}`
- [x] New `test_toolcall_end_partial_tolerates_malformed_args_json` — truncated JSON → `{}`, no raise
- [x] Existing tool-call streaming + final-message assertions still pass
- [x] Full provider suite green (373 passed); ruff check + format clean; 100% patch coverage