### PR TITLE
fix(docs): version-aware section links with single-section nav highlight

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -87,9 +87,29 @@ const config: Config = {
       title: 'CubePi',
       logo: { alt: 'CubePi logo', src: 'img/brand/cubepi-logo.svg' },
       items: [
-        { type: 'doc', docId: 'getting-started/installation', label: 'Docs', position: 'left' },
-        { type: 'doc', docId: 'api/index', label: 'API', position: 'left' },
-        { type: 'doc', docId: 'recipes/weather-agent', label: 'Recipes', position: 'left' },
+        // Path-based active matching so each top-nav item highlights only for
+        // its own docs section. `type: 'doc'` can't do this here because every
+        // doc lives in one shared sidebar, which lights up all three at once.
+        // Each regex tolerates an optional locale prefix (/zh-Hans) and an
+        // optional version segment (e.g. /docs/0.4/) before the section.
+        {
+          to: '/docs/getting-started/installation',
+          label: 'Docs',
+          position: 'left',
+          activeBaseRegex: '^(?:/zh-Hans)?/docs/(?!(?:(?:\\d+\\.\\d+|next)/)?(?:api|recipes)(?:/|$))',
+        },
+        {
+          to: '/docs/api/',
+          label: 'API',
+          position: 'left',
+          activeBaseRegex: '^(?:/zh-Hans)?/docs/(?:(?:\\d+\\.\\d+|next)/)?api(?:/|$)',
+        },
+        {
+          to: '/docs/recipes/weather-agent',
+          label: 'Recipes',
+          position: 'left',
+          activeBaseRegex: '^(?:/zh-Hans)?/docs/(?:(?:\\d+\\.\\d+|next)/)?recipes(?:/|$)',
+        },
         { to: '/changelog', label: 'Changelog', position: 'left' },
         { type: 'docsVersionDropdown', position: 'right' },
         { type: 'localeDropdown', position: 'right' },

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -87,29 +87,12 @@ const config: Config = {
       title: 'CubePi',
       logo: { alt: 'CubePi logo', src: 'img/brand/cubepi-logo.svg' },
       items: [
-        // Path-based active matching so each top-nav item highlights only for
-        // its own docs section. `type: 'doc'` can't do this here because every
-        // doc lives in one shared sidebar, which lights up all three at once.
-        // Each regex tolerates an optional locale prefix (/zh-Hans) and an
-        // optional version segment (e.g. /docs/0.4/) before the section.
-        {
-          to: '/docs/getting-started/installation',
-          label: 'Docs',
-          position: 'left',
-          activeBaseRegex: '^(?:/zh-Hans)?/docs/(?!(?:(?:\\d+\\.\\d+|next)/)?(?:api|recipes)(?:/|$))',
-        },
-        {
-          to: '/docs/api/',
-          label: 'API',
-          position: 'left',
-          activeBaseRegex: '^(?:/zh-Hans)?/docs/(?:(?:\\d+\\.\\d+|next)/)?api(?:/|$)',
-        },
-        {
-          to: '/docs/recipes/weather-agent',
-          label: 'Recipes',
-          position: 'left',
-          activeBaseRegex: '^(?:/zh-Hans)?/docs/(?:(?:\\d+\\.\\d+|next)/)?recipes(?:/|$)',
-        },
+        // Version-aware section links (see src/components/VersionAwareDocLink):
+        // active state is path-driven so only one lights up per page, and the
+        // target stays within the version the reader is currently browsing.
+        { type: 'custom-versionAwareDocLink', section: 'docs', label: 'Docs', position: 'left' },
+        { type: 'custom-versionAwareDocLink', section: 'api', label: 'API', position: 'left' },
+        { type: 'custom-versionAwareDocLink', section: 'recipes', label: 'Recipes', position: 'left' },
         { to: '/changelog', label: 'Changelog', position: 'left' },
         { type: 'docsVersionDropdown', position: 'right' },
         { type: 'localeDropdown', position: 'right' },

--- a/website/src/components/VersionAwareDocLink.tsx
+++ b/website/src/components/VersionAwareDocLink.tsx
@@ -1,0 +1,53 @@
+import React, {type ReactNode} from 'react';
+import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import type {Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
+import {
+  useActiveDocContext,
+  useLatestVersion,
+} from '@docusaurus/plugin-content-docs/client';
+
+type Section = 'docs' | 'api' | 'recipes';
+
+// One shared sidebar means a plain `type: 'doc'` item would light up all three
+// top-nav links at once. We instead drive the active state from the pathname
+// (per-section regex, tolerant of the optional /zh-Hans locale and /docs/0.4/
+// version segments) while building a version-aware `to` so clicking stays in
+// whatever version the reader is currently browsing.
+const SECTIONS: Record<Section, {entry: string; activeBaseRegex: string}> = {
+  docs: {
+    entry: 'getting-started/installation',
+    activeBaseRegex:
+      '^(?:/zh-Hans)?/docs/(?!(?:(?:\\d+\\.\\d+|next)/)?(?:api|recipes)(?:/|$))',
+  },
+  api: {
+    entry: 'api/',
+    activeBaseRegex: '^(?:/zh-Hans)?/docs/(?:(?:\\d+\\.\\d+|next)/)?api(?:/|$)',
+  },
+  recipes: {
+    entry: 'recipes/weather-agent',
+    activeBaseRegex: '^(?:/zh-Hans)?/docs/(?:(?:\\d+\\.\\d+|next)/)?recipes(?:/|$)',
+  },
+};
+
+type Props = Omit<DefaultNavbarItemProps, 'to' | 'activeBaseRegex'> & {
+  section: Section;
+};
+
+export default function VersionAwareDocLink({
+  section,
+  ...props
+}: Props): ReactNode {
+  const {activeVersion} = useActiveDocContext('default');
+  const latestVersion = useLatestVersion('default');
+  const version = activeVersion ?? latestVersion;
+  const {entry, activeBaseRegex} = SECTIONS[section];
+  const base = version.path.replace(/\/$/, '');
+
+  return (
+    <DefaultNavbarItem
+      {...props}
+      to={`${base}/${entry}`}
+      activeBaseRegex={activeBaseRegex}
+    />
+  );
+}

--- a/website/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/website/src/theme/NavbarItem/ComponentTypes.tsx
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import VersionAwareDocLink from '@site/src/components/VersionAwareDocLink';
+
+export default {
+  ...ComponentTypes,
+  'custom-versionAwareDocLink': VersionAwareDocLink,
+};


### PR DESCRIPTION
## Summary

Clicking **Docs** in the top nav also showed **API** and **Recipes** as
active. Root cause: all three were `type: 'doc'` items and every doc lives in
the single shared `docs` sidebar, so Docusaurus marks all three active on any
docs page.

Stock config can't give all three of {correct highlight, version-aware nav,
unified sidebar} at once — highlight and rendered sidebar are both tied to the
doc's sidebar membership. So this adds a small custom navbar item,
`VersionAwareDocLink` (registered via `src/theme/NavbarItem/ComponentTypes`),
that:

- drives the **active state from the pathname** (per-section regex, tolerant of
  the optional `/zh-Hans` locale prefix and `/docs/<version>/` segment) → only
  one item lights up per page;
- builds a **version-aware `to`** from the reader's current docs version → a
  click stays within the version being browsed (e.g. on `/docs/0.4/...` all
  section links point at `/docs/0.4/...`);
- leaves the **unified left sidebar untouched**.

## Test plan

`docusaurus build` (both locales) + `tsc` (new files clean). Inspected built HTML:

| Page | Active item | Section link targets |
|---|---|---|
| latest getting-started / api / recipes | the matching one only | `/docs/...` |
| `/docs/0.4/api` | API only | all three → `/docs/0.4/...` |
| `/docs/0.4/getting-started`, `/docs/0.4/recipes` | matching one only | `/docs/0.4/...` |
| zh-Hans equivalents | matching one only | `/zh-Hans/docs[/0.4]/...` |