### PR TITLE
feat(agent): cancel a not-yet-drained steering message by steer_id

### DIFF
--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -61,6 +61,16 @@ class _MessageQueue:
         self._messages = self._messages[1:]
         return [first]
 
+    def remove(self, steer_id: str) -> bool:
+        kept = [
+            m
+            for m in self._messages
+            if getattr(m, "metadata", {}).get("steer_id") != steer_id
+        ]
+        removed = len(kept) != len(self._messages)
+        self._messages = kept
+        return removed
+
     def clear(self) -> None:
         self._messages = []
 
@@ -180,6 +190,14 @@ class Agent(Generic[TMessage]):
 
     def steer(self, message: Message) -> None:
         self._steering_queue.enqueue(message)
+
+    def cancel_steer(self, steer_id: str) -> bool:
+        """Remove a not-yet-drained steering message by its steer_id.
+
+        Returns True if a queued message was removed; False if it was already
+        drained or never queued (best-effort cancel).
+        """
+        return self._steering_queue.remove(steer_id)
 
     def follow_up(self, message: Message) -> None:
         self._follow_up_queue.enqueue(message)

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -531,3 +531,38 @@ class TestAgentPromptInputTypes:
         assert "first" in texts
         assert "second" in texts
         assert isinstance(agent.state.messages[-1], AssistantMessage)
+
+
+def _steer_msg(text: str, steer_id: str) -> UserMessage:
+    return UserMessage(
+        content=[TextContent(text=text)], metadata={"steer_id": steer_id}
+    )
+
+
+def test_message_queue_remove_by_steer_id():
+    q = _MessageQueue(mode="all")
+    q.enqueue(_steer_msg("a", "s1"))
+    q.enqueue(_steer_msg("b", "s2"))
+    assert q.remove("s1") is True
+    assert [m.content[0].text for m in q.drain()] == ["b"]
+
+
+def test_message_queue_remove_missing_returns_false():
+    q = _MessageQueue(mode="all")
+    q.enqueue(_steer_msg("a", "s1"))
+    assert q.remove("nope") is False
+    assert len(q.drain()) == 1
+
+
+def test_message_queue_remove_ignores_messages_without_steer_id():
+    q = _MessageQueue(mode="all")
+    q.enqueue(UserMessage(content=[TextContent(text="x")]))  # no metadata.steer_id
+    assert q.remove("s1") is False
+
+
+@pytest.mark.asyncio
+async def test_agent_cancel_steer_removes_queued_steer():
+    agent = Agent(provider=FauxProvider(), model=make_model())
+    agent.steer(_steer_msg("hi", "s1"))
+    assert agent.cancel_steer("s1") is True
+    assert agent.cancel_steer("s1") is False


### PR DESCRIPTION
## Summary
- Add `_MessageQueue.remove(steer_id)` to drop a queued steering message whose `metadata["steer_id"]` matches.
- Add `Agent.cancel_steer(steer_id) -> bool` (best-effort: returns False if already drained or never queued).

## Why
Downstream (cubebox) is adding a "cancel a pending steer" UX: a user can retract a steer they just sent, as long as the agent hasn't drained it yet. cubepi needs queue removal by a client-supplied id carried in `UserMessage.metadata["steer_id"]`. No Message-schema change.

## Test plan
- [x] `uv run pytest tests/agent/test_agent.py -k "cancel_steer or message_queue_remove"` (4 new tests)
- [x] Full `tests/agent/test_agent.py` suite green