### PR TITLE
refactor(images): extensible provider interface (slim model + class factory)

### DIFF
--- a/cubepi/providers/images/__init__.py
+++ b/cubepi/providers/images/__init__.py
@@ -1,40 +1,29 @@
 from __future__ import annotations
 
-from typing import Any
+# Import openai_images so its module-level register_images_provider_class call runs,
+# making create_images_provider("openai-images", ...) work out of the box.
+from cubepi.providers.images import openai_images as _openai_images_mod  # noqa: F401
 
+from cubepi.providers.images.faux import FauxImagesProvider
+from cubepi.providers.images.openai_images import OpenAIImagesProvider
 from cubepi.providers.images.registry import (
     ImagesProvider,
-    get_images_provider,
-    register_images_provider,
+    create_images_provider,
+    register_images_provider_class,
 )
 from cubepi.providers.images.types import (
     AssistantImages,
     ImagesContext,
     ImagesModel,
-    ImagesQuality,
-    ImagesSize,
 )
-
-
-async def generate_images(
-    model: ImagesModel,
-    context: ImagesContext,
-    options: dict[str, Any] | None = None,
-) -> AssistantImages:
-    provider = get_images_provider(model.api)
-    if provider is None:
-        raise ValueError(f"No images provider registered for api: {model.api}")
-    return await provider.generate_images(model, context, options)
-
 
 __all__ = [
     "AssistantImages",
     "ImagesContext",
     "ImagesModel",
     "ImagesProvider",
-    "ImagesQuality",
-    "ImagesSize",
-    "generate_images",
-    "get_images_provider",
-    "register_images_provider",
+    "FauxImagesProvider",
+    "OpenAIImagesProvider",
+    "create_images_provider",
+    "register_images_provider_class",
 ]

--- a/cubepi/providers/images/faux.py
+++ b/cubepi/providers/images/faux.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from cubepi.providers.base import ImageContent
-from cubepi.providers.images.registry import register_images_provider
 from cubepi.providers.images.types import AssistantImages, ImagesContext, ImagesModel
 
 
@@ -26,7 +25,3 @@ class FauxImagesProvider:
             output=[ImageContent(source=self._png_b64, media_type="image/png")],
             stop_reason="stop",
         )
-
-
-def register_faux_images(png_b64: str) -> None:
-    register_images_provider(FauxImagesProvider(png_b64))

--- a/cubepi/providers/images/openai_images.py
+++ b/cubepi/providers/images/openai_images.py
@@ -5,7 +5,7 @@ import io
 from typing import Any
 
 from cubepi.providers.base import ImageContent, TextContent
-from cubepi.providers.images.registry import register_images_provider
+from cubepi.providers.images.registry import register_images_provider_class
 from cubepi.providers.images.types import AssistantImages, ImagesContext, ImagesModel
 
 
@@ -43,13 +43,8 @@ class OpenAIImagesProvider:
         context: ImagesContext,
         options: dict[str, Any] | None = None,
     ) -> AssistantImages:
+        # Provider-specific knobs (size, quality, output_format, …) flow through options.
         params: dict[str, Any] = {"model": model.id, "prompt": context.prompt, "n": 1}
-        if model.size != "auto":
-            params["size"] = model.size
-        if model.quality != "auto":
-            params["quality"] = model.quality
-        # Caller passthrough: output_format, output_compression, background, n, …
-        # Merged last so callers can override the defaults above.
         if options:
             params.update(options)
 
@@ -100,7 +95,4 @@ class OpenAIImagesProvider:
         return buf
 
 
-def register_openai_images(
-    *, api_key: str | None = None, base_url: str | None = None
-) -> None:
-    register_images_provider(OpenAIImagesProvider(api_key=api_key, base_url=base_url))
+register_images_provider_class("openai-images", OpenAIImagesProvider)

--- a/cubepi/providers/images/registry.py
+++ b/cubepi/providers/images/registry.py
@@ -17,12 +17,15 @@ class ImagesProvider(Protocol):
     ) -> AssistantImages: ...
 
 
-_REGISTRY: dict[str, ImagesProvider] = {}
+_PROVIDER_CLASSES: dict[str, type[ImagesProvider]] = {}
 
 
-def register_images_provider(provider: ImagesProvider) -> None:
-    _REGISTRY[provider.api] = provider
+def register_images_provider_class(api: str, cls: type[ImagesProvider]) -> None:
+    _PROVIDER_CLASSES[api] = cls
 
 
-def get_images_provider(api: str) -> ImagesProvider | None:
-    return _REGISTRY.get(api)
+def create_images_provider(api: str, **kwargs: Any) -> ImagesProvider:
+    cls = _PROVIDER_CLASSES.get(api)
+    if cls is None:
+        raise ValueError(f"No images provider registered for api: {api}")
+    return cls(**kwargs)  # type: ignore[call-arg]

--- a/cubepi/providers/images/types.py
+++ b/cubepi/providers/images/types.py
@@ -6,16 +6,11 @@ from pydantic import BaseModel, Field
 
 from cubepi.providers.base import ImageContent, TextContent
 
-ImagesSize = Literal["1024x1024", "1536x1024", "1024x1536", "auto"]
-ImagesQuality = Literal["low", "medium", "high", "auto"]
-
 
 class ImagesModel(BaseModel):
     id: str
     provider: str
     api: str = ""
-    size: ImagesSize = "auto"
-    quality: ImagesQuality = "auto"
 
 
 class ImagesContext(BaseModel):

--- a/tests/providers/images/test_generate.py
+++ b/tests/providers/images/test_generate.py
@@ -2,22 +2,31 @@ import base64
 
 import pytest
 
-from cubepi.providers.images import generate_images
-from cubepi.providers.images.faux import register_faux_images
+from cubepi.providers.images import create_images_provider
+from cubepi.providers.images.faux import FauxImagesProvider
+from cubepi.providers.images.openai_images import OpenAIImagesProvider
 from cubepi.providers.images.types import ImagesContext, ImagesModel
 
 
 @pytest.mark.asyncio
-async def test_generate_images_via_faux():
-    register_faux_images(png_b64=base64.b64encode(b"\x89PNG-stub").decode())
+async def test_faux_provider_direct():
+    """FauxImagesProvider can be instantiated directly and returns an image."""
+    provider = FauxImagesProvider(png_b64=base64.b64encode(b"\x89PNG-stub").decode())
     model = ImagesModel(id="faux-image", provider="faux", api="faux-images")
-    out = await generate_images(model, ImagesContext(prompt="a cat"))
+    out = await provider.generate_images(model, ImagesContext(prompt="a cat"))
     assert out.stop_reason == "stop"
     assert out.output and out.output[0].type == "image"
 
 
 @pytest.mark.asyncio
-async def test_generate_images_unknown_api_raises():
-    model = ImagesModel(id="x", provider="x", api="missing-images")
+async def test_create_openai_provider_returns_instance():
+    """create_images_provider('openai-images', ...) returns an OpenAIImagesProvider."""
+    # Importing cubepi.providers.images registers the class; just verify the factory works.
+    p = create_images_provider("openai-images", api_key="sk-test")
+    assert isinstance(p, OpenAIImagesProvider)
+    assert p.api == "openai-images"
+
+
+def test_create_unknown_api_raises():
     with pytest.raises(ValueError):
-        await generate_images(model, ImagesContext(prompt="x"))
+        create_images_provider("missing-images")

--- a/tests/providers/images/test_openai_images.py
+++ b/tests/providers/images/test_openai_images.py
@@ -38,16 +38,15 @@ def _provider_with_fake():
 
 
 @pytest.mark.asyncio
-async def test_generate_text_to_image():
+async def test_generate_text_to_image_with_options():
+    """size and quality passed via options flow into the API call."""
     p = _provider_with_fake()
-    model = ImagesModel(
-        id="gpt-image-1",
-        provider="openai",
-        api="openai-images",
-        size="1024x1024",
-        quality="high",
+    model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    out = await p.generate_images(
+        model,
+        ImagesContext(prompt="a cat"),
+        options={"size": "1024x1024", "quality": "high"},
     )
-    out = await p.generate_images(model, ImagesContext(prompt="a cat"))
     assert out.stop_reason == "stop"
     assert out.output[0].type == "image"
     assert p._client.images.generate_kwargs["model"] == "gpt-image-1"
@@ -57,7 +56,8 @@ async def test_generate_text_to_image():
 
 
 @pytest.mark.asyncio
-async def test_auto_size_quality_omitted():
+async def test_no_options_means_no_size_or_quality():
+    """When no options are passed, size and quality are absent from the request."""
     p = _provider_with_fake()
     model = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
     await p.generate_images(model, ImagesContext(prompt="x"))
@@ -126,12 +126,12 @@ def test_to_file_preserves_input_format(media_type, expected_name):
     assert f.name == expected_name
 
 
-def test_register_openai_images_registers_provider():
-    from cubepi.providers.images.openai_images import register_openai_images
-    from cubepi.providers.images.registry import get_images_provider
+def test_class_registration_works():
+    """Importing openai_images registers the class; create_images_provider works."""
+    from cubepi.providers.images import create_images_provider
 
-    register_openai_images(api_key="sk-test")
-    assert get_images_provider("openai-images") is not None
+    p = create_images_provider("openai-images", api_key="sk-test")
+    assert isinstance(p, OpenAIImagesProvider)
 
 
 def test_base_url_is_accepted():

--- a/tests/providers/images/test_registry.py
+++ b/tests/providers/images/test_registry.py
@@ -1,13 +1,18 @@
+import pytest
+
 from cubepi.providers.images.registry import (
     ImagesProvider,
-    get_images_provider,
-    register_images_provider,
+    create_images_provider,
+    register_images_provider_class,
 )
 from cubepi.providers.images.types import AssistantImages
 
 
-class _Stub:
+class _StubProvider:
     api = "stub-images"
+
+    def __init__(self, *, token: str = "") -> None:
+        self.token = token
 
     async def generate_images(self, model, context, options=None):
         return AssistantImages(
@@ -15,12 +20,22 @@ class _Stub:
         )
 
 
-def test_register_and_get():
-    register_images_provider(_Stub())
-    p = get_images_provider("stub-images")
-    assert p is not None
+def test_register_and_create():
+    register_images_provider_class("stub-images", _StubProvider)  # type: ignore[arg-type]
+    p = create_images_provider("stub-images")
     assert isinstance(p, ImagesProvider)
+    assert p.api == "stub-images"
 
 
-def test_get_unknown_returns_none():
-    assert get_images_provider("nope-images") is None
+def test_create_passes_kwargs():
+    register_images_provider_class("stub-images", _StubProvider)  # type: ignore[arg-type]
+    p = create_images_provider("stub-images", token="abc")
+    assert isinstance(p, _StubProvider)
+    assert p.token == "abc"
+
+
+def test_create_unknown_api_raises():
+    with pytest.raises(
+        ValueError, match="No images provider registered for api: nope-images"
+    ):
+        create_images_provider("nope-images")

--- a/tests/providers/images/test_types.py
+++ b/tests/providers/images/test_types.py
@@ -6,11 +6,24 @@ from cubepi.providers.images.types import (
 )
 
 
-def test_images_model_defaults():
+def test_images_model_fields():
     m = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    assert m.id == "gpt-image-1"
+    assert m.provider == "openai"
     assert m.api == "openai-images"
-    assert m.size == "auto"
-    assert m.quality == "auto"
+
+
+def test_images_model_api_defaults_to_empty():
+    m = ImagesModel(id="gpt-image-1", provider="openai")
+    assert m.api == ""
+
+
+def test_images_model_no_size_or_quality():
+    # size and quality are not fields on ImagesModel; only id/provider/api exist.
+    m = ImagesModel(id="gpt-image-1", provider="openai", api="openai-images")
+    assert not hasattr(m, "size")
+    assert not hasattr(m, "quality")
+    assert set(ImagesModel.model_fields) == {"id", "provider", "api"}
 
 
 def test_images_context_input_content():


### PR DESCRIPTION
## Summary
Reshapes the `providers/images/` interface (from #110) so future providers with different APIs (e.g. Google "nano banana"/Gemini) plug in cleanly.

- `ImagesModel` slimmed to identity only (`id`/`provider`/`api`); removed OpenAI-specific `size`/`quality` Literals. Provider-specific knobs (size, quality, output_format, aspect_ratio, …) now flow through the per-call `options` dict, which each provider interprets.
- Replaced the instance registry with a **class factory**: `register_images_provider_class(api, cls)` + `create_images_provider(api, **creds)`. Callers construct the right per-run provider instance from an `api` string (mirrors the chat-side `build_cubepi_provider(api)`).
- `OpenAIImagesProvider` builds params from `{model, prompt, n} + options`; keeps output_format→media_type, multi-image, edit branch, error handling. Registered as a class on import.
- Removed top-level `generate_images()` + instance-registry helpers (callers use `create_images_provider(...).generate_images(...)` or instantiate directly). No other callers in the repo.

## Test plan
- [x] `pytest tests/providers/images/ -q` → 28 passed
- [x] `pytest tests/providers tests/agent -q` → 509 passed
- [x] ruff + format clean; mypy clean on the images module