### PR TITLE
feat(trace-cli): show span_id in trace view node labels

### DIFF
--- a/cubepi/cli/trace/render.py
+++ b/cubepi/cli/trace/render.py
@@ -61,6 +61,8 @@ def _node_label(node: TreeNode) -> str:
         parts.append("[yellow]aborted[/yellow]")
     if node.orphan:
         parts.append("[dim](orphan)[/dim]")
+    if sp.span_id:
+        parts.append(f"[dim]\\[{sp.span_id[:10]}][/dim]")
     return "  ".join(parts)
 
 


### PR DESCRIPTION
## Summary
- Append a short span_id (`0x` + 8 hex) to each span label in `cubepi trace view`, so a specific span can be located in the raw JSONL straight from the rendered tree.

## Why
When inspecting a trace, there was no way to map a node in the rendered tree back to its concrete span in the `.jsonl` file. Showing the span_id makes "find/inspect this exact span" trivial.

## Test plan
- [x] `cubepi trace view <id>` renders `[0x........]` after each node label (verified on a real trace).
- [x] No behavior change beyond the label suffix.