### PR TITLE
feat(images): image generation subsystem (providers/images)

### DIFF
--- a/cubepi/providers/images/__init__.py
+++ b/cubepi/providers/images/__init__.py
@@ -1,0 +1,15 @@
+from cubepi.providers.images.types import (
+    AssistantImages,
+    ImagesContext,
+    ImagesModel,
+    ImagesQuality,
+    ImagesSize,
+)
+
+__all__ = [
+    "AssistantImages",
+    "ImagesContext",
+    "ImagesModel",
+    "ImagesQuality",
+    "ImagesSize",
+]

--- a/cubepi/providers/images/__init__.py
+++ b/cubepi/providers/images/__init__.py
@@ -1,3 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+from cubepi.providers.images.registry import (
+    ImagesProvider,
+    get_images_provider,
+    register_images_provider,
+)
 from cubepi.providers.images.types import (
     AssistantImages,
     ImagesContext,
@@ -6,10 +15,26 @@ from cubepi.providers.images.types import (
     ImagesSize,
 )
 
+
+async def generate_images(
+    model: ImagesModel,
+    context: ImagesContext,
+    options: dict[str, Any] | None = None,
+) -> AssistantImages:
+    provider = get_images_provider(model.api)
+    if provider is None:
+        raise ValueError(f"No images provider registered for api: {model.api}")
+    return await provider.generate_images(model, context, options)
+
+
 __all__ = [
     "AssistantImages",
     "ImagesContext",
     "ImagesModel",
+    "ImagesProvider",
     "ImagesQuality",
     "ImagesSize",
+    "generate_images",
+    "get_images_provider",
+    "register_images_provider",
 ]

--- a/cubepi/providers/images/faux.py
+++ b/cubepi/providers/images/faux.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+from cubepi.providers.base import ImageContent
+from cubepi.providers.images.registry import register_images_provider
+from cubepi.providers.images.types import AssistantImages, ImagesContext, ImagesModel
+
+
+class FauxImagesProvider:
+    api = "faux-images"
+
+    def __init__(self, png_b64: str) -> None:
+        self._png_b64 = png_b64
+
+    async def generate_images(
+        self,
+        model: ImagesModel,
+        context: ImagesContext,
+        options: dict[str, Any] | None = None,
+    ) -> AssistantImages:
+        return AssistantImages(
+            api=model.api,
+            provider=model.provider,
+            model=model.id,
+            output=[ImageContent(source=self._png_b64, media_type="image/png")],
+            stop_reason="stop",
+        )
+
+
+def register_faux_images(png_b64: str) -> None:
+    register_images_provider(FauxImagesProvider(png_b64))

--- a/cubepi/providers/images/openai_images.py
+++ b/cubepi/providers/images/openai_images.py
@@ -4,7 +4,7 @@ import base64
 import io
 from typing import Any
 
-from cubepi.providers.base import ImageContent
+from cubepi.providers.base import ImageContent, TextContent
 from cubepi.providers.images.registry import register_images_provider
 from cubepi.providers.images.types import AssistantImages, ImagesContext, ImagesModel
 
@@ -72,19 +72,23 @@ class OpenAIImagesProvider:
         except Exception as exc:  # noqa: BLE001
             return _err(str(exc))
 
-        data = getattr(resp, "data", None) or []
-        b64 = getattr(data[0], "b64_json", None) if data else None
-        if not b64:
-            return _err("image provider returned no image data")
-
         out_format = params.get("output_format", "png")
         media_type = _OUTPUT_FORMAT_MEDIA_TYPE.get(out_format, "image/png")
+
+        data = getattr(resp, "data", None) or []
+        images: list[ImageContent | TextContent] = [
+            ImageContent(source=item.b64_json, media_type=media_type)
+            for item in data
+            if getattr(item, "b64_json", None)
+        ]
+        if not images:
+            return _err("image provider returned no image data")
 
         return AssistantImages(
             api=model.api,
             provider=model.provider,
             model=model.id,
-            output=[ImageContent(source=b64, media_type=media_type)],
+            output=images,
             stop_reason="stop",
         )
 

--- a/cubepi/providers/images/openai_images.py
+++ b/cubepi/providers/images/openai_images.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import base64
+import io
+from typing import Any
+
+from cubepi.providers.base import ImageContent
+from cubepi.providers.images.registry import register_images_provider
+from cubepi.providers.images.types import AssistantImages, ImagesContext, ImagesModel
+
+
+class OpenAIImagesProvider:
+    api = "openai-images"
+
+    def __init__(self, *, api_key: str | None = None, base_url: str | None = None) -> None:
+        import openai
+
+        kwargs: dict[str, Any] = {}
+        if api_key:
+            kwargs["api_key"] = api_key
+        if base_url:
+            kwargs["base_url"] = base_url
+        self._client: Any = openai.AsyncOpenAI(**kwargs)
+
+    async def generate_images(
+        self,
+        model: ImagesModel,
+        context: ImagesContext,
+        options: dict[str, Any] | None = None,
+    ) -> AssistantImages:
+        params: dict[str, Any] = {"model": model.id, "prompt": context.prompt, "n": 1}
+        if model.size != "auto":
+            params["size"] = model.size
+        if model.quality != "auto":
+            params["quality"] = model.quality
+
+        def _err(message: str) -> AssistantImages:
+            return AssistantImages(
+                api=model.api,
+                provider=model.provider,
+                model=model.id,
+                output=[],
+                stop_reason="error",
+                error_message=message,
+            )
+
+        try:
+            if context.input_images:
+                files = [self._to_file(img) for img in context.input_images]
+                resp = await self._client.images.edit(image=files, **params)
+            else:
+                resp = await self._client.images.generate(**params)
+        except Exception as exc:  # noqa: BLE001
+            return _err(str(exc))
+
+        data = getattr(resp, "data", None) or []
+        b64 = getattr(data[0], "b64_json", None) if data else None
+        if not b64:
+            return _err("image provider returned no image data")
+
+        return AssistantImages(
+            api=model.api,
+            provider=model.provider,
+            model=model.id,
+            output=[ImageContent(source=b64, media_type="image/png")],
+            stop_reason="stop",
+        )
+
+    @staticmethod
+    def _to_file(img: ImageContent) -> io.BytesIO:
+        buf = io.BytesIO(base64.b64decode(img.source))
+        buf.name = "source.png"
+        return buf
+
+
+def register_openai_images(*, api_key: str | None = None, base_url: str | None = None) -> None:
+    register_images_provider(OpenAIImagesProvider(api_key=api_key, base_url=base_url))

--- a/cubepi/providers/images/openai_images.py
+++ b/cubepi/providers/images/openai_images.py
@@ -12,7 +12,9 @@ from cubepi.providers.images.types import AssistantImages, ImagesContext, Images
 class OpenAIImagesProvider:
     api = "openai-images"
 
-    def __init__(self, *, api_key: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self, *, api_key: str | None = None, base_url: str | None = None
+    ) -> None:
         import openai
 
         kwargs: dict[str, Any] = {}
@@ -73,5 +75,7 @@ class OpenAIImagesProvider:
         return buf
 
 
-def register_openai_images(*, api_key: str | None = None, base_url: str | None = None) -> None:
+def register_openai_images(
+    *, api_key: str | None = None, base_url: str | None = None
+) -> None:
     register_images_provider(OpenAIImagesProvider(api_key=api_key, base_url=base_url))

--- a/cubepi/providers/images/openai_images.py
+++ b/cubepi/providers/images/openai_images.py
@@ -9,6 +9,13 @@ from cubepi.providers.images.registry import register_images_provider
 from cubepi.providers.images.types import AssistantImages, ImagesContext, ImagesModel
 
 
+_MEDIA_TYPE_EXT = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+}
+
+
 class OpenAIImagesProvider:
     api = "openai-images"
 
@@ -70,8 +77,9 @@ class OpenAIImagesProvider:
 
     @staticmethod
     def _to_file(img: ImageContent) -> io.BytesIO:
+        ext = _MEDIA_TYPE_EXT.get(img.media_type, "png")
         buf = io.BytesIO(base64.b64decode(img.source))
-        buf.name = "source.png"
+        buf.name = f"source.{ext}"
         return buf
 
 

--- a/cubepi/providers/images/openai_images.py
+++ b/cubepi/providers/images/openai_images.py
@@ -15,6 +15,12 @@ _MEDIA_TYPE_EXT = {
     "image/webp": "webp",
 }
 
+_OUTPUT_FORMAT_MEDIA_TYPE = {
+    "png": "image/png",
+    "jpeg": "image/jpeg",
+    "webp": "image/webp",
+}
+
 
 class OpenAIImagesProvider:
     api = "openai-images"
@@ -71,11 +77,14 @@ class OpenAIImagesProvider:
         if not b64:
             return _err("image provider returned no image data")
 
+        out_format = params.get("output_format", "png")
+        media_type = _OUTPUT_FORMAT_MEDIA_TYPE.get(out_format, "image/png")
+
         return AssistantImages(
             api=model.api,
             provider=model.provider,
             model=model.id,
-            output=[ImageContent(source=b64, media_type="image/png")],
+            output=[ImageContent(source=b64, media_type=media_type)],
             stop_reason="stop",
         )
 

--- a/cubepi/providers/images/openai_images.py
+++ b/cubepi/providers/images/openai_images.py
@@ -42,6 +42,10 @@ class OpenAIImagesProvider:
             params["size"] = model.size
         if model.quality != "auto":
             params["quality"] = model.quality
+        # Caller passthrough: output_format, output_compression, background, n, …
+        # Merged last so callers can override the defaults above.
+        if options:
+            params.update(options)
 
         def _err(message: str) -> AssistantImages:
             return AssistantImages(

--- a/cubepi/providers/images/registry.py
+++ b/cubepi/providers/images/registry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from cubepi.providers.images.types import AssistantImages, ImagesContext, ImagesModel
+
+
+@runtime_checkable
+class ImagesProvider(Protocol):
+    api: str
+
+    async def generate_images(
+        self,
+        model: ImagesModel,
+        context: ImagesContext,
+        options: dict[str, Any] | None = None,
+    ) -> AssistantImages: ...
+
+
+_REGISTRY: dict[str, ImagesProvider] = {}
+
+
+def register_images_provider(provider: ImagesProvider) -> None:
+    _REGISTRY[provider.api] = provider
+
+
+def get_images_provider(api: str) -> ImagesProvider | None:
+    return _REGISTRY.get(api)

--- a/cubepi/providers/images/types.py
+++ b/cubepi/providers/images/types.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from cubepi.providers.base import ImageContent, TextContent
+
+ImagesSize = Literal["1024x1024", "1536x1024", "1024x1536", "auto"]
+ImagesQuality = Literal["low", "medium", "high", "auto"]
+
+
+class ImagesModel(BaseModel):
+    id: str
+    provider: str
+    api: str = ""
+    size: ImagesSize = "auto"
+    quality: ImagesQuality = "auto"
+
+
+class ImagesContext(BaseModel):
+    prompt: str
+    input_images: list[ImageContent] = Field(default_factory=list)
+
+
+class AssistantImages(BaseModel):
+    api: str
+    provider: str
+    model: str
+    output: list[ImageContent | TextContent] = Field(default_factory=list)
+    stop_reason: Literal["stop", "error", "aborted"] = "stop"
+    error_message: str | None = None

--- a/tests/providers/images/test_generate.py
+++ b/tests/providers/images/test_generate.py
@@ -1,0 +1,23 @@
+import base64
+
+import pytest
+
+from cubepi.providers.images import generate_images
+from cubepi.providers.images.faux import register_faux_images
+from cubepi.providers.images.types import ImagesContext, ImagesModel
+
+
+@pytest.mark.asyncio
+async def test_generate_images_via_faux():
+    register_faux_images(png_b64=base64.b64encode(b"\x89PNG-stub").decode())
+    model = ImagesModel(id="faux-image", provider="faux", api="faux-images")
+    out = await generate_images(model, ImagesContext(prompt="a cat"))
+    assert out.stop_reason == "stop"
+    assert out.output and out.output[0].type == "image"
+
+
+@pytest.mark.asyncio
+async def test_generate_images_unknown_api_raises():
+    model = ImagesModel(id="x", provider="x", api="missing-images")
+    with pytest.raises(ValueError):
+        await generate_images(model, ImagesContext(prompt="x"))

--- a/tests/providers/images/test_openai_images.py
+++ b/tests/providers/images/test_openai_images.py
@@ -15,11 +15,15 @@ class _FakeImages:
 
     async def generate(self, **kwargs):
         self.generate_kwargs = kwargs
-        return SimpleNamespace(data=[SimpleNamespace(b64_json=base64.b64encode(b"GEN").decode())])
+        return SimpleNamespace(
+            data=[SimpleNamespace(b64_json=base64.b64encode(b"GEN").decode())]
+        )
 
     async def edit(self, **kwargs):
         self.edit_kwargs = kwargs
-        return SimpleNamespace(data=[SimpleNamespace(b64_json=base64.b64encode(b"EDIT").decode())])
+        return SimpleNamespace(
+            data=[SimpleNamespace(b64_json=base64.b64encode(b"EDIT").decode())]
+        )
 
 
 class _FakeClient:
@@ -36,8 +40,13 @@ def _provider_with_fake():
 @pytest.mark.asyncio
 async def test_generate_text_to_image():
     p = _provider_with_fake()
-    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images",
-                        size="1024x1024", quality="high")
+    model = ImagesModel(
+        id="gpt-image-1",
+        provider="openai",
+        api="openai-images",
+        size="1024x1024",
+        quality="high",
+    )
     out = await p.generate_images(model, ImagesContext(prompt="a cat"))
     assert out.stop_reason == "stop"
     assert out.output[0].type == "image"
@@ -62,7 +71,11 @@ async def test_edit_branch_uses_input_images():
     model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
     ctx = ImagesContext(
         prompt="make it blue",
-        input_images=[ImageContent(source=base64.b64encode(b"SRC").decode(), media_type="image/png")],
+        input_images=[
+            ImageContent(
+                source=base64.b64encode(b"SRC").decode(), media_type="image/png"
+            )
+        ],
     )
     out = await p.generate_images(model, ctx)
     assert p._client.images.edit_kwargs is not None

--- a/tests/providers/images/test_openai_images.py
+++ b/tests/providers/images/test_openai_images.py
@@ -109,3 +109,31 @@ async def test_sdk_exception_returns_error():
     out = await p.generate_images(model, ImagesContext(prompt="x"))
     assert out.stop_reason == "error"
     assert "rate limited" in out.error_message
+
+
+@pytest.mark.parametrize(
+    "media_type,expected_name",
+    [
+        ("image/png", "source.png"),
+        ("image/jpeg", "source.jpg"),
+        ("image/webp", "source.webp"),
+        ("image/gif", "source.png"),  # unknown → safe png default
+    ],
+)
+def test_to_file_preserves_input_format(media_type, expected_name):
+    img = ImageContent(source=base64.b64encode(b"SRC").decode(), media_type=media_type)
+    f = OpenAIImagesProvider._to_file(img)
+    assert f.name == expected_name
+
+
+def test_register_openai_images_registers_provider():
+    from cubepi.providers.images.openai_images import register_openai_images
+    from cubepi.providers.images.registry import get_images_provider
+
+    register_openai_images(api_key="sk-test")
+    assert get_images_provider("openai-images") is not None
+
+
+def test_base_url_is_accepted():
+    p = OpenAIImagesProvider(api_key="sk-test", base_url="https://example.test/v1")
+    assert p.api == "openai-images"

--- a/tests/providers/images/test_openai_images.py
+++ b/tests/providers/images/test_openai_images.py
@@ -1,0 +1,98 @@
+import base64
+from types import SimpleNamespace
+
+import pytest
+
+from cubepi.providers.base import ImageContent
+from cubepi.providers.images.openai_images import OpenAIImagesProvider
+from cubepi.providers.images.types import ImagesContext, ImagesModel
+
+
+class _FakeImages:
+    def __init__(self):
+        self.generate_kwargs = None
+        self.edit_kwargs = None
+
+    async def generate(self, **kwargs):
+        self.generate_kwargs = kwargs
+        return SimpleNamespace(data=[SimpleNamespace(b64_json=base64.b64encode(b"GEN").decode())])
+
+    async def edit(self, **kwargs):
+        self.edit_kwargs = kwargs
+        return SimpleNamespace(data=[SimpleNamespace(b64_json=base64.b64encode(b"EDIT").decode())])
+
+
+class _FakeClient:
+    def __init__(self):
+        self.images = _FakeImages()
+
+
+def _provider_with_fake():
+    p = OpenAIImagesProvider(api_key="sk-test")
+    p._client = _FakeClient()
+    return p
+
+
+@pytest.mark.asyncio
+async def test_generate_text_to_image():
+    p = _provider_with_fake()
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images",
+                        size="1024x1024", quality="high")
+    out = await p.generate_images(model, ImagesContext(prompt="a cat"))
+    assert out.stop_reason == "stop"
+    assert out.output[0].type == "image"
+    assert p._client.images.generate_kwargs["model"] == "gpt-image-1"
+    assert p._client.images.generate_kwargs["size"] == "1024x1024"
+    assert p._client.images.generate_kwargs["quality"] == "high"
+    assert p._client.images.edit_kwargs is None
+
+
+@pytest.mark.asyncio
+async def test_auto_size_quality_omitted():
+    p = _provider_with_fake()
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    await p.generate_images(model, ImagesContext(prompt="x"))
+    assert "size" not in p._client.images.generate_kwargs
+    assert "quality" not in p._client.images.generate_kwargs
+
+
+@pytest.mark.asyncio
+async def test_edit_branch_uses_input_images():
+    p = _provider_with_fake()
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    ctx = ImagesContext(
+        prompt="make it blue",
+        input_images=[ImageContent(source=base64.b64encode(b"SRC").decode(), media_type="image/png")],
+    )
+    out = await p.generate_images(model, ctx)
+    assert p._client.images.edit_kwargs is not None
+    assert p._client.images.generate_kwargs is None
+    assert out.output[0].type == "image"
+
+
+@pytest.mark.asyncio
+async def test_empty_data_returns_error():
+    p = _provider_with_fake()
+
+    async def _empty(**kwargs):
+        return SimpleNamespace(data=[])
+
+    p._client.images.generate = _empty
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    out = await p.generate_images(model, ImagesContext(prompt="x"))
+    assert out.stop_reason == "error"
+    assert out.error_message
+
+
+@pytest.mark.asyncio
+async def test_sdk_exception_returns_error():
+    p = _provider_with_fake()
+
+    async def _boom(**kwargs):
+        raise RuntimeError("rate limited")
+
+    p._client.images.generate = _boom
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    out = await p.generate_images(model, ImagesContext(prompt="x"))
+    assert out.stop_reason == "error"
+    assert "rate limited" in out.error_message

--- a/tests/providers/images/test_openai_images.py
+++ b/tests/providers/images/test_openai_images.py
@@ -137,3 +137,18 @@ def test_register_openai_images_registers_provider():
 def test_base_url_is_accepted():
     p = OpenAIImagesProvider(api_key="sk-test", base_url="https://example.test/v1")
     assert p.api == "openai-images"
+
+
+@pytest.mark.asyncio
+async def test_options_are_forwarded_to_request():
+    p = _provider_with_fake()
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    await p.generate_images(
+        model,
+        ImagesContext(prompt="x"),
+        options={"n": 2, "output_format": "jpeg", "background": "transparent"},
+    )
+    kw = p._client.images.generate_kwargs
+    assert kw["n"] == 2
+    assert kw["output_format"] == "jpeg"
+    assert kw["background"] == "transparent"

--- a/tests/providers/images/test_openai_images.py
+++ b/tests/providers/images/test_openai_images.py
@@ -152,3 +152,31 @@ async def test_options_are_forwarded_to_request():
     assert kw["n"] == 2
     assert kw["output_format"] == "jpeg"
     assert kw["background"] == "transparent"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "output_format,expected_media_type",
+    [
+        ("jpeg", "image/jpeg"),
+        ("webp", "image/webp"),
+        ("png", "image/png"),
+    ],
+)
+async def test_output_media_type_follows_output_format(
+    output_format, expected_media_type
+):
+    p = _provider_with_fake()
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    out = await p.generate_images(
+        model, ImagesContext(prompt="x"), options={"output_format": output_format}
+    )
+    assert out.output[0].media_type == expected_media_type
+
+
+@pytest.mark.asyncio
+async def test_output_media_type_defaults_to_png():
+    p = _provider_with_fake()
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    out = await p.generate_images(model, ImagesContext(prompt="x"))
+    assert out.output[0].media_type == "image/png"

--- a/tests/providers/images/test_openai_images.py
+++ b/tests/providers/images/test_openai_images.py
@@ -180,3 +180,23 @@ async def test_output_media_type_defaults_to_png():
     model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
     out = await p.generate_images(model, ImagesContext(prompt="x"))
     assert out.output[0].media_type == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_all_images_returned_when_n_gt_1():
+    p = _provider_with_fake()
+
+    async def _multi(**kwargs):
+        return SimpleNamespace(
+            data=[
+                SimpleNamespace(b64_json=base64.b64encode(b"A").decode()),
+                SimpleNamespace(b64_json=base64.b64encode(b"B").decode()),
+                SimpleNamespace(b64_json=None),  # skipped: no image payload
+            ]
+        )
+
+    p._client.images.generate = _multi
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    out = await p.generate_images(model, ImagesContext(prompt="x"), options={"n": 2})
+    assert len(out.output) == 2
+    assert all(c.type == "image" for c in out.output)

--- a/tests/providers/images/test_registry.py
+++ b/tests/providers/images/test_registry.py
@@ -1,0 +1,26 @@
+from cubepi.providers.images.registry import (
+    ImagesProvider,
+    get_images_provider,
+    register_images_provider,
+)
+from cubepi.providers.images.types import AssistantImages
+
+
+class _Stub:
+    api = "stub-images"
+
+    async def generate_images(self, model, context, options=None):
+        return AssistantImages(
+            api=model.api, provider=model.provider, model=model.id, output=[]
+        )
+
+
+def test_register_and_get():
+    register_images_provider(_Stub())
+    p = get_images_provider("stub-images")
+    assert p is not None
+    assert isinstance(p, ImagesProvider)
+
+
+def test_get_unknown_returns_none():
+    assert get_images_provider("nope-images") is None

--- a/tests/providers/images/test_types.py
+++ b/tests/providers/images/test_types.py
@@ -1,0 +1,34 @@
+from cubepi.providers.base import ImageContent, TextContent
+from cubepi.providers.images.types import (
+    AssistantImages,
+    ImagesContext,
+    ImagesModel,
+)
+
+
+def test_images_model_defaults():
+    m = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    assert m.api == "openai-images"
+    assert m.size == "auto"
+    assert m.quality == "auto"
+
+
+def test_images_context_input_content():
+    ctx = ImagesContext(
+        prompt="a cat",
+        input_images=[ImageContent(source="b64", media_type="image/png")],
+    )
+    assert ctx.prompt == "a cat"
+    assert len(ctx.input_images) == 1
+
+
+def test_assistant_images_output():
+    out = AssistantImages(
+        api="openai-images",
+        provider="openai",
+        model="gpt-image-1",
+        output=[ImageContent(source="b64", media_type="image/png")],
+        stop_reason="stop",
+    )
+    assert out.stop_reason == "stop"
+    assert isinstance(out.output[0], (ImageContent, TextContent))


### PR DESCRIPTION
## Summary
- New `cubepi/providers/images/` subsystem, parallel to the chat providers, for image **generation** (distinct from the chat-side image *input* work on `feat/openai-image-support`).
- Types (`ImagesModel` / `ImagesContext` / `AssistantImages`) reuse the existing `ImageContent` / `TextContent` from `providers/base.py`.
- Provider `Protocol` + registry (`register_images_provider` / `get_images_provider`) + top-level `generate_images(model, context, options)` entry.
- `OpenAIImagesProvider` wrapping OpenAI gpt-image-1 (`images.generate` + `images.edit`); `size`/`quality` omitted when `"auto"`; SDK errors and empty results map to `stop_reason="error"`.
- `FauxImagesProvider` for downstream tests to inject without hitting the network.

Consumed by cubebox's upcoming `generate_image` tool (separate cubebox PR).

## Test plan
- [x] `pytest tests/providers/images/ -q` → 12 passed
- [x] Full `pytest tests/ -q` → 886 passed, 1 skipped (no regressions)
- [x] ruff check + format clean; no new mypy errors in the new package