### PR TITLE
fix(tracing): nest subagent runs under their execute_tool span

### DIFF
--- a/cubepi/cli/trace/commands.py
+++ b/cubepi/cli/trace/commands.py
@@ -20,7 +20,7 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
     p_ls.set_defaults(handler=cmd_ls)
 
     p_view = trace_sub.add_parser("view", help="render a run as a tree")
-    p_view.add_argument("run", help="run id or path to a .jsonl file")
+    p_view.add_argument("run", help="trace id or path to a .jsonl file")
     _add_dir(p_view)
     p_view.add_argument(
         "-v", "--verbose", action="store_true", help="expand all span attributes"
@@ -31,7 +31,7 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
     p_view.set_defaults(handler=cmd_view)
 
     p_follow = trace_sub.add_parser("follow", help="stream spans as they complete")
-    p_follow.add_argument("run", help="run id or path to a .jsonl file")
+    p_follow.add_argument("run", help="trace id or path to a .jsonl file")
     _add_dir(p_follow)
     p_follow.add_argument(
         "--interval", type=float, default=0.5, help="poll interval seconds"
@@ -42,7 +42,7 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
     p_follow.set_defaults(handler=cmd_follow)
 
     p_stats = trace_sub.add_parser("stats", help="aggregate stats across runs")
-    p_stats.add_argument("runs", nargs="*", help="run ids (default: whole dir)")
+    p_stats.add_argument("runs", nargs="*", help="trace ids (default: whole dir)")
     _add_dir(p_stats)
     p_stats.add_argument("--by", choices=("model", "tool"), default="model")
     p_stats.add_argument("--since", default=None, help="YYYY-MM-DD lower bound")

--- a/cubepi/cli/trace/follow.py
+++ b/cubepi/cli/trace/follow.py
@@ -69,10 +69,10 @@ def follow_run(
     interval: float = 0.5,
     timeout: float | None = None,
 ) -> None:
-    """Tail a run, printing each span as it completes.
+    """Tail a trace, printing each span as it completes.
 
-    ``resolve_files`` is re-invoked every poll so a run crossing UTC midnight
-    (a new ``<next-date>/<run_id>.jsonl`` file) is picked up without restarting.
+    ``resolve_files`` is re-invoked every poll so a trace crossing UTC midnight
+    (a new ``<next-date>/<trace_id>.jsonl`` file) is picked up without restarting.
     Each file keeps its own offset/buffer/skipped state. Exits when the root
     invoke_agent span appears, after ``timeout`` idle seconds, or on Ctrl-C.
     """

--- a/cubepi/cli/trace/loader.py
+++ b/cubepi/cli/trace/loader.py
@@ -1,4 +1,4 @@
-"""Discover trace files, resolve a run id to file(s), read spans."""
+"""Discover trace files, resolve a trace id to file(s), read spans."""
 
 from __future__ import annotations
 
@@ -15,16 +15,16 @@ _MIN = datetime.min.replace(tzinfo=timezone.utc)
 
 
 class RunResolutionError(Exception):
-    """Raised when a run id / path cannot be resolved to any file."""
+    """Raised when a trace id / path cannot be resolved to any file."""
 
 
 def resolve_run(arg: str, directory: Path) -> list[Path]:
     """Resolve a CLI argument to one or more JSONL files.
 
-    A ``.jsonl`` path is used directly. Otherwise ``arg`` is a run id and we
-    glob ``<dir>/*/{run_id}.jsonl`` across date subdirs — a run that crosses
-    UTC midnight is split across date dirs, so ALL matches are returned and
-    later merged. Zero matches is an error.
+    A ``.jsonl`` path is used directly. Otherwise ``arg`` is a trace id and we
+    glob ``<dir>/*/{trace_id}.jsonl`` across date subdirs — a trace that
+    crosses UTC midnight is split across date dirs, so ALL matches are
+    returned and later merged. Zero matches is an error.
     """
     path = Path(arg)
     if path.suffix == ".jsonl" and path.is_file():
@@ -32,21 +32,21 @@ def resolve_run(arg: str, directory: Path) -> list[Path]:
     matches = sorted(directory.glob(f"*/{arg}.jsonl"))
     if matches:
         return matches
-    # No exact run id. `ls` truncates ids, so accept any prefix that names
-    # exactly one run; an ambiguous prefix is reported with its candidates.
-    by_run: dict[str, list[Path]] = {}
+    # No exact trace id. `ls` truncates ids, so accept any prefix that names
+    # exactly one trace; an ambiguous prefix is reported with its candidates.
+    by_trace: dict[str, list[Path]] = {}
     for f in sorted(directory.glob(f"*/{arg}*.jsonl")):
-        by_run.setdefault(f.stem, []).append(f)
-    if len(by_run) == 1:
-        (only,) = by_run.values()
+        by_trace.setdefault(f.stem, []).append(f)
+    if len(by_trace) == 1:
+        (only,) = by_trace.values()
         return sorted(only)
-    if len(by_run) > 1:
-        candidates = ", ".join(sorted(by_run))
+    if len(by_trace) > 1:
+        candidates = ", ".join(sorted(by_trace))
         raise RunResolutionError(
-            f"run prefix {arg!r} is ambiguous under {directory}: matches {candidates}"
+            f"trace prefix {arg!r} is ambiguous under {directory}: matches {candidates}"
         )
     raise RunResolutionError(
-        f"no trace file for run {arg!r} under {directory} (try `cubepi trace ls`)"
+        f"no trace file for trace {arg!r} under {directory} (try `cubepi trace ls`)"
     )
 
 
@@ -85,7 +85,9 @@ def _run_prompt(spans: list[Span]) -> str | None:
     successive runs in one thread stay distinguishable. ``None`` when content
     isn't recorded or no user text is present.
     """
-    root = next((s for s in spans if s.is_invoke_agent), None)
+    root = next(
+        (s for s in spans if s.is_invoke_agent and not s.parent_id), None
+    ) or next((s for s in spans if s.is_invoke_agent), None)
     candidates = [root] if root is not None else spans
     for sp in candidates:
         raw = sp.attributes.get(schema.GEN_AI_INPUT_MESSAGES)
@@ -120,7 +122,7 @@ def _run_prompt(spans: list[Span]) -> str | None:
 
 @dataclass
 class RunSummary:
-    run_id: str
+    trace_id: str
     files: list[Path]
     start: datetime | None
     span_count: int
@@ -130,16 +132,17 @@ class RunSummary:
 
 
 def list_runs(directory: Path, limit: int | None = None) -> list[RunSummary]:
-    """Summarize each run, newest first.
+    """Summarize each trace, newest first.
 
-    Files are grouped by run_id (stem), so a run split across two date dirs
-    (crossed UTC midnight) is summarized as ONE run, not two.
+    Files are grouped by trace_id (stem), so a trace split across two date
+    dirs (crossed UTC midnight) is summarized as ONE trace, not two. The
+    span_count spans the whole trace — parent run plus nested subagent runs.
     """
-    by_run: dict[str, list[Path]] = {}
+    by_trace: dict[str, list[Path]] = {}
     for f in directory.glob("*/*.jsonl"):
-        by_run.setdefault(f.stem, []).append(f)
+        by_trace.setdefault(f.stem, []).append(f)
     summaries: list[RunSummary] = []
-    for run_id, files in by_run.items():
+    for trace_id, files in by_trace.items():
         spans, _ = load_run(sorted(files))
         if not spans:
             continue
@@ -151,7 +154,7 @@ def list_runs(directory: Path, limit: int | None = None) -> list[RunSummary]:
             duration = (max(ends) - start).total_seconds() * 1000.0
         summaries.append(
             RunSummary(
-                run_id=run_id,
+                trace_id=trace_id,
                 files=sorted(files),
                 start=start,
                 span_count=len(spans),

--- a/cubepi/cli/trace/render.py
+++ b/cubepi/cli/trace/render.py
@@ -130,7 +130,7 @@ def render_runs(runs: list[RunSummary]) -> None:
 
     console = _console()
     table = Table(title="cubepi runs")
-    for col in ("started", "run_id", "spans", "status", "duration"):
+    for col in ("started", "trace_id", "spans", "status", "duration"):
         table.add_column(col)
     table.add_column("input", max_width=48, no_wrap=True, overflow="ellipsis")
     for r in runs:
@@ -138,7 +138,7 @@ def render_runs(runs: list[RunSummary]) -> None:
         dur = f"{r.duration_ms:.0f}ms" if r.duration_ms is not None else "?"
         status = "[red]error[/red]" if r.has_error else "ok"
         prompt = " ".join(r.prompt.split()) if r.prompt else "[dim]—[/dim]"
-        table.add_row(started, r.run_id, str(r.span_count), status, dur, prompt)
+        table.add_row(started, r.trace_id, str(r.span_count), status, dur, prompt)
     console.print(table)
 
 

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -115,29 +115,37 @@ def _get_tracer(scope_name: str) -> Any:
 # CLIENT span through the parent's owning provider so trace_ids and
 # exporter destination stay consistent (codex round-7).
 #
-# Lookup uses a per-task ``ContextVar`` holding an opaque handle, with
-# the actual ``(span, provider)`` payload stored in a module-level
-# ``_active_entries`` dict. The dict is the source of truth for
-# cleanup; the contextvar is the per-task pointer.
+# Lookup uses a per-task ``ContextVar`` holding a STACK of opaque
+# handles (outermost first, innermost last), with the actual
+# ``(span, provider)`` payload stored in a module-level
+# ``_active_entries`` dict. The dict is the source of truth for which
+# handles are still live; the contextvar stack records nesting order
+# per task.
 #
-# Why both: tool-call ids are provider-local (Faux / OpenAI-style mint
-# ``tc1`` / ``call_...`` per conversation), so a global dict keyed by
-# ``tool_call_id`` lets concurrent agents overwrite each other (codex
-# round-8). ContextVars scope per asyncio task and copy on
-# ``create_task``, so each agent run — and each spawned tool task
-# within it — sees only its own parent. BUT the cubepi agent loop
-# emits ``ToolExecutionStartEvent`` in the parent task and (in
-# ``parallel`` tool mode) ``ToolExecutionEndEvent`` from the per-tool
-# *child* task it spawns. A ``Token`` produced in the parent task
-# cannot be ``reset`` in a child task — ``ContextVar.reset`` raises
-# ``ValueError`` (codex round-9). The dict-handle indirection lets
-# ``unregister_tool_span`` clean up the payload unconditionally (so
-# any later lookup through the stale contextvar returns ``None``),
-# while the contextvar reset is best-effort and skipped silently when
-# the calling task differs from the registering one.
+# Why a stack (not a single handle): tools nest — an outer
+# ``subagent`` tool body runs an inner agent whose own tools register
+# while the outer tool span is still active. ContextVars scope per
+# asyncio task and copy on ``create_task``, so each task sees its own
+# stack. BUT the cubepi agent loop emits ``ToolExecutionStartEvent``
+# in the parent task and (in ``parallel`` tool mode)
+# ``ToolExecutionEndEvent`` from the per-tool *child* task it spawns.
+# A ``Token`` produced in one task cannot be ``reset`` in another —
+# ``ContextVar.reset`` raises ``ValueError`` (codex round-9). With a
+# single handle slot, an inner tool's cross-task unregister popped its
+# payload but could not restore the slot to the outer handle, leaving
+# the outer tool body with a stale pointer that resolved to ``None`` —
+# so a later subagent/MCP call failed to nest under the still-active
+# outer tool (codex P2, PR #122). The stack fixes this: unregister
+# pops the payload from ``_active_entries`` (cross-task safe) and
+# best-effort resets the contextvar; ``_get_tool_span_entry`` walks
+# the stack inward→outward and returns the first handle whose payload
+# is still live, so a dead inner handle is skipped and the outer tool
+# is found. Dead handles linger only in a task's local stack tuple and
+# are GC'd when that task ends; ``_active_entries`` stays bounded by
+# live registrations.
 _active_entries: dict[object, tuple[Any, Any]] = {}
-_current_handle: contextvars.ContextVar[object | None] = contextvars.ContextVar(
-    "_cubepi_mcp_current_tool_handle", default=None
+_handle_stack: contextvars.ContextVar[tuple[object, ...]] = contextvars.ContextVar(
+    "_cubepi_mcp_tool_handle_stack", default=()
 )
 
 
@@ -145,15 +153,15 @@ def register_tool_span(
     tool_call_id: str,
     span: Any,
     provider: Any = None,
-) -> tuple[object, contextvars.Token[object | None]]:
+) -> tuple[object, contextvars.Token[tuple[object, ...]]]:
     """Publish ``span`` (and its owning ``provider``) as the current
     ``execute_tool`` parent for the calling task.
 
     Returns a ``(handle, cv_token)`` tuple — pass it to
-    :func:`unregister_tool_span` on tool-exec end. The handle is used
-    for dict cleanup (safe across tasks); the cv_token is used for
-    contextvar reset (best-effort, only valid in the registering
-    task).
+    :func:`unregister_tool_span` on tool-exec end. The handle keys the
+    ``_active_entries`` payload (cleaned cross-task safely); the
+    cv_token resets the per-task handle stack (best-effort, only valid
+    in the registering task).
 
     ``tool_call_id`` is accepted for API symmetry / future debug attrs
     but is not used as a lookup key — see module-level comment.
@@ -161,12 +169,12 @@ def register_tool_span(
     del tool_call_id
     handle = object()
     _active_entries[handle] = (span, provider)
-    cv_token = _current_handle.set(handle)
+    cv_token = _handle_stack.set(_handle_stack.get() + (handle,))
     return (handle, cv_token)
 
 
 def unregister_tool_span(
-    token: tuple[object, contextvars.Token[object | None]] | None,
+    token: tuple[object, contextvars.Token[tuple[object, ...]]] | None,
 ) -> None:
     """Clean up a previously-registered entry.
 
@@ -174,20 +182,20 @@ def unregister_tool_span(
     or ``None`` (no-op, for callers that defensively unregister when
     the corresponding register failed).
 
-    The dict entry is always removed — this is the safety net for
-    cross-task ``unregister`` (parallel tool mode emits
+    The ``_active_entries`` payload is always removed — the safety net
+    for cross-task ``unregister`` (parallel tool mode emits
     ``ToolExecutionEndEvent`` from the child task even though
-    ``register`` ran in the parent). The contextvar reset is
-    attempted but silently skipped if the calling task is not the
-    registering task; the next ``register`` in the parent task will
-    overwrite the stale handle.
+    ``register`` ran in the parent). The handle-stack reset is
+    attempted but silently skipped when the calling task is not the
+    registering one; the now-dead handle simply lingers in that task's
+    stack until the task ends, and ``_get_tool_span_entry`` skips it.
     """
     if token is None:
         return
     handle, cv_token = token
     _active_entries.pop(handle, None)
     try:
-        _current_handle.reset(cv_token)
+        _handle_stack.reset(cv_token)
     except (ValueError, LookupError):
         pass
 
@@ -196,15 +204,19 @@ def _get_tool_span_entry() -> tuple[Any, Any] | None:
     """Return the (span, provider) entry for the current task, or
     ``None`` when no live ``execute_tool`` is in scope.
 
-    A stale contextvar handle (pointing at an already-cleaned-up dict
-    entry) returns ``None`` — exactly the same outcome as no parent at
-    all, so the MCP CLIENT span starts a new root rather than
+    Walks the per-task handle stack inner→outer and returns the first
+    handle whose payload is still live in ``_active_entries``. A nested
+    inner tool that ended in a child task leaves its (now-dead) handle
+    on this task's stack but its payload is gone, so it is skipped and
+    the enclosing tool is returned. When no live handle remains the
+    MCP CLIENT span / inner agent root starts a new root rather than
     parenting under an already-ended span.
     """
-    handle = _current_handle.get()
-    if handle is None:
-        return None
-    return _active_entries.get(handle)
+    for handle in reversed(_handle_stack.get()):
+        entry = _active_entries.get(handle)
+        if entry is not None:
+            return entry
+    return None
 
 
 def _current_span_via_registered() -> Any:

--- a/cubepi/tracing/exporters/jsonl.py
+++ b/cubepi/tracing/exporters/jsonl.py
@@ -86,7 +86,13 @@ class JsonlSpanExporter(SpanExporter):
         else:
             date_dir = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
         ctx = span.get_span_context()
-        trace_id = format(ctx.trace_id, "032x") if ctx and ctx.trace_id else "unknown-trace"
+        # Use is_valid (matches cubepi.mcp._tracing / http_loader convention):
+        # guards trace_id != 0 idiomatically; invalid contexts → unknown-trace.
+        trace_id = (
+            format(ctx.trace_id, "032x")
+            if ctx is not None and ctx.is_valid
+            else "unknown-trace"
+        )
         return self._directory / date_dir / f"{_safe_filename(trace_id)}.jsonl"
 
     @staticmethod

--- a/cubepi/tracing/exporters/jsonl.py
+++ b/cubepi/tracing/exporters/jsonl.py
@@ -1,8 +1,10 @@
 """Append-only JSONL span exporter.
 
 One span per line, OTLP/JSON-shaped via ``span.to_json()``. Files are
-sharded ``<directory>/<YYYY-MM-DD>/<run_id>.jsonl`` so each run lands
-in its own file and per-day directories don't grow unbounded.
+sharded ``<directory>/<YYYY-MM-DD>/<trace_id>.jsonl`` — one file per trace,
+so a parent run plus any nested subagent runs (which inherit the trace_id
+but get their own run_id) land together and per-day directories don't grow
+unbounded.
 """
 
 from __future__ import annotations
@@ -17,16 +19,15 @@ from typing import Any
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
-from cubepi.tracing.schema import CUBEPI_RUN_ID
-
 
 class JsonlSpanExporter(SpanExporter):
     """Write each ReadableSpan as one JSON line.
 
-    Files: ``<directory>/<YYYY-MM-DD>/<run_id>.jsonl``. The date used for
-    the subdirectory is the span's start time (UTC). The ``run_id`` comes
-    from the ``cubepi.run_id`` attribute set by the cubepi Recorder;
-    spans without that attribute fall back to ``"unknown-run"``.
+    Files: ``<directory>/<YYYY-MM-DD>/<trace_id>.jsonl``, one file per trace
+    so the parent run and any nested subagent runs (same trace_id, different
+    ``cubepi.run_id``) land together. The date used for the subdirectory is
+    the span's start time (UTC). The ``trace_id`` is the span's 32-hex trace
+    id; spans without a context fall back to ``"unknown-trace"``.
 
     Permissions: files are created mode ``0o600`` (user-only).
     """
@@ -84,11 +85,9 @@ class JsonlSpanExporter(SpanExporter):
             date_dir = dt.strftime("%Y-%m-%d")
         else:
             date_dir = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
-        run_id = (span.attributes or {}).get(CUBEPI_RUN_ID, "unknown-run")
-        # Sanitize: run_ids are uuids in practice, but defend against odd
-        # characters slipping through extra_attrs.
-        safe = _safe_filename(str(run_id))
-        return self._directory / date_dir / f"{safe}.jsonl"
+        ctx = span.get_span_context()
+        trace_id = format(ctx.trace_id, "032x") if ctx and ctx.trace_id else "unknown-trace"
+        return self._directory / date_dir / f"{_safe_filename(trace_id)}.jsonl"
 
     @staticmethod
     def _encode(span: ReadableSpan) -> str:
@@ -129,4 +128,4 @@ def _safe_filename(name: str) -> str:
             out.append(ch)
         else:
             out.append("_")
-    return "".join(out) or "unknown-run"
+    return "".join(out) or "unknown-trace"

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -517,9 +517,8 @@ class Recorder:
         # that keys like ``run_id`` / ``turn_index`` / ``agent.tools``
         # — which the recorder owns under ``cubepi.*`` — can never be
         # overwritten by caller-supplied values. Reserved cubepi
-        # schema keys (especially ``cubepi.run_id`` which the JSONL
-        # exporter shards on) must stay recorder-controlled (codex P2
-        # on PR #92).
+        # schema keys (especially ``cubepi.run_id``, a per-span filtering
+        # attribute) must stay recorder-controlled (codex P2 on PR #92).
         try:
             from cubepi.tracing.context import _current_metadata, _current_tags
 
@@ -630,8 +629,8 @@ class Recorder:
             attributes={
                 CUBEPI_TURN_INDEX: run.turn_index,
                 # Propagate run_id so every child span carries it —
-                # OTel does NOT inherit attributes from parent spans, and
-                # JsonlSpanExporter shards by ``cubepi.run_id`` per span.
+                # OTel does NOT inherit attributes from parent spans. It's a
+                # filtering attribute; the JSONL exporter shards by trace_id.
                 CUBEPI_RUN_ID: run.run_id,
             },
         )
@@ -705,7 +704,8 @@ class Recorder:
             GEN_AI_TOOL_NAME: event.tool_name,
             GEN_AI_TOOL_CALL_ID: event.tool_call_id,
             GEN_AI_TOOL_TYPE: "function",
-            # Per-span run_id so JsonlSpanExporter shards correctly.
+            # Record run_id as a span attribute (for filtering); the JSONL
+            # exporter now shards by trace_id, not run_id.
             CUBEPI_RUN_ID: run.run_id,
         }
         # NOTE: gen_ai.tool.call.arguments is opt-in content recorded
@@ -848,7 +848,8 @@ class Recorder:
             GEN_AI_PROVIDER_NAME: map_provider_name(model.provider),
             GEN_AI_REQUEST_MODEL: model.id,
             GEN_AI_REQUEST_STREAM: True,
-            # Per-span run_id so JsonlSpanExporter shards correctly.
+            # Record run_id as a span attribute (for filtering); the JSONL
+            # exporter now shards by trace_id, not run_id.
             CUBEPI_RUN_ID: run.run_id,
         }
         # Pull StreamOptions-derived params from the payload where the

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -18,6 +18,7 @@ or error). See ``docs/specs/2026-05-18-cubepi-tracing-design.md`` §9.
 
 from __future__ import annotations
 
+import contextvars
 import hashlib
 import time
 import traceback
@@ -117,6 +118,19 @@ if TYPE_CHECKING:
     from cubepi.tracing.tracer import Tracer
 
 
+# Per-task "active run" gate. A provider instance shared by a parent
+# agent and an inner subagent fires EVERY attached recorder's provider
+# listeners (listeners are per-provider-instance). Without this gate the
+# parent recorder's chat-span listener would also fire for the inner
+# agent's LLM call and mint a duplicate chat span under the parent's
+# turn. Each recorder sets this contextvar to its own ``_RunState`` while
+# its run owns the current asyncio task, and the provider listeners act
+# only when the active run matches their own run.
+_active_run: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+    "cubepi.tracing.active_run", default=None
+)
+
+
 @dataclass
 class _RunState:
     """Per-run mutable state. One per attached agent run."""
@@ -188,6 +202,11 @@ class Recorder:
         # definitions (description, execution_mode) at tool-exec span
         # open. ``None`` if the agent doesn't expose a tool registry.
         self._agent: Any | None = None
+        # Reset token for the per-task ``_active_run`` contextvar, set in
+        # ``_on_agent_start`` and reset in ``_on_agent_end`` /
+        # ``_close_open_spans`` (the latter covers cancelled runs that
+        # never emit AgentEndEvent).
+        self._active_run_token: Any | None = None
 
     # ------------------------------------------------------------------
     # Attach / detach
@@ -365,6 +384,22 @@ class Recorder:
                 pass
         run.tool_span_tokens.clear()
 
+    def _reset_active_run(self) -> None:
+        """Reset the per-task ``_active_run`` gate to its prior value.
+
+        Called from both ``_on_agent_end`` (normal completion) and
+        ``_close_open_spans`` (the detach / cancellation path — a
+        CancelledError-aborted run never emits AgentEndEvent, and
+        ``detach()`` always runs ``_close_open_spans``).
+        """
+        token = getattr(self, "_active_run_token", None)
+        if token is not None:
+            try:
+                _active_run.reset(token)
+            except (ValueError, LookupError):
+                pass
+            self._active_run_token = None
+
     def _close_open_spans(self, run: "_RunState | None") -> None:
         """End any spans still open on ``run``.
 
@@ -416,6 +451,11 @@ class Recorder:
             except Exception:
                 pass
             # Don't null agent_span — _RunState gets dropped wholesale.
+        # Release the per-task active-run gate. A cancelled run never
+        # reaches _on_agent_end, so the only reset opportunity is here
+        # (detach always calls _close_open_spans). Without this a stale
+        # token would keep gating the parent task's next turn.
+        self._reset_active_run()
 
     def _on_agent_start(self) -> None:
         # Defensive cleanup: if a prior run was cancelled
@@ -448,6 +488,11 @@ class Recorder:
         # Resource carries gen_ai.agent.name at process level — agents
         # that vary per-run set their own value via _ensure_agent_name.
         self._run = _RunState(run_id=run_id, agent_span=span)
+        # Claim the per-task active-run gate for this run so this
+        # recorder's provider listeners act only for LLM calls made on
+        # the task that owns this run (not for an inner subagent sharing
+        # the same provider instance).
+        self._active_run_token = _active_run.set(self._run)
 
         # Stamp any tags / metadata set via ``cubepi.tracing.tracing_context``
         # for this run. Per-task contextvar scoping means concurrent
@@ -551,6 +596,7 @@ class Recorder:
         # ``_sweep_tool_span_tokens`` docstring.
         self._sweep_tool_span_tokens(run)
         run.agent_span.end()
+        self._reset_active_run()
         self._run = None
 
     # ------------------------------------------------------------------
@@ -780,6 +826,8 @@ class Recorder:
         run = self._run
         if run is None or run.turn_span is None:
             return
+        if _active_run.get() is not run:
+            return
         ctx = trace.set_span_in_context(run.turn_span)
         attrs: dict[str, Any] = {
             GEN_AI_OPERATION_NAME: OP_CHAT,
@@ -878,6 +926,8 @@ class Recorder:
         run = self._run
         if run is None or run.chat_span is None or run.chat_first_chunk_recorded:
             return
+        if _active_run.get() is not run:
+            return
         # Only count "content" chunks for time-to-first-chunk (not 'start').
         if event.type in (
             "text_delta",
@@ -898,6 +948,8 @@ class Recorder:
         del model
         run = self._run
         if run is None or run.chat_span is None:
+            return
+        if _active_run.get() is not run:
             return
         span = run.chat_span
         try:

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -473,9 +473,23 @@ class Recorder:
         # Open the root invoke_agent span. Caller-context propagation
         # (parent_trace_id / parent_span_id from a host service) lands
         # here in a future run_scope feature.
+        parent_ctx = None
+        try:
+            # TODO(tracing): relocate this "current tool span" helper out of
+            # cubepi.mcp._tracing — it now serves generic nested agents, not
+            # just MCP clients.
+            from cubepi.mcp import _tracing as _mcp_tracing
+
+            entry = _mcp_tracing._get_tool_span_entry()
+            if entry is not None:
+                tool_span, _tool_provider = entry
+                parent_ctx = trace.set_span_in_context(tool_span)
+        except ImportError:  # pragma: no cover — mcp module always present
+            parent_ctx = None
         span = self._tracer.otel_tracer.start_span(
             name=SPAN_NAME_INVOKE_AGENT,
             kind=SpanKind.INTERNAL,
+            context=parent_ctx,
             attributes={
                 GEN_AI_OPERATION_NAME: OP_INVOKE_AGENT,
                 CUBEPI_RUN_ID: run_id,

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -949,6 +949,11 @@ class Recorder:
         run = self._run
         if run is None or run.chat_span is None:
             return
+        # A non-owning recorder normally already bailed in _on_provider_request
+        # (so its chat_span stays None and the guard above catches it). This
+        # gate is the defensive backstop for the case where chat_span is set
+        # but the active task belongs to a different run — never close a span
+        # this recorder didn't open for the current task.
         if _active_run.get() is not run:
             return
         span = run.chat_span

--- a/dev/plans/2026-05-27-subagent-trace-nesting.md
+++ b/dev/plans/2026-05-27-subagent-trace-nesting.md
@@ -537,6 +537,105 @@ git commit -m "test(tracing): end-to-end nested-subagent subtree"
 
 ---
 
+## Task 3.5: Shard JSONL by trace_id so `trace view` shows the nested subtree (cubepi)
+
+**Why:** After Tasks 1–2 the inner subagent run gets its OWN `cubepi.run_id`, but `JsonlSpanExporter` shards files by `cubepi.run_id` (`<date>/<run_id>.jsonl`). So the inner run's spans (the nested `invoke_agent → turn → chat → execute_tool`) write to a SEPARATE file, and `trace view <run_id>` — which loads only the one run-id file — renders the `execute_tool subagent` node childless again. The parent/child span links are correct (shared `trace_id`, `parent_span_id` set), only the *file layout* hides them.
+
+**Decision (chosen over a loader-merge approach):** shard the JSONL exporter by **`trace_id`** instead of `run_id`. One file per trace = parent + all (nested) subagents together, so `view` is complete with no cross-file merging. The trace-cli becomes trace-keyed. **No backward-compat for old `run_id`-named files** — parse only the new `trace_id` format; pre-existing files may simply not resolve.
+
+**This does NOT affect the OTLP exporter** — OTLP ships spans with full context and backends assemble by `trace_id` natively; sharding is a JSONL-only concern.
+
+**Files:**
+- Modify: `cubepi/tracing/exporters/jsonl.py` (`_path_for`, docstrings)
+- Modify: `cubepi/cli/trace/loader.py` (`resolve_run`→trace semantics, `RunSummary.run_id`→`trace_id`, `list_runs`, `_run_prompt` picks the ROOT invoke_agent)
+- Modify: `cubepi/cli/trace/render.py` (`render_runs` column `run_id`→`trace_id`)
+- Modify: `cubepi/cli/trace/commands.py` (arg help text run→trace; call sites unchanged)
+- Modify: `cubepi/tracing/recorder.py` (update the stale "Per-span run_id so JsonlSpanExporter shards correctly" comments — run_id is still recorded as a span attribute, just not the shard key)
+- Tests: `tests/tracing/` jsonl-exporter coverage + `tests/cli/trace/{test_loader,test_commands,test_follow,test_model,test_schema_roundtrip}.py` (fixtures that build `<run_id>.jsonl` files → `<trace_id>.jsonl`)
+
+- [ ] **Step 1: Write/update the failing exporter test**
+
+Find the existing test that asserts the JSONL filename (grep `tests/` for `_path_for`, `.jsonl`, and `JsonlSpanExporter`). Add/adjust a test asserting the file is named by the span's `trace_id`, and that two spans sharing a `trace_id` but with DIFFERENT `cubepi.run_id` land in the SAME file:
+
+```python
+def test_jsonl_shards_by_trace_id_not_run_id(tmp_path):
+    from opentelemetry.sdk.trace import ReadableSpan  # or reuse the harness's span builder
+    exporter = JsonlSpanExporter(directory=tmp_path)
+    # Two spans, same trace_id, different cubepi.run_id (parent + inner run).
+    parent_span = _make_readable_span(trace_id=0xABC, run_id="run-parent", start_ns=...)
+    inner_span = _make_readable_span(trace_id=0xABC, run_id="run-inner", start_ns=...)
+    exporter.export([parent_span, inner_span])
+    files = list(tmp_path.glob("*/*.jsonl"))
+    assert len(files) == 1, f"expected ONE file per trace_id, got {[f.name for f in files]}"
+    assert files[0].stem == format(0xABC, "032x")
+```
+
+> Build the ReadableSpans with whatever helper the existing exporter/recorder tests use (grep for how `ReadableSpan` or a fake span is constructed in `tests/tracing/`). If the suite only tests the exporter indirectly through the recorder, write the span fixtures the same way the recorder tests produce spans.
+
+- [ ] **Step 2: Run it; expect FAIL** (currently two files, named by run_id).
+
+Run: `cd /home/chris/cubepi && uv run --extra tracing pytest <the exporter test> -v`
+
+- [ ] **Step 3: Shard by trace_id in `jsonl.py`**
+
+Replace the `run_id` lookup in `_path_for`:
+
+```python
+    def _path_for(self, span: ReadableSpan) -> Path:
+        start_ns = span.start_time or 0
+        if start_ns:
+            dt = datetime.fromtimestamp(start_ns / 1_000_000_000, tz=timezone.utc)
+            date_dir = dt.strftime("%Y-%m-%d")
+        else:
+            date_dir = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+        ctx = span.get_span_context()
+        trace_id = format(ctx.trace_id, "032x") if ctx and ctx.trace_id else "unknown-trace"
+        return self._directory / date_dir / f"{_safe_filename(trace_id)}.jsonl"
+```
+
+Drop the now-unused `CUBEPI_RUN_ID` import if nothing else uses it. Update the module + class docstrings (`<run_id>.jsonl` → `<trace_id>.jsonl`; explain one file per trace, subagent runs included).
+
+- [ ] **Step 4: Run the exporter test; expect PASS** (one file, stem = 32-hex trace_id).
+
+- [ ] **Step 5: Update the trace-cli to be trace-keyed**
+
+- `loader.py`:
+  - Rename `RunSummary.run_id` → `trace_id`. In `list_runs`, the file stem is now the trace_id; populate `trace_id=stem`. `span_count` now counts the whole trace (parent + subagents) — that's intended.
+  - `_run_prompt`: pick the ROOT `invoke_agent` (the one whose `parent_id` is falsy), not just the first `is_invoke_agent` — a trace now contains subagent `invoke_agent` spans too. Use: `root = next((s for s in spans if s.is_invoke_agent and not s.parent_id), None)` and fall back to the old behavior if none.
+  - `resolve_run`: keep the stem-glob logic (now matches trace_id stems); update docstring/error text "run" → "trace".
+- `render.py` `render_runs`: change the `"run_id"` column header to `"trace_id"`, read `r.trace_id`.
+- `commands.py`: update `view`/`follow`/`stats` arg help from "run id" to "trace id" (the positional value is now a trace id / prefix). Function names may stay.
+- `recorder.py`: update the two "Per-span run_id so JsonlSpanExporter shards correctly" comments to say run_id is recorded for filtering but sharding is by trace_id.
+
+- [ ] **Step 6: Update affected trace-cli tests**
+
+Run the trace-cli suite to see what breaks, then fix fixtures that hardcode `<run_id>.jsonl`:
+
+Run: `cd /home/chris/cubepi && uv run --extra tracing pytest tests/cli/trace/ -v`
+Update each failing test to build `<trace_id>.jsonl` fixtures and assert on `trace_id` (not `run_id`). Keep the test INTENT; only the file-naming/identifier changes. Verify `test_loader`, `test_commands`, `test_follow`, `test_model`, `test_schema_roundtrip`.
+
+- [ ] **Step 7: Full regression**
+
+Run: `cd /home/chris/cubepi && uv run --extra tracing --extra tracing-otlp pytest tests/tracing/ tests/cli/ -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/chris/cubepi
+git add cubepi/tracing/exporters/jsonl.py cubepi/cli/trace/ cubepi/tracing/recorder.py tests/
+git commit -m "feat(tracing): shard JSONL by trace_id so subagent runs view as one tree
+
+JsonlSpanExporter sharded by cubepi.run_id, so a nested subagent run (its
+own run_id) wrote to a separate file and trace view rendered the
+execute_tool subagent node childless. Shard by trace_id instead — one file
+per trace, parent + nested subagents together — and make the trace-cli
+trace-keyed. No backward-compat for old run_id-named files. OTLP is
+unaffected (backends assemble by trace_id)."
+```
+
+---
+
 ## Task 4: cubebox — attach the parent Tracer to the inner agent
 
 Make the inner subagent run actually recorded (and, with Tasks 1–2, nested) by attaching the active `Tracer` around `inner.prompt()`.
@@ -711,11 +810,12 @@ cd /home/chris/cubebox/backend && uv lock --upgrade-package cubepi
 
 - [ ] **Step 3: Run a real subagent task and inspect the trace**
 
-Run a subagent-spawning prompt, then:
+Run a subagent-spawning prompt, then list traces and view the trace (the CLI is now trace-keyed — Task 3.5):
 ```bash
-cd /home/chris/cubebox/backend && uv run python -m cubepi.cli trace view <run_id> --dir cubepi-traces
+cd /home/chris/cubebox/backend && uv run python -m cubepi.cli trace ls --dir cubepi-traces      # copy the trace_id
+cd /home/chris/cubebox/backend && uv run python -m cubepi.cli trace view <trace_id> --dir cubepi-traces
 ```
-Expected: under each `execute_tool subagent [..]` node there is now a nested `invoke_agent → cubepi.turn → {chat, execute_tool}` subtree (with span_ids shown), instead of flat sibling chats. Confirm no duplicate chat spans.
+Expected: a SINGLE trace file contains the whole run; under each `execute_tool subagent [..]` node there is now a nested `invoke_agent → cubepi.turn → {chat, execute_tool}` subtree (with span_ids shown), instead of flat sibling chats. Confirm no duplicate chat spans, and that the subagent's spans are present (they no longer land in a separate per-run-id file).
 
 - [ ] **Step 4: Commit the pin bump**
 

--- a/dev/plans/2026-05-27-subagent-trace-nesting.md
+++ b/dev/plans/2026-05-27-subagent-trace-nesting.md
@@ -1,0 +1,745 @@
+# Subagent Trace Nesting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make an inner (sub)agent's spans nest under the `execute_tool subagent` span that spawned it — its `cubepi.turn` / `chat` / `execute_tool` spans become children of the tool span instead of leaking flat onto the parent agent's turn.
+
+**Architecture:** Two coordinated changes. (1) cubepi `Recorder`: gate provider-listener span creation on a per-task "active run" contextvar so a *shared provider* no longer routes an inner agent's LLM calls into the parent recorder's run; and parent the inner run's root span under the active `execute_tool` span when one is in scope for the task. (2) cubebox `SubAgentMiddleware`: attach the parent's `Tracer` to the inner agent so the inner run is actually recorded.
+
+**Tech Stack:** Python 3.13, OpenTelemetry SDK, `contextvars`, cubepi event-driven `Recorder`, pytest.
+
+---
+
+## Background — Root Cause (verified against trace `9c6a0909`)
+
+The `Recorder` (`cubepi/tracing/recorder.py`) records spans two ways:
+
+- **Structural spans** (`invoke_agent` / `cubepi.turn` / `execute_tool`) — driven by the *attached* agent's events. Parents wired with explicit `context=set_span_in_context(run.agent_span | run.turn_span)`.
+- **`chat` spans** — driven by **provider listeners** (`_on_provider_request/chunk/response`) registered on `agent._provider`, parented to `self._run.turn_span`.
+
+cubebox's `SubAgentMiddleware._execute` (`backend/cubebox/middleware/subagents.py`) spawns an inner `cubepi.Agent` that (a) **reuses the parent's provider instance** and (b) is **never attached** to a recorder (only `inner.subscribe(_listener)` for SSE). Consequences:
+
+1. Inner agent's turn/tool/agent events never reach a recorder → **no nested turn spans, no nested `execute_tool` spans**.
+2. Inner LLM calls go through the shared provider → the *parent* recorder's `_on_provider_request` fires and parents the `chat` span under `self._run.turn_span` (the parent's subagent-calling turn) → **inner chats flatten under the outer turn**, siblings of `execute_tool subagent`.
+
+The tracing design spec (`dev/specs/2026-05-18-cubepi-tracing-design.md` §6.1 / §8 "nested agents") already describes the intended behavior: an inner agent with its own `Tracer` whose root `start_span` nests under the active tool span via context propagation. The infra for per-task parent routing already exists for MCP CLIENT spans (`cubepi/mcp/_tracing.py`: `register_tool_span` + `_get_tool_span_entry` + `_current_handle` contextvar). This plan reuses that pattern for agent runs.
+
+### Verified feasibility facts
+
+- `Tracer.attach()` constructs a **fresh `Recorder`** per call (`cubepi/tracing/tracer.py:148`), so one `Tracer` can attach to parent **and** inner agent, each with isolated `_RunState`, both exporting to the same JSONL/OTLP destinations (same `trace_id` file).
+- `Recorder._on_tool_exec_start` calls `register_tool_span(...)` **before** the tool body runs; for `parallel` tool mode the body runs in a child task created after the contextvar is set, so it inherits `_current_handle`. For `sequential` mode the body runs inline in the same task. Either way `_get_tool_span_entry()` returns the active `execute_tool` span inside the subagent tool body.
+
+---
+
+## File Structure
+
+- `cubepi/tracing/recorder.py` — add a per-task "active run" contextvar; gate the three provider listeners on it; parent the `invoke_agent` root under the active tool span when present.
+- `cubepi/mcp/_tracing.py` — no new code; reuse `_get_tool_span_entry()` (already public-internal) to fetch `(span, provider)` for the current task.
+- `backend/cubebox/middleware/subagents.py` (cubebox repo) — accept a `tracer` and `tracer.attach(inner)` around `inner.prompt()`.
+- `backend/cubebox/streams/run_manager.py` (cubebox repo) — pass the active `Tracer` into `SubAgentMiddleware`.
+- Tests: `tests/tracing/test_subagent_nesting.py` (cubepi), `backend/tests/.../test_subagent_trace.py` (cubebox).
+
+> **Cross-repo note:** cubepi reaches cubebox runtime only via a pinned `rev` in `backend/uv.lock`. After cubepi changes land (Tasks 1–3) and are pushed, bump the pin in cubebox before the cubebox change (Task 4) can be verified end-to-end. See Task 5.
+
+---
+
+## Task 1: Per-task "active run" gate on provider listeners (cubepi)
+
+Stops a shared provider from routing an inner agent's LLM calls into the parent recorder's run. Each recorder marks *its* run active in the current task on `AgentStart`; provider listeners no-op when the task's active run isn't theirs.
+
+**Files:**
+- Modify: `cubepi/tracing/recorder.py` (module-level contextvar; `_on_agent_start`, `_on_agent_end`, `_close_open_spans`/abort path; `_on_provider_request`, `_on_provider_chunk`, `_on_provider_response`)
+- Test: `tests/tracing/test_subagent_nesting.py`
+
+- [ ] **Step 1: Write the failing test**
+
+> **Why this test must drive the PARENT run (codex BLOCKING).** A naive
+> repro that attaches both agents but only calls `inner.prompt()` does NOT
+> reproduce the bug: the parent recorder never receives `AgentStartEvent`, so
+> its `_run is None` and `_on_provider_request` early-returns (`recorder.py`
+> "run is None" guard) — it never mints a duplicate. The leak only happens
+> when the parent run is **live and mid-turn** (its `turn_span` is open while
+> it awaits the subagent tool). So the test MUST run the parent through a turn
+> that calls a tool whose body attaches+runs the inner agent — exactly the
+> production shape.
+
+```python
+# tests/tracing/test_subagent_nesting.py
+import pytest
+from cubepi import AgentTool, AgentToolResult, TextContent
+from pydantic import BaseModel
+from tests.tracing.helpers import build_tracer_with_memory_exporter, FauxProvider, make_agent
+
+
+class _Empty(BaseModel):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_shared_provider_does_not_double_mint_inner_chat(tmp_path):
+    """Parent (mid-turn) spawns an inner agent that shares the parent's provider
+    and is attached to the SAME tracer. Without the active-run gate, BOTH
+    recorders' provider listeners fire for the inner LLM call -> a duplicate
+    chat span under the parent turn. With the gate, only the inner recorder
+    mints it."""
+    tracer, exporter = build_tracer_with_memory_exporter()
+    # ONE shared provider. Scripted replies are consumed in cross-agent CALL
+    # order: parent turn-1 emits the tool call; the inner agent (run inside the
+    # tool body) consumes the next reply; parent turn-2 finalizes last.
+    provider = FauxProvider(scripted_replies=[
+        {"tool_calls": [{"id": "tc1", "name": "spawn", "arguments": {}}]},  # parent T1
+        "inner-final",                                                       # inner
+        "parent-final",                                                      # parent T2
+    ])
+
+    async def _spawn(tool_call_id, args, *, signal=None, on_update=None):
+        inner = make_agent(provider=provider, tools=[])
+        detach = tracer.attach(inner)
+        try:
+            await inner.prompt("inner task")
+        finally:
+            res = detach()
+            if res is not None:
+                await res
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    spawn = AgentTool(name="spawn", description="spawn inner", parameters=_Empty, execute=_spawn)
+    parent = make_agent(provider=provider, tools=[spawn])
+    detach_parent = tracer.attach(parent)
+    try:
+        await parent.prompt("go")
+    finally:
+        res = detach_parent()
+        if res is not None:
+            await res
+    await tracer.shutdown()
+
+    spans = exporter.get_finished_spans()
+    chat_spans = [s for s in spans if s.attributes.get("gen_ai.operation.name") == "chat"]
+    # Expected: 2 parent chats (T1 + T2) + 1 inner chat = 3.
+    # The bug adds a 4th: the parent recorder ALSO mints the inner call under
+    # the parent's open turn_span.
+    assert len(chat_spans) == 3, (
+        f"expected 3 chat spans, got {len(chat_spans)} "
+        "(parent recorder double-handled the inner LLM call)"
+    )
+```
+
+> If `tests/tracing/helpers.py` lacks `build_tracer_with_memory_exporter` / `FauxProvider` / `make_agent`, reuse the existing fixtures used by the current recorder tests (grep `tests/tracing/` for `InMemorySpanExporter` and the faux provider). Adapt names + the `scripted_replies` shape (some fakes take `AssistantMessage`s, others a callable) to the existing harness rather than inventing new ones.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/tracing/test_subagent_nesting.py::test_shared_provider_does_not_double_mint_inner_chat -v`
+Expected: FAIL — 4 chat spans (the parent recorder mints an extra one for the inner LLM call, parented under the parent turn).
+
+- [ ] **Step 3: Add the active-run contextvar and set/reset it**
+
+In `cubepi/tracing/recorder.py`, near the top-level imports (after the existing module constants), add:
+
+```python
+import contextvars
+
+# Per-task pointer to the _RunState that "owns" the current asyncio task.
+# Provider listeners are registered per provider INSTANCE; when one provider
+# is shared by a parent agent and an inner (sub)agent, every attached
+# recorder's listener fires for every LLM call on that provider. This
+# contextvar lets each listener act only for the run that is active in the
+# calling task. Copies into child tasks at creation (asyncio semantics), and
+# the inner agent's AgentStart overwrites it within the child task.
+_active_run: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+    "cubepi.tracing.active_run", default=None
+)
+```
+
+In `_on_agent_start`, immediately after `self._run = _RunState(run_id=run_id, agent_span=span)`:
+
+```python
+        # Mark this run active for the current task so the shared-provider
+        # listeners route LLM spans to the right recorder.
+        self._active_run_token = _active_run.set(self._run)
+```
+
+Add `self._active_run_token = None` to `Recorder.__init__` (alongside the other per-run fields). Reset it best-effort in a small helper and call that helper from **BOTH** `_on_agent_end` **AND** `_close_open_spans` (the detach cleanup path):
+
+```python
+    def _reset_active_run(self) -> None:
+        token = getattr(self, "_active_run_token", None)
+        if token is not None:
+            try:
+                _active_run.reset(token)
+            except (ValueError, LookupError):
+                pass
+            self._active_run_token = None
+```
+
+> **Why reset in `_close_open_spans`, not only `_on_agent_end` (codex SHOULD-FIX).**
+> `Agent._run_with_lifecycle` re-raises `asyncio.CancelledError` WITHOUT
+> emitting `AgentEndEvent`, so a cancelled inner run never reaches
+> `_on_agent_end`. `Tracer.attach`'s `detach()` always runs
+> `_close_open_spans` synchronously (see `recorder.py` `_sync_detach`), and
+> Task 4 calls `detach()` in a `finally`. In **sequential** tool mode the inner
+> agent's `_on_agent_start` and the tool body's `detach()` run in the SAME task,
+> so the reset token is valid and the reset succeeds — preventing a stale
+> `_active_run` from gating the parent's post-tool turn in that same task. Put
+> the reset in `_close_open_spans` so cancellation can't leak a stale gate.
+
+> **Why the per-task gate is correct under parallel tool mode (codex SHOULD-FIX — document this).**
+> In `parallel` mode the parent emits `ToolExecutionStartEvent` in the parent
+> task BEFORE `asyncio.create_task(_run())` spawns the per-tool child task
+> (`agent/tools.py` `_execute_parallel`). The child task copies the parent's
+> contextvar snapshot at creation; then `inner.prompt()` fires `AgentStartEvent`
+> inside that same child task, so `_active_run.set(inner_run)` shadows ONLY the
+> child task's copy — the parent task's `_active_run` is untouched. The inner's
+> `AgentEndEvent` (or `detach`) runs on that same child-task path, so the reset
+> token is same-task. `_active_run.reset` raising on cross-task is handled
+> best-effort (mirrors the existing `unregister_tool_span` pattern); the
+> source of truth is `self._run`, the contextvar is only the per-task pointer.
+
+- [ ] **Step 4: Gate the three provider listeners**
+
+At the top of `_on_provider_request`, `_on_provider_chunk`, and `_on_provider_response`, after the existing `run = self._run` / `if run is None ...` guard, add:
+
+```python
+        if _active_run.get() is not run:
+            # A different run owns this task (e.g. an inner subagent sharing
+            # our provider). That run's own recorder will handle this event.
+            return
+```
+
+> Place the check AFTER `run is None` so a recorder with no live run still no-ops. For `_on_provider_chunk` / `_on_provider_response`, also keep the existing `run.chat_span is None` guards.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/tracing/test_subagent_nesting.py::test_shared_provider_does_not_double_mint_inner_chat -v`
+Expected: PASS — exactly 3 chat spans.
+
+- [ ] **Step 6: Cancellation test — a cancelled inner run must not leave a stale gate**
+
+```python
+@pytest.mark.asyncio
+async def test_cancelled_inner_does_not_gate_parents_next_turn(tmp_path):
+    """Inner run cancelled mid-LLM-call (no AgentEndEvent) in SEQUENTIAL tool
+    mode runs in the same task as the parent. If detach()/_close_open_spans
+    fails to reset _active_run, the parent's post-tool turn would be wrongly
+    gated and its chat span dropped. Assert the parent's T2 chat survives."""
+    tracer, exporter = build_tracer_with_memory_exporter()
+
+    # Inner provider call raises CancelledError; parent then finalizes.
+    provider = FauxProvider(scripted_replies=[
+        {"tool_calls": [{"id": "tc1", "name": "spawn", "arguments": {}}]},  # parent T1
+        CancelledError(),                                                    # inner -> cancel
+        "parent-final",                                                      # parent T2
+    ])
+
+    async def _spawn(tool_call_id, args, *, signal=None, on_update=None):
+        inner = make_agent(provider=provider, tools=[])
+        detach = tracer.attach(inner)
+        try:
+            await inner.prompt("inner task")
+        except CancelledError:
+            pass  # subagent tool swallows + returns an error result in prod
+        finally:
+            res = detach()
+            if res is not None:
+                await res
+        return AgentToolResult(content=[TextContent(text="[cancelled]")], is_error=True)
+
+    # Force sequential so the inner run shares the parent/loop task.
+    spawn = AgentTool(name="spawn", description="spawn inner", parameters=_Empty,
+                      execute=_spawn, execution_mode="sequential")
+    parent = make_agent(provider=provider, tools=[spawn])
+    detach_parent = tracer.attach(parent)
+    try:
+        await parent.prompt("go")
+    finally:
+        res = detach_parent()
+        if res is not None:
+            await res
+    await tracer.shutdown()
+
+    spans = exporter.get_finished_spans()
+    # Identify the PARENT run UNAMBIGUOUSLY via the execute_tool span's run_id.
+    # `_on_tool_exec_start` stamps CUBEPI_RUN_ID = the parent recorder's
+    # run.run_id on the tool span, so this is the parent run regardless of
+    # task ordering. (codex SHOULD-FIX: do NOT use `next(parent is None)` — at
+    # Task 1 time, before Task 2 lands, the cancelled inner run ALSO opens a
+    # parentless invoke_agent span, so parentless-root selection is ambiguous.)
+    tool_span = next(s for s in spans if s.name == "execute_tool spawn")
+    parent_run_id = tool_span.attributes.get("cubepi.run_id")
+    parent_chats = [s for s in spans
+                    if s.attributes.get("gen_ai.operation.name") == "chat"
+                    and s.attributes.get("cubepi.run_id") == parent_run_id]
+    # Parent T1 AND T2 must both be present under the PARENT run. If the stale
+    # inner gate were left set, T2's provider call would be skipped and only 1
+    # parent chat would exist.
+    assert len(parent_chats) == 2, (
+        f"expected 2 parent-run chat spans, got {len(parent_chats)} — parent's "
+        "post-tool turn was gated by a stale _active_run from the cancelled inner run"
+    )
+```
+
+> Import `from asyncio import CancelledError` at the top of the test module.
+> Adapt the faux provider's "raise on this reply" mechanism to the harness
+> (some fakes accept an exception instance in `scripted_replies`; others need a
+> side-effect callable). The invariant under test is harness-independent: after
+> a cancelled inner run, the parent's next provider call in the same task is
+> NOT gated.
+
+- [ ] **Step 7: Run cancellation test**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/tracing/test_subagent_nesting.py::test_cancelled_inner_does_not_gate_parents_next_turn -v`
+Expected: PASS (with the reset wired into `_close_open_spans` per Step 3).
+
+- [ ] **Step 8: Regression — existing tracing tests still green**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/tracing/ -q`
+Expected: PASS (no regressions in single-agent recording).
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/chris/cubepi
+git add cubepi/tracing/recorder.py tests/tracing/test_subagent_nesting.py
+git commit -m "fix(tracing): gate provider listeners on per-task active run
+
+A provider shared by a parent and inner agent fired every attached
+recorder's chat-span listener. Route each listener to the run that owns
+the calling task via a contextvar so an inner subagent's LLM calls no
+longer leak into the parent recorder's run."
+```
+
+---
+
+## Task 2: Parent the inner run's root under the active `execute_tool` span (cubepi)
+
+When `invoke_agent` opens inside an active tool body, nest it under that tool span (inherit `trace_id`, set `parent_span_id`) instead of starting a new root.
+
+**Files:**
+- Modify: `cubepi/tracing/recorder.py` (`_on_agent_start`, around the `start_span(SPAN_NAME_INVOKE_AGENT ...)` call ~line 436)
+- Test: `tests/tracing/test_subagent_nesting.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_inner_run_nests_under_active_tool_span(tmp_path):
+    """An invoke_agent span opened while an execute_tool span is active for the
+    task must be parented under that tool span (same trace_id)."""
+    from cubepi.mcp import _tracing as mcp_tracing
+    tracer, exporter = build_tracer_with_memory_exporter()
+
+    # Open a standalone execute_tool-like parent span and register it as the
+    # active tool span for this task, mimicking _on_tool_exec_start.
+    parent_span = tracer.otel_tracer.start_span("execute_tool subagent")
+    token = mcp_tracing.register_tool_span("tc1", parent_span, provider=None)
+    try:
+        provider = FauxProvider(scripted_replies=["inner-done"])
+        inner = make_agent(provider=provider, tools=[])
+        detach = tracer.attach(inner)
+        try:
+            await inner.prompt("hi")
+        finally:
+            await detach()
+    finally:
+        mcp_tracing.unregister_tool_span(token)
+        parent_span.end()
+    await tracer.shutdown()
+
+    spans = {s.name: s for s in exporter.get_finished_spans()}
+    root = next(s for s in exporter.get_finished_spans()
+                if s.attributes.get("gen_ai.operation.name") == "invoke_agent")
+    parent_ctx = parent_span.get_span_context()
+    assert root.parent is not None
+    assert root.parent.span_id == parent_ctx.span_id, "invoke_agent not nested under tool span"
+    assert root.context.trace_id == parent_ctx.trace_id, "trace_id not inherited"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/tracing/test_subagent_nesting.py::test_inner_run_nests_under_active_tool_span -v`
+Expected: FAIL — `root.parent is None` (invoke_agent opened as a new root).
+
+- [ ] **Step 3: Nest the root under the active tool span**
+
+In `_on_agent_start`, replace the unconditional root open:
+
+```python
+        span = self._tracer.otel_tracer.start_span(
+            name=SPAN_NAME_INVOKE_AGENT,
+            kind=SpanKind.INTERNAL,
+            attributes={ ... },
+        )
+```
+
+with a context-aware open:
+
+```python
+        from opentelemetry import trace as _otel_trace
+        parent_ctx = None
+        try:
+            # TODO(tracing): relocate this "current tool span" helper out of
+            # cubepi.mcp._tracing — it now serves generic nested agents, not
+            # just MCP clients.
+            from cubepi.mcp import _tracing as _mcp_tracing
+            entry = _mcp_tracing._get_tool_span_entry()
+            if entry is not None:
+                tool_span, _tool_provider = entry
+                parent_ctx = _otel_trace.set_span_in_context(tool_span)
+        except ImportError:  # pragma: no cover — mcp module always present
+            parent_ctx = None
+
+        span = self._tracer.otel_tracer.start_span(
+            name=SPAN_NAME_INVOKE_AGENT,
+            kind=SpanKind.INTERNAL,
+            context=parent_ctx,  # see branch note below
+            attributes={
+                GEN_AI_OPERATION_NAME: OP_INVOKE_AGENT,
+                CUBEPI_RUN_ID: run_id,
+                GEN_AI_PROVIDER_NAME: "cubepi",
+            },
+        )
+```
+
+> **Two branches (codex NIT — don't call `context=None` a "new root").**
+> When no tool span is active for the task, `parent_ctx` stays `None` and
+> `start_span` falls back to the OTel ambient current context — i.e. exactly
+> today's behavior (a root span in practice, since the recorder never installs
+> its own spans as ambient current). Single-agent runs are unaffected. The new
+> work is the OTHER branch: when `_get_tool_span_entry()` returns a live tool
+> span, `parent_ctx = set_span_in_context(tool_span)` makes the inner
+> `invoke_agent` a child of the `execute_tool` span — inheriting its `trace_id`
+> and taking `parent_span_id = tool_span`. This is the "run_scope /
+> caller-context propagation" the existing `_on_agent_start` comment anticipates.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/tracing/test_subagent_nesting.py::test_inner_run_nests_under_active_tool_span -v`
+Expected: PASS.
+
+- [ ] **Step 5: Regression**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/tracing/ -q`
+Expected: PASS — single-agent roots still have `parent is None`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/chris/cubepi
+git add cubepi/tracing/recorder.py tests/tracing/test_subagent_nesting.py
+git commit -m "feat(tracing): nest inner-agent invoke_agent under active tool span
+
+When a recorder opens invoke_agent while an execute_tool span is active
+for the task (a subagent running inside a tool body), parent the root
+under that tool span so the whole inner run nests in the same trace."
+```
+
+---
+
+## Task 3: End-to-end cubepi test — nested subagent produces a nested subtree
+
+Proves Tasks 1+2 compose: an inner agent attached to the same Tracer, run inside an `execute_tool` body, yields `execute_tool → invoke_agent → cubepi.turn → {chat, execute_tool}` nesting.
+
+**Files:**
+- Test: `tests/tracing/test_subagent_nesting.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_full_nested_subtree_via_real_tool(tmp_path):
+    """A tool whose body attaches+runs an inner agent that ITSELF calls a tool
+    yields the full nested subtree: the inner invoke_agent AND its turn / chat /
+    execute_tool spans all descend from the outer execute_tool span."""
+    tracer, exporter = build_tracer_with_memory_exporter()
+    # Replies are consumed in cross-agent CALL order. The inner agent runs
+    # INSIDE the spawn tool body, BEFORE the parent's post-tool turn, so its
+    # replies come before `parent-final` (codex SHOULD-FIX: original order was
+    # wrong — the inner would have eaten `parent-final`).
+    provider = FauxProvider(scripted_replies=[
+        {"tool_calls": [{"id": "tc1", "name": "spawn", "arguments": {}}]},   # parent T1
+        {"tool_calls": [{"id": "tc2", "name": "inner_tool", "arguments": {}}]},  # inner T1
+        "inner-final",                                                         # inner T2
+        "parent-final",                                                        # parent T2
+    ])
+
+    async def _inner_tool(tool_call_id, args, *, signal=None, on_update=None):
+        return AgentToolResult(content=[TextContent(text="inner-tool-ok")])
+
+    inner_tool = AgentTool(name="inner_tool", description="inner work",
+                           parameters=_Empty, execute=_inner_tool)
+
+    async def _spawn(tool_call_id, args, *, signal=None, on_update=None):
+        inner = make_agent(provider=provider, tools=[inner_tool])
+        detach = tracer.attach(inner)
+        try:
+            await inner.prompt("do the thing")
+        finally:
+            res = detach()
+            if res is not None:
+                await res
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    spawn = AgentTool(name="spawn", description="spawn inner", parameters=_Empty, execute=_spawn)
+    parent = make_agent(provider=provider, tools=[spawn])
+    detach_parent = tracer.attach(parent)
+    try:
+        await parent.prompt("go")
+    finally:
+        res = detach_parent()
+        if res is not None:
+            await res
+    await tracer.shutdown()
+
+    spans = exporter.get_finished_spans()
+    by_id = {s.context.span_id: s for s in spans}
+    tool_span = next(s for s in spans if s.name == "execute_tool spawn")
+    inner_root = next(s for s in spans
+                      if s.attributes.get("gen_ai.operation.name") == "invoke_agent"
+                      and s.parent is not None
+                      and s.parent.span_id == tool_span.context.span_id)
+
+    def _descends_from(span, ancestor_id):
+        cur = span
+        while cur is not None and cur.parent is not None:
+            if cur.parent.span_id == ancestor_id:
+                return True
+            cur = by_id.get(cur.parent.span_id)
+        return False
+
+    # (a) inner chat descends from the inner root (not the parent turn).
+    inner_chats = [s for s in spans
+                   if s.attributes.get("gen_ai.operation.name") == "chat"
+                   and _descends_from(s, inner_root.context.span_id)]
+    assert inner_chats, "inner chat span did not nest under the inner run"
+    # (b) the inner agent's OWN execute_tool span exists AND nests under the
+    #     inner root — this is the regression guard for the original
+    #     'missing inner tool spans' bug (codex SHOULD-FIX).
+    inner_tool_spans = [s for s in spans
+                        if s.name == "execute_tool inner_tool"
+                        and _descends_from(s, inner_root.context.span_id)]
+    assert inner_tool_spans, "inner execute_tool span missing or not nested under the inner run"
+```
+
+> Adjust `FauxProvider`'s scripted-reply shape to match the existing harness (some fakes take a list of `AssistantMessage`s, others a callable). The intent: parent calls `spawn`; the inner agent then calls `inner_tool` and finalizes; the parent finalizes last. `_Empty` is defined once in Task 1's test module.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/chris/cubepi && uv run pytest tests/tracing/test_subagent_nesting.py::test_full_nested_subtree_via_real_tool -v`
+Expected: PASS once Tasks 1+2 are in (this is the integration guard). If it FAILS, the active-tool-span contextvar is not visible in the tool body's task — investigate `execute_tool_calls` task creation ordering before patching further (do NOT add a second fix on top).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/chris/cubepi
+git add tests/tracing/test_subagent_nesting.py
+git commit -m "test(tracing): end-to-end nested-subagent subtree"
+```
+
+---
+
+## Task 4: cubebox — attach the parent Tracer to the inner agent
+
+Make the inner subagent run actually recorded (and, with Tasks 1–2, nested) by attaching the active `Tracer` around `inner.prompt()`.
+
+**Files:**
+- Modify: `backend/cubebox/middleware/subagents.py` (`SubAgentMiddleware.__init__` to accept `tracer`; `_execute` to attach/detach)
+- Modify: `backend/cubebox/streams/run_manager.py` (pass the active `Tracer` into `SubAgentMiddleware`)
+- Test: `backend/tests/middleware/test_subagent_trace.py`
+
+- [ ] **Step 1: Confirm the Tracer source in run-manager (codex SHOULD-FIX — be exact)**
+
+The process-level Tracer is on app state. `SubAgentMiddleware` is constructed at `backend/cubebox/streams/run_manager.py:1282` (`subagent_mw = SubAgentMiddleware(...)`), but the local `tracer = getattr(self._app.state, "tracer", None)` is only read LATER at line ~1467 (where the parent agent is attached via cubepi's best-effort `trace` scope). So at construction time the local does not yet exist — read it directly:
+
+Run: `cd /home/chris/cubebox && grep -n "SubAgentMiddleware(\|getattr(self._app.state, \"tracer\"\|app.state.tracer" backend/cubebox/streams/run_manager.py`
+Expected: construction at ~1282, tracer accessor at ~1467. The fix passes `tracer=getattr(self._app.state, "tracer", None)` into the constructor at 1282 (it's `None` when tracing is disabled — handled below).
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# backend/tests/middleware/test_subagent_trace.py
+import pytest
+from asyncio import CancelledError
+
+
+class _FakeTracer:
+    def __init__(self):
+        self.attached = []
+        self.detached = 0
+    def attach(self, agent):
+        self.attached.append(agent)
+        def _detach():               # mirror Tracer.attach: sync call, may return awaitable
+            self.detached += 1
+            return None
+        return _detach
+
+
+@pytest.mark.asyncio
+async def test_subagent_attaches_and_detaches_tracer_on_success():
+    """SubAgentMiddleware attaches the provided Tracer to the inner agent and
+    detaches in finally on the success path."""
+    tracer = _FakeTracer()
+    # Build SubAgentMiddleware(tracer=tracer, ...) with a stub subagent_map and
+    # a provider whose inner run completes normally; invoke the subagent tool.
+    ...  # use the existing SubAgentMiddleware test harness (Step note)
+    assert len(tracer.attached) == 1, "inner agent was not attached"
+    assert tracer.detached == 1, "detach() not called in finally"
+
+
+@pytest.mark.asyncio
+async def test_subagent_detaches_tracer_when_inner_run_fails():
+    """Even when the inner run raises a normal Exception, detach() still runs
+    (finally) and the tool returns an is_error result rather than propagating."""
+    tracer = _FakeTracer()
+    # Build the middleware with an inner provider that raises Exception mid-run;
+    # invoke the subagent tool (it returns an is_error result, not raising).
+    ...
+    assert len(tracer.attached) == 1
+    assert tracer.detached == 1, "detach() not called on the failure path"
+
+
+@pytest.mark.asyncio
+async def test_subagent_detaches_tracer_when_inner_run_cancelled():
+    """CancelledError is BaseException — NOT caught by `except Exception` — so it
+    propagates out of the tool body, but the `finally` block must still detach
+    (codex SHOULD-FIX: cancellation path was untested)."""
+    tracer = _FakeTracer()
+    # Build the middleware with an inner provider that raises CancelledError;
+    # invoke the subagent tool and expect the CancelledError to propagate.
+    ...
+    with pytest.raises(CancelledError):
+        await _invoke_subagent_tool(...)  # adapt to the harness's invocation helper
+    assert len(tracer.attached) == 1
+    assert tracer.detached == 1, "detach() not called on the cancellation path"
+
+
+@pytest.mark.asyncio
+async def test_run_manager_passes_process_tracer_to_subagent_middleware(monkeypatch):
+    """run_manager constructs SubAgentMiddleware with the app-state tracer."""
+    # Arrange app.state.tracer = sentinel; drive the run-manager path that
+    # builds SubAgentMiddleware; assert the middleware received tracer=sentinel.
+    ...
+```
+
+> Flesh out the `...` blocks with the existing subagent middleware test harness (grep `backend/tests` for `SubAgentMiddleware`). The three invariants that matter: (1) inner agent attached, (2) detach runs on BOTH success and failure paths, (3) run-manager wires the app-state tracer in.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /home/chris/cubebox/backend && uv run pytest tests/middleware/test_subagent_trace.py -v`
+Expected: FAIL — inner agent never attached / tracer never threaded.
+
+- [ ] **Step 4: Thread the Tracer through and attach (best-effort)**
+
+In `SubAgentMiddleware.__init__`, add an optional `tracer: Any = None` parameter and store `self._tracer = tracer`. In `_execute`, wrap the run so tracing can NEVER break the subagent (mirrors the parent's best-effort attach in run_manager):
+
+```python
+            detach = None
+            if self._tracer is not None:
+                try:
+                    detach = self._tracer.attach(inner)
+                except Exception as exc:  # tracing must never break the run
+                    logger.debug("subagent tracer.attach failed: {}", exc)
+                    detach = None
+            try:
+                await inner.prompt(args.prompt)
+            except Exception as exc:
+                ...  # unchanged existing error handling -> returns is_error result
+            finally:
+                if detach is not None:
+                    try:
+                        res = detach()
+                        if res is not None:
+                            await res
+                    except Exception as exc:
+                        logger.debug("subagent tracer.detach failed: {}", exc)
+```
+
+In `run_manager.py:1282`, add the `tracer=` kwarg to the EXISTING construction (do not change the other args — the real call passes `default_provider_name`, `shared_tools`, `inherited_middleware`, NOT `metadata`):
+
+```python
+            subagent_mw = SubAgentMiddleware(
+                subagent_map={},
+                default_provider=provider,
+                default_model_id=model_id,
+                default_provider_name=provider_name,
+                shared_tools=_sandbox_tools + _artifact_tools + _builtin_tools,
+                inherited_middleware=_cost_mw_for_inherit,
+                tracer=getattr(self._app.state, "tracer", None),  # NEW
+            )
+```
+
+> Same Tracer instance ⇒ same exporters ⇒ inner spans land in the parent's trace file. Task 1's active-run gate prevents double chat spans; Task 2 nests the inner root under `execute_tool subagent`. `tracer=None` (tracing disabled) ⇒ the attach block is skipped, behavior unchanged.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /home/chris/cubebox/backend && uv run pytest tests/middleware/test_subagent_trace.py -v`
+Expected: PASS (all three).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/chris/cubebox
+git add backend/cubebox/middleware/subagents.py backend/cubebox/streams/run_manager.py backend/tests/middleware/test_subagent_trace.py
+git commit -m "fix(subagents): attach Tracer to inner agent so its run is traced
+
+Inner subagent runs were invisible to the recorder (no nested turn/tool
+spans) and leaked chat spans onto the parent turn. Attach the active
+Tracer to the inner agent; with the cubepi run-nesting fix its spans now
+nest under the execute_tool subagent span."
+```
+
+---
+
+## Task 5: Bump the cubepi pin in cubebox and verify end-to-end
+
+cubepi changes (Tasks 1–3) reach cubebox runtime only via the pinned `rev`.
+
+**Files:**
+- Modify: `backend/uv.lock` (via `uv`), `backend/pyproject.toml` if the rev is pinned there
+
+- [ ] **Step 1: Push cubepi changes and capture the new rev**
+
+```bash
+cd /home/chris/cubepi && git push && git rev-parse HEAD
+```
+
+- [ ] **Step 2: Bump the pin**
+
+```bash
+cd /home/chris/cubebox/backend && uv lock --upgrade-package cubepi
+```
+> Do not hand-edit `uv.lock`. Confirm the new `rev` matches the pushed cubepi HEAD: `grep -A1 'name = "cubepi"' uv.lock`.
+
+- [ ] **Step 3: Run a real subagent task and inspect the trace**
+
+Run a subagent-spawning prompt, then:
+```bash
+cd /home/chris/cubebox/backend && uv run python -m cubepi.cli trace view <run_id> --dir cubepi-traces
+```
+Expected: under each `execute_tool subagent [..]` node there is now a nested `invoke_agent → cubepi.turn → {chat, execute_tool}` subtree (with span_ids shown), instead of flat sibling chats. Confirm no duplicate chat spans.
+
+- [ ] **Step 4: Commit the pin bump**
+
+```bash
+cd /home/chris/cubebox
+git add backend/uv.lock backend/pyproject.toml
+git commit -m "build(deps): bump cubepi pin for subagent trace nesting"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Task 1 = shared-provider routing (spec §6 provider listeners); Task 2 = nested-agent caller-context (spec §6.1 / §8); Task 4 = the cubebox side the spec assumes ("inner agent with its own Tracer"). The span_id display ask is already shipped in `render.py` (out of scope here).
+- **Known risk (call out before coding Task 3):** if `_get_tool_span_entry()` is not visible inside the parallel tool body's task, the inner root won't nest. The contextvar copies at child-task creation, and `register_tool_span` runs in `_on_tool_exec_start` *before* the body task is created, so it should be visible — but Task 3's integration test is the gate. If it fails, fix the contextvar propagation, not the symptom.
+- **Type consistency:** `tracer.attach(agent)` returns a `detach` callable that may return an awaitable `Task` or `None`; Tasks 1/3/4 all handle both (`res = detach(); if res is not None: await res`).
+- **Worktree (per project discipline):** execute this plan in a dedicated worktree, not on `main`, in BOTH repos. The span_id `render.py` change is currently uncommitted on `~/cubepi` `main` — fold it into the worktree branch or commit it separately before starting.
+
+### Codex review (2026-05-27) — folded in
+
+- **[BLOCKING, fixed]** Task 1's original test only ran `inner.prompt()`, so the parent recorder's `_run` was `None` and its listener already early-returned — the test wasn't red for the real bug. Rewritten to drive the parent through a turn that spawns the inner agent (production shape); pre-fix expects **4** chat spans, post-fix **3**.
+- **[SHOULD-FIX, fixed]** Cancellation: `CancelledError` bypasses `AgentEndEvent`, so the `_active_run` reset now lives in `_close_open_spans` (the detach path), with a dedicated sequential-mode cancellation test (Task 1 Step 6).
+- **[SHOULD-FIX, fixed]** Parallel-mode contextvar shadowing argument is now written out explicitly in Task 1 Step 3.
+- **[SHOULD-FIX, fixed]** Task 3 now makes the inner agent call a real `inner_tool` and asserts the inner `execute_tool` span descends from the inner root (regression guard for "missing inner tool spans"); FauxProvider replies reordered to tool-call → inner-tool → inner-final → parent-final.
+- **[SHOULD-FIX, fixed]** Task 4 test now asserts `detach()` on success AND failure paths and that run-manager wires `app.state.tracer`; tracer source pinned to `run_manager.py:1282` via `getattr(self._app.state, "tracer", None)`, attach/detach wrapped best-effort.
+- **[NIT, fixed]** Task 2 wording now distinguishes the `context=None` (ambient/today) branch from the tool-span-parent branch.
+- **[NIT, noted]** `_get_tool_span_entry()` lives in `cubepi.mcp._tracing`; the recorder already depends on that module, so Task 2 adds no new layering breach. Long-term this "current tool span" helper should move into a tracing-owned module since it now serves generic nested agents, not just MCP clients — out of scope for this plan; leave a `# TODO(tracing): relocate current-tool-span helper out of mcp` where Task 2 reads it.

--- a/tests/cli/trace/test_loader.py
+++ b/tests/cli/trace/test_loader.py
@@ -272,7 +272,11 @@ def test_run_prompt_prefers_root_over_subagent_invoke_agent():
 
     sub = Span(
         _span(
-            "0x9", "0x5", "invoke_agent", "2026-05-20T00:00:02Z", "r-sub",
+            "0x9",
+            "0x5",
+            "invoke_agent",
+            "2026-05-20T00:00:02Z",
+            "r-sub",
             **{
                 "gen_ai.operation.name": "invoke_agent",
                 "gen_ai.input.messages": json.dumps(
@@ -283,7 +287,11 @@ def test_run_prompt_prefers_root_over_subagent_invoke_agent():
     )
     root = Span(
         _span(
-            "0x1", None, "invoke_agent", "2026-05-20T00:00:00Z", "r-root",
+            "0x1",
+            None,
+            "invoke_agent",
+            "2026-05-20T00:00:00Z",
+            "r-root",
             **{
                 "gen_ai.operation.name": "invoke_agent",
                 "gen_ai.input.messages": json.dumps(

--- a/tests/cli/trace/test_loader.py
+++ b/tests/cli/trace/test_loader.py
@@ -259,3 +259,37 @@ def test_list_runs_merges_cross_midnight(tmp_path):
     runs = list_runs(tmp_path)
     assert len(runs) == 1  # one run, not two
     assert runs[0].span_count == 2
+
+
+def test_run_prompt_prefers_root_over_subagent_invoke_agent():
+    # A trace file now holds the parent run PLUS nested subagent runs, each
+    # with its own invoke_agent span. The prompt shown in `ls` must come from
+    # the ROOT (parent-less) invoke_agent, not a subagent's. The subagent span
+    # is placed FIRST in the list so this distinguishes the parent-less filter
+    # from plain iteration order (which would otherwise pick the subagent).
+    from cubepi.cli.trace.loader import _run_prompt
+    from cubepi.cli.trace.model import Span
+
+    sub = Span(
+        _span(
+            "0x9", "0x5", "invoke_agent", "2026-05-20T00:00:02Z", "r-sub",
+            **{
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.input.messages": json.dumps(
+                    [{"role": "user", "content": "subagent prompt"}]
+                ),
+            },
+        )
+    )
+    root = Span(
+        _span(
+            "0x1", None, "invoke_agent", "2026-05-20T00:00:00Z", "r-root",
+            **{
+                "gen_ai.operation.name": "invoke_agent",
+                "gen_ai.input.messages": json.dumps(
+                    [{"role": "user", "content": "root prompt"}]
+                ),
+            },
+        )
+    )
+    assert _run_prompt([sub, root]) == "root prompt"

--- a/tests/cli/trace/test_loader.py
+++ b/tests/cli/trace/test_loader.py
@@ -38,7 +38,7 @@ def test_resolve_by_path(tmp_path):
     assert resolve_run(str(f), tmp_path) == [f]
 
 
-def test_resolve_by_run_id_merges_cross_midnight(tmp_path):
+def test_resolve_by_trace_id_merges_cross_midnight(tmp_path):
     f1 = tmp_path / "2026-05-19" / "r1.jsonl"
     f2 = tmp_path / "2026-05-20" / "r1.jsonl"
     _write(f1, [_span("0x1", None, "invoke_agent", "2026-05-19T23:59:59Z", "r1")])
@@ -53,7 +53,7 @@ def test_resolve_zero_match_errors(tmp_path):
 
 
 def test_resolve_by_unique_prefix(tmp_path):
-    # `ls` truncates run ids, so a copied prefix must resolve to its one run.
+    # `ls` truncates trace ids, so a copied prefix must resolve to its one trace.
     f = tmp_path / "2026-05-20" / "66f1806f-4c90-4d50.jsonl"
     _write(f, [_span("0x1", None, "invoke_agent", "2026-05-20T00:00:00Z", "r1")])
     assert resolve_run("66f1806f", tmp_path) == [f]
@@ -79,7 +79,7 @@ def test_resolve_ambiguous_prefix_errors(tmp_path):
 
 
 def test_resolve_exact_match_preferred_over_prefix(tmp_path):
-    # An exact run id must not be shadowed by a longer-named sibling run.
+    # An exact trace id must not be shadowed by a longer-named sibling trace.
     exact = tmp_path / "2026-05-20" / "run1.jsonl"
     _write(exact, [_span("0x1", None, "x", None, "r1")])
     _write(
@@ -133,7 +133,7 @@ def test_list_runs(tmp_path):
     )
     runs = list_runs(tmp_path)
     assert len(runs) == 1
-    assert runs[0].run_id == "r1"
+    assert runs[0].trace_id == "r1"
     assert runs[0].span_count == 2
 
 
@@ -229,7 +229,7 @@ def test_list_runs_prompt_handles_bad_messages(tmp_path):
             )
         ],
     )
-    prompts = {r.run_id: r.prompt for r in list_runs(tmp_path)}
+    prompts = {r.trace_id: r.prompt for r in list_runs(tmp_path)}
     assert prompts == {"r1": None, "r2": None}
 
 

--- a/tests/cli/trace/test_render.py
+++ b/tests/cli/trace/test_render.py
@@ -102,7 +102,7 @@ def test_render_tree_falls_back_to_status_description():
 def test_render_runs_includes_input_column(capsys):
     runs = [
         RunSummary(
-            run_id="r1",
+            trace_id="r1",
             files=[Path("x.jsonl")],
             start=None,
             span_count=3,

--- a/tests/cli/trace/test_schema_roundtrip.py
+++ b/tests/cli/trace/test_schema_roundtrip.py
@@ -26,7 +26,9 @@ def test_real_exporter_output_parses(tmp_path):
             chat.set_attribute(CUBEPI_RUN_ID, "roundtrip")
     exporter.export([root, chat])
 
-    files = sorted(tmp_path.glob("*/roundtrip.jsonl"))
+    # One file per trace; stem is the 32-hex trace_id, not the run_id.
+    trace_id = format(root.context.trace_id, "032x")
+    files = sorted(tmp_path.glob(f"*/{trace_id}.jsonl"))
     assert files, "exporter wrote no file"
     loaded, skipped = load_run(files)
     assert skipped == 0

--- a/tests/tracing/test_jsonl_exporter.py
+++ b/tests/tracing/test_jsonl_exporter.py
@@ -1,0 +1,34 @@
+"""JsonlSpanExporter shards by trace_id, not per-span run_id."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk.trace")
+
+from opentelemetry.sdk.trace import TracerProvider  # noqa: E402
+
+from cubepi.tracing.exporters import JsonlSpanExporter  # noqa: E402
+from cubepi.tracing.schema import CUBEPI_RUN_ID  # noqa: E402
+
+
+def test_jsonl_shards_by_trace_id_not_run_id(tmp_path):
+    # A parent span and a nested (subagent) span share one trace_id but carry
+    # DIFFERENT cubepi.run_id values — the subagent run gets its own run_id.
+    exporter = JsonlSpanExporter(directory=tmp_path)
+    provider = TracerProvider()
+    tracer = provider.get_tracer("cubepi.tracing")
+    with tracer.start_as_current_span("invoke_agent") as parent:
+        parent.set_attribute(CUBEPI_RUN_ID, "parent-run")
+        with tracer.start_as_current_span("invoke_agent") as child:
+            # Same trace, different run id (nested subagent run).
+            child.set_attribute(CUBEPI_RUN_ID, "subagent-run")
+
+    assert parent.context.trace_id == child.context.trace_id
+    assert parent.attributes[CUBEPI_RUN_ID] != child.attributes[CUBEPI_RUN_ID]
+
+    exporter.export([parent, child])
+
+    files = list(tmp_path.glob("*/*.jsonl"))
+    assert len(files) == 1, [f.name for f in files]
+    assert files[0].stem == format(parent.context.trace_id, "032x")

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -989,6 +989,43 @@ class TestMCPSpanParentage:
             "_active_entries leaked after cross-task unregister_tool_span"
         )
 
+    async def test_nested_tool_falls_back_to_outer_after_inner_unregister_cross_task(
+        self,
+    ):
+        """Parallel-mode shape: an inner tool registers while an outer tool is
+        active, then its ToolExecutionEnd unregisters from a CHILD task — so the
+        per-task contextvar can't be reset. A later lookup in the outer task
+        must fall back to the still-active OUTER tool span, not return None;
+        otherwise a subsequent subagent/MCP call fails to nest under the outer
+        execute_tool span (codex P2, PR #122)."""
+        import asyncio as _asyncio
+
+        from cubepi.mcp import _tracing as mcp_tracing
+
+        tok_outer = mcp_tracing.register_tool_span(
+            "outer", "span-outer", provider="prov-outer"
+        )
+        tok_inner = mcp_tracing.register_tool_span(
+            "inner", "span-inner", provider="prov-inner"
+        )
+        try:
+            # Innermost lookup is the inner tool while it is live.
+            assert mcp_tracing._get_tool_span_entry() == ("span-inner", "prov-inner")
+
+            async def _end_inner() -> None:
+                mcp_tracing.unregister_tool_span(tok_inner)
+
+            # Inner ends in a different task (cross-task reset fails silently).
+            await _asyncio.create_task(_end_inner())
+
+            # Must fall back to the OUTER tool, not None.
+            assert mcp_tracing._get_tool_span_entry() == ("span-outer", "prov-outer")
+        finally:
+            mcp_tracing.unregister_tool_span(tok_outer)
+
+        # Fully unwound: no active tool for this task.
+        assert mcp_tracing._get_tool_span_entry() is None
+
     async def test_mcp_span_orphan_when_no_registered_parent(self, monkeypatch):
         """Without a registered parent, the MCP span starts a new
         root trace. Pinning this so the parented-path test above is

--- a/tests/tracing/test_subagent_nesting.py
+++ b/tests/tracing/test_subagent_nesting.py
@@ -231,3 +231,104 @@ async def test_inner_run_nests_under_active_tool_span():
         "invoke_agent not nested under tool span"
     )
     assert root.context.trace_id == pctx.trace_id, "trace_id not inherited"
+
+
+async def test_full_nested_subtree_via_real_tool():
+    """End-to-end composition of Tasks 1+2: a tool whose body attaches and runs
+    an inner agent (which itself calls a tool) yields the full nested subtree
+    ``execute_tool spawn -> invoke_agent -> cubepi.turn -> {chat,
+    execute_tool inner_tool}`` — the inner chat and inner tool span both descend
+    from the inner run's root, and the inner root nests under the tool span.
+    """
+    provider = FauxProvider()
+    exporter = InMemoryExporter()
+    tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+
+    # FIFO across both agents in CALL order: parent->spawn, inner->inner_tool,
+    # inner-final, parent-final.
+    provider.append_responses(
+        [
+            faux_assistant_message(
+                [ToolCall(id="tc1", name="spawn", arguments={})],
+                stop_reason="tool_use",
+            ),
+            faux_assistant_message(
+                [ToolCall(id="tc2", name="inner_tool", arguments={})],
+                stop_reason="tool_use",
+            ),
+            faux_assistant_message("inner-final"),
+            faux_assistant_message("parent-final"),
+        ]
+    )
+
+    async def _inner_tool(tool_call_id, args, *, signal=None, on_update=None):
+        return AgentToolResult(content=[TextContent(text="inner-tool-ok")])
+
+    inner_tool = AgentTool(
+        name="inner_tool",
+        description="inner tool",
+        parameters=_Empty,
+        execute=_inner_tool,
+    )
+
+    async def _spawn(tool_call_id, args, *, signal=None, on_update=None):
+        inner = _make_agent(provider, tools=[inner_tool])
+        detach = tracer.attach(inner)
+        try:
+            await inner.prompt("do the thing")
+            await inner.wait_for_idle()
+        finally:
+            res = detach()
+            if res is not None:
+                await res
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    spawn = AgentTool(
+        name="spawn", description="spawn inner", parameters=_Empty, execute=_spawn
+    )
+    parent = _make_agent(provider, tools=[spawn])
+    detach_parent = tracer.attach(parent)
+    try:
+        await parent.prompt("go")
+        await parent.wait_for_idle()
+    finally:
+        res = detach_parent()
+        if res is not None:
+            await res
+    await tracer.shutdown()
+
+    spans = exporter.spans
+    by_id = {s.context.span_id: s for s in spans}
+    tool_span = next(s for s in spans if s.name == "execute_tool spawn")
+    inner_root = next(
+        s
+        for s in spans
+        if (s.attributes or {}).get("gen_ai.operation.name") == "invoke_agent"
+        and s.parent is not None
+        and s.parent.span_id == tool_span.context.span_id
+    )
+
+    def _descends_from(span, ancestor_id):
+        cur = span
+        while cur is not None and cur.parent is not None:
+            if cur.parent.span_id == ancestor_id:
+                return True
+            cur = by_id.get(cur.parent.span_id)
+        return False
+
+    inner_chats = [
+        s
+        for s in spans
+        if (s.attributes or {}).get("gen_ai.operation.name") == "chat"
+        and _descends_from(s, inner_root.context.span_id)
+    ]
+    assert inner_chats, "inner chat span did not nest under the inner run"
+    inner_tool_spans = [
+        s
+        for s in spans
+        if s.name == "execute_tool inner_tool"
+        and _descends_from(s, inner_root.context.span_id)
+    ]
+    assert inner_tool_spans, (
+        "inner execute_tool span missing or not nested under the inner run"
+    )

--- a/tests/tracing/test_subagent_nesting.py
+++ b/tests/tracing/test_subagent_nesting.py
@@ -113,7 +113,14 @@ async def test_shared_provider_does_not_double_mint_inner_chat():
     assert len(chat_spans) == 3, f"expected 3 chat spans, got {len(chat_spans)}"
 
 
-async def test_cancelled_inner_does_not_gate_parents_next_turn():
+async def test_cancelled_inner_gate_released_for_parents_next_turn():
+    """A cancelled inner run must release the active-run gate so the parent's
+    next turn is recorded. The gate-reset path that matters here is `detach()`
+    -> `_close_open_spans` -> `_reset_active_run` (the inner run may skip
+    AgentEndEvent on cancellation). Asserting the parent run has 2 chat spans
+    proves both that the gate was released AND that no inner chat leaked onto
+    the parent run.
+    """
     provider = FauxProvider()
     exporter = InMemoryExporter()
     tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])

--- a/tests/tracing/test_subagent_nesting.py
+++ b/tests/tracing/test_subagent_nesting.py
@@ -187,3 +187,47 @@ async def test_cancelled_inner_gate_released_for_parents_next_turn():
     assert len(parent_chats) == 2, (
         f"expected 2 parent-run chat spans, got {len(parent_chats)}"
     )
+
+
+async def test_inner_run_nests_under_active_tool_span():
+    """When invoke_agent opens while an execute_tool span is active for the
+    task (a subagent running inside a tool body), the inner agent's root
+    invoke_agent span must nest under that tool span — inheriting trace_id
+    and setting parent_span_id — instead of starting a new root.
+    """
+    from cubepi.mcp import _tracing as mcp_tracing
+
+    provider = FauxProvider()
+    exporter = InMemoryExporter()
+    tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+
+    provider.append_responses([faux_assistant_message("inner-final")])
+
+    parent_span = tracer.otel_tracer.start_span("execute_tool subagent")
+    token = mcp_tracing.register_tool_span("tc1", parent_span, provider=None)
+    try:
+        inner = _make_agent(provider, tools=[])
+        detach = tracer.attach(inner)
+        try:
+            await inner.prompt("hi")
+            await inner.wait_for_idle()
+        finally:
+            res = detach()
+            if res is not None:
+                await res
+    finally:
+        mcp_tracing.unregister_tool_span(token)
+        parent_span.end()
+    await tracer.shutdown()
+
+    root = next(
+        s
+        for s in exporter.spans
+        if (s.attributes or {}).get("gen_ai.operation.name") == "invoke_agent"
+    )
+    pctx = parent_span.get_span_context()
+    assert root.parent is not None, "invoke_agent opened as a new root"
+    assert root.parent.span_id == pctx.span_id, (
+        "invoke_agent not nested under tool span"
+    )
+    assert root.context.trace_id == pctx.trace_id, "trace_id not inherited"

--- a/tests/tracing/test_subagent_nesting.py
+++ b/tests/tracing/test_subagent_nesting.py
@@ -152,9 +152,7 @@ async def test_cancelled_inner_gate_released_for_parents_next_turn():
             res = detach()
             if res is not None:
                 await res
-        return AgentToolResult(
-            content=[TextContent(text="[cancelled]")], is_error=True
-        )
+        return AgentToolResult(content=[TextContent(text="[cancelled]")], is_error=True)
 
     # Sequential mode so the inner run shares the parent/loop task.
     spawn = AgentTool(

--- a/tests/tracing/test_subagent_nesting.py
+++ b/tests/tracing/test_subagent_nesting.py
@@ -1,0 +1,182 @@
+"""Subagent nesting: a provider shared by a parent and an inner agent
+must not let the parent recorder's chat-span listener fire for the
+inner agent's LLM calls.
+
+Both agents share ONE FauxProvider instance, and both attach the SAME
+Tracer. Provider listeners are per-provider-instance, so without the
+per-task active-run gate the parent recorder's ``_on_provider_request``
+fires for the inner agent's call too — minting a duplicate chat span
+under the parent's turn. These tests pin that the gate routes each
+listener only to the run that owns the calling asyncio task.
+
+The harness mirrors ``test_recorder.py``: a real ``Agent`` + ``Tracer``
++ in-memory exporter, driven through ``agent.prompt`` against a
+``FauxProvider`` whose queued responses are consumed FIFO across BOTH
+agents in cross-agent call order.
+"""
+
+from __future__ import annotations
+
+from asyncio import CancelledError
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from pydantic import BaseModel
+
+from cubepi.agent.agent import Agent
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import Model, TextContent, ToolCall
+from cubepi.providers.faux import FauxProvider, faux_assistant_message
+from cubepi.tracing import Tracer
+
+
+MODEL = Model(id="faux-1", provider="faux")
+
+
+class InMemoryExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans):  # noqa: ANN001
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+class _Empty(BaseModel):
+    pass
+
+
+def _make_agent(provider: FauxProvider, tools: list[AgentTool] | None) -> Agent:
+    return Agent(
+        provider=provider,
+        model=MODEL,
+        system_prompt="test prompt",
+        tools=tools,
+    )
+
+
+async def test_shared_provider_does_not_double_mint_inner_chat():
+    provider = FauxProvider()
+    exporter = InMemoryExporter()
+    tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+
+    # Cross-agent CALL order: parent tool-call to `spawn`, inner-final,
+    # parent-final. Consumed FIFO across both agents.
+    provider.append_responses(
+        [
+            faux_assistant_message(
+                [ToolCall(id="tc1", name="spawn", arguments={})],
+                stop_reason="tool_use",
+            ),
+            faux_assistant_message("inner-final"),
+            faux_assistant_message("parent-final"),
+        ]
+    )
+
+    async def _spawn(tool_call_id, args, *, signal=None, on_update=None):
+        inner = _make_agent(provider, tools=[])
+        detach = tracer.attach(inner)
+        try:
+            await inner.prompt("inner task")
+            await inner.wait_for_idle()
+        finally:
+            res = detach()
+            if res is not None:
+                await res
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    spawn = AgentTool(
+        name="spawn", description="spawn inner", parameters=_Empty, execute=_spawn
+    )
+    parent = _make_agent(provider, tools=[spawn])
+    detach_parent = tracer.attach(parent)
+    try:
+        await parent.prompt("go")
+        await parent.wait_for_idle()
+    finally:
+        res = detach_parent()
+        if res is not None:
+            await res
+    await tracer.shutdown()
+
+    chat_spans = [
+        s
+        for s in exporter.spans
+        if (s.attributes or {}).get("gen_ai.operation.name") == "chat"
+    ]
+    assert len(chat_spans) == 3, f"expected 3 chat spans, got {len(chat_spans)}"
+
+
+async def test_cancelled_inner_does_not_gate_parents_next_turn():
+    provider = FauxProvider()
+    exporter = InMemoryExporter()
+    tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+
+    def _raise_cancelled(messages, model, system_prompt, tools):
+        raise CancelledError()
+
+    # parent tool-call, inner provider call raises CancelledError, parent-final.
+    provider.append_responses(
+        [
+            faux_assistant_message(
+                [ToolCall(id="tc1", name="spawn", arguments={})],
+                stop_reason="tool_use",
+            ),
+            _raise_cancelled,
+            faux_assistant_message("parent-final"),
+        ]
+    )
+
+    async def _spawn(tool_call_id, args, *, signal=None, on_update=None):
+        inner = _make_agent(provider, tools=[])
+        detach = tracer.attach(inner)
+        try:
+            await inner.prompt("inner task")
+            await inner.wait_for_idle()
+        except CancelledError:
+            pass
+        finally:
+            res = detach()
+            if res is not None:
+                await res
+        return AgentToolResult(
+            content=[TextContent(text="[cancelled]")], is_error=True
+        )
+
+    # Sequential mode so the inner run shares the parent/loop task.
+    spawn = AgentTool(
+        name="spawn",
+        description="spawn inner",
+        parameters=_Empty,
+        execute=_spawn,
+        execution_mode="sequential",
+    )
+    parent = _make_agent(provider, tools=[spawn])
+    detach_parent = tracer.attach(parent)
+    try:
+        await parent.prompt("go")
+        await parent.wait_for_idle()
+    finally:
+        res = detach_parent()
+        if res is not None:
+            await res
+    await tracer.shutdown()
+
+    # Identify the parent run unambiguously via the execute_tool span's run_id.
+    tool_span = next(s for s in exporter.spans if s.name == "execute_tool spawn")
+    parent_run_id = (tool_span.attributes or {}).get("cubepi.run_id")
+    parent_chats = [
+        s
+        for s in exporter.spans
+        if (s.attributes or {}).get("gen_ai.operation.name") == "chat"
+        and (s.attributes or {}).get("cubepi.run_id") == parent_run_id
+    ]
+    assert len(parent_chats) == 2, (
+        f"expected 2 parent-run chat spans, got {len(parent_chats)}"
+    )

--- a/tests/tracing/test_subagent_nesting.py
+++ b/tests/tracing/test_subagent_nesting.py
@@ -330,3 +330,36 @@ async def test_full_nested_subtree_via_real_tool():
     assert inner_tool_spans, (
         "inner execute_tool span missing or not nested under the inner run"
     )
+
+
+async def test_provider_chunk_and_response_gated_when_run_not_active():
+    """White-box: the active-run gate in ``_on_provider_chunk`` /
+    ``_on_provider_response`` early-returns when a DIFFERENT run owns the task,
+    even if this recorder's run still has an open chat_span. Defensive backstop
+    beyond the ``chat_span is None`` guard (a non-owning recorder normally never
+    opens a chat_span at all)."""
+    from cubepi.tracing import recorder as rec
+
+    exporter = InMemoryExporter()
+    tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+    r = rec.Recorder(tracer)
+    run = rec._RunState(
+        run_id="r1", agent_span=tracer.otel_tracer.start_span("invoke_agent")
+    )
+    run.chat_span = tracer.otel_tracer.start_span("chat faux-1")
+    r._run = run
+
+    class _Chunk:
+        type = "text_delta"
+
+    token = rec._active_run.set(object())  # a different run owns this task
+    try:
+        r._on_provider_chunk(_Chunk(), MODEL)
+        r._on_provider_response({}, MODEL, None)
+    finally:
+        rec._active_run.reset(token)
+
+    # Gate held: first-chunk timing not recorded and the chat_span was not
+    # closed by this non-owning recorder.
+    assert run.chat_first_chunk_recorded is False
+    assert run.chat_span is not None


### PR DESCRIPTION
## Summary
Subagent runs were mis-traced: the inner agent's `chat` spans were flattened under the **parent** turn and its tool spans were missing, because (1) a provider shared by parent + inner agent fired the parent recorder's listeners for the inner call, and (2) the inner run started a fresh root instead of nesting under the spawning `execute_tool` span. This makes a subagent's whole run nest correctly under the `execute_tool` node.

- **Per-task active-run gate** (`recorder.py`): each recorder marks its run active in the current asyncio task; provider listeners (`chat` spans) act only for the run that owns the task, so a shared provider no longer double-mints an inner subagent's chat span. Reset on `AgentEnd` **and** `_close_open_spans` (covers cancelled runs that skip `AgentEndEvent`).
- **Nest the inner root** (`recorder._on_agent_start`): when `invoke_agent` opens while an `execute_tool` span is active for the task, parent it under that tool span (inherits `trace_id`, sets `parent_span_id`) instead of starting a new root.
- **Shard JSONL by `trace_id`, not `run_id`** (`exporters/jsonl.py` + trace-cli): a nested subagent run has its own `run_id` but inherits the parent's `trace_id`; sharding by `run_id` put its spans in a separate file so `trace view` rendered the subagent node childless. Now one file per trace (parent + nested subagents together) and the trace-cli is trace-keyed. **No backward-compat for old `run_id`-named files.** OTLP is unaffected (backends assemble by `trace_id`).

The matching cubebox change (attach the Tracer to the inner agent) is a separate PR; the span_id `trace view` label change is #121.

## Test plan
- [x] `tests/tracing/test_subagent_nesting.py`: shared-provider no-double-mint (3 chat spans), cancellation gate-release, full nested subtree via a real tool (inner `execute_tool` descends from the inner root).
- [x] `tests/tracing/test_jsonl_exporter.py`: two spans same `trace_id` / different `run_id` → one file named by `trace_id`.
- [x] `tests/cli/trace/`: trace-keyed loader/ls/render; `_run_prompt` prefers the root invoke_agent.
- [x] Full `tests/tracing/ tests/cli/` suite green (191).

Design ref: `dev/specs/2026-05-18-cubepi-tracing-design.md` §6.1 / §8 (nested agents); plan in `dev/plans/2026-05-27-subagent-trace-nesting.md`.