### PR TITLE
feat(tracing): stream recording + trace convert CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,19 @@ async with (
 Span tree per run:
 
 ```
-invoke_agent <agent_name>              [INTERNAL]
-└── cubepi.turn                        [INTERNAL]
-    ├── chat <model>                   [CLIENT]   ← the LLM call itself
-    └── execute_tool <tool_name>       [INTERNAL] ← each tool invocation
-        └── tools/call <tool_name>     [CLIENT]   ← MCP-backed tools only
+trace
+└── invoke_agent  14425.8ms  [0x1cd97cdb]         ← one per agent.prompt()
+    ├── cubepi.turn  1283.1ms  [0x5cfda93e]        ← one per LLM round-trip
+    │   ├── chat deepseek-v4-flash  1208.7ms  tok 6845/68  [0x0d130229]
+    │   └── execute_tool subagent  9610.2ms  subagent  [0x38bdd10a]
+    │       └── invoke_agent  9601.0ms  [0x8094f99b]   ← subagent run, nested
+    │           └── cubepi.turn  9598.4ms  [0x57c5cfc7]
+    │               ├── chat deepseek-v4-flash  1190.3ms  [0x8205ca6b]
+    │               └── execute_tool web_search  6500.2ms  web_search  [0xca4e59fc]
+    └── cubepi.turn  491.9ms  ERROR  [0xce25f242]
+        └── chat deepseek-v4-flash  427.2ms  ERROR  [0x0bff68ec]
+            └── error: Error code: 400 - ... `tool_use` ids were found without
+                `tool_result` blocks immediately after: call_01_...
 ```
 
 No prompts / model outputs are recorded by default. Opt in with

--- a/cubepi/cli/trace/commands.py
+++ b/cubepi/cli/trace/commands.py
@@ -48,6 +48,34 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
     )
     p_follow.set_defaults(handler=cmd_follow)
 
+    from cubepi.cli.trace.convert import cmd_convert
+
+    p_convert = trace_sub.add_parser(
+        "convert", help="reconstruct API request body from a recorded chat span"
+    )
+    p_convert.add_argument("run", help="trace id or path to a .jsonl file")
+    _add_dir(p_convert)
+    p_convert.add_argument(
+        "--turn",
+        type=int,
+        default=None,
+        metavar="N",
+        help="select the N-th chat span (1-indexed); default: last",
+    )
+    p_convert.add_argument(
+        "--span",
+        default=None,
+        metavar="SPAN_ID",
+        help="select span by id prefix",
+    )
+    p_convert.add_argument(
+        "--format",
+        choices=("openai", "anthropic", "curl"),
+        default="openai",
+        help="output format (default: openai)",
+    )
+    p_convert.set_defaults(handler=cmd_convert)
+
     p_stats = trace_sub.add_parser("stats", help="aggregate stats across runs")
     p_stats.add_argument("runs", nargs="*", help="trace ids (default: whole dir)")
     _add_dir(p_stats)

--- a/cubepi/cli/trace/convert.py
+++ b/cubepi/cli/trace/convert.py
@@ -1,0 +1,305 @@
+"""cubepi trace convert — reconstruct an API request body from a recorded chat span."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from cubepi.cli.trace import loader
+from cubepi.tracing import schema
+
+
+def cmd_convert(args: argparse.Namespace) -> int:
+    directory = Path(args.dir)
+    try:
+        files = loader.resolve_run(args.run, directory)
+    except loader.RunResolutionError as exc:
+        print(str(exc))
+        return 1
+
+    spans, _skipped = loader.load_run(files)
+    chat_spans = [s for s in spans if s.is_chat]
+    if not chat_spans:
+        print("no chat spans found — was record_content=True when tracing?")
+        return 1
+
+    target = None
+    if args.span:
+        prefix = args.span
+        matches = [s for s in chat_spans if (s.span_id or "").startswith(prefix)]
+        if not matches:
+            print(f"no chat span with id prefix {prefix!r}")
+            return 1
+        if len(matches) > 1:
+            ids = ", ".join(s.span_id or "" for s in matches)
+            print(f"ambiguous span prefix {prefix!r}: {ids}")
+            return 1
+        target = matches[0]
+    elif args.turn is not None:
+        idx = args.turn - 1
+        if idx < 0 or idx >= len(chat_spans):
+            print(f"--turn {args.turn} out of range (1..{len(chat_spans)})")
+            return 1
+        target = chat_spans[idx]
+    else:
+        target = chat_spans[-1]
+
+    attrs = target.attributes
+    model_id = str(attrs.get(schema.GEN_AI_REQUEST_MODEL, ""))
+    max_tokens = attrs.get(schema.GEN_AI_REQUEST_MAX_TOKENS)
+    temperature = attrs.get(schema.GEN_AI_REQUEST_TEMPERATURE)
+
+    msgs: list[dict[str, Any]] = _parse_json_attr(
+        attrs.get(schema.GEN_AI_INPUT_MESSAGES)
+    )
+    sys_instructions: list[dict[str, Any]] = _parse_json_attr(
+        attrs.get(schema.GEN_AI_SYSTEM_INSTRUCTIONS)
+    )
+    tool_defs: list[dict[str, Any]] = _parse_json_attr(
+        attrs.get(schema.GEN_AI_TOOL_DEFINITIONS)
+    )
+
+    fmt = args.format
+    if fmt == "anthropic":
+        body = _build_anthropic(model_id, msgs, sys_instructions, tool_defs, max_tokens)
+        print(json.dumps(body, indent=2, ensure_ascii=False))
+    elif fmt == "curl":
+        print(
+            _build_curl(
+                model_id, msgs, sys_instructions, tool_defs, max_tokens, temperature
+            )
+        )
+    else:
+        body = _build_openai(
+            model_id, msgs, sys_instructions, tool_defs, max_tokens, temperature
+        )
+        print(json.dumps(body, indent=2, ensure_ascii=False))
+    return 0
+
+
+def _parse_json_attr(raw: Any) -> list[dict[str, Any]]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [x for x in raw if isinstance(x, dict)]
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [x for x in parsed if isinstance(x, dict)]
+        except (json.JSONDecodeError, TypeError):
+            pass
+    return []
+
+
+def _system_text(instructions: list[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    for block in instructions:
+        role = block.get("role", "")
+        if role == "system":
+            for part in block.get("parts", []) or []:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text = part.get("content") or part.get("text") or ""
+                    if text:
+                        parts.append(str(text))
+    return "\n\n".join(parts)
+
+
+def messages_to_openai(msgs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for msg in msgs:
+        role = msg.get("role", "")
+        parts = msg.get("parts") or []
+        if role == "user":
+            texts = [
+                str(p.get("content") or p.get("text") or "")
+                for p in parts
+                if isinstance(p, dict) and p.get("type") == "text"
+            ]
+            out.append({"role": "user", "content": " ".join(t for t in texts if t)})
+        elif role == "assistant":
+            tool_calls: list[dict[str, Any]] = []
+            text_parts: list[str] = []
+            for p in parts:
+                if not isinstance(p, dict):
+                    continue
+                if p.get("type") == "tool_call":
+                    args = p.get("arguments", {})
+                    tool_calls.append(
+                        {
+                            "id": str(p.get("id", "")),
+                            "type": "function",
+                            "function": {
+                                "name": str(p.get("name", "")),
+                                "arguments": (
+                                    json.dumps(args)
+                                    if isinstance(args, dict)
+                                    else str(args)
+                                ),
+                            },
+                        }
+                    )
+                elif p.get("type") == "text":
+                    t = str(p.get("content") or p.get("text") or "")
+                    if t:
+                        text_parts.append(t)
+            entry: dict[str, Any] = {
+                "role": "assistant",
+                "content": " ".join(text_parts) if text_parts else None,
+            }
+            if tool_calls:
+                entry["tool_calls"] = tool_calls
+            out.append(entry)
+        elif role == "tool":
+            for p in parts:
+                if isinstance(p, dict) and p.get("type") == "tool_call_response":
+                    out.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": str(p.get("id", "")),
+                            "content": str(p.get("result", "")),
+                        }
+                    )
+    return out
+
+
+def messages_to_anthropic(msgs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    pending_tool_results: list[dict[str, Any]] = []
+    for msg in msgs:
+        role = msg.get("role", "")
+        parts = msg.get("parts") or []
+        if role == "tool":
+            for p in parts:
+                if isinstance(p, dict) and p.get("type") == "tool_call_response":
+                    pending_tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": str(p.get("id", "")),
+                            "content": str(p.get("result", "")),
+                        }
+                    )
+        elif role == "user":
+            if pending_tool_results:
+                out.append({"role": "user", "content": list(pending_tool_results)})
+                pending_tool_results = []
+            content_blocks: list[dict[str, Any]] = []
+            for p in parts:
+                if not isinstance(p, dict):
+                    continue
+                if p.get("type") == "text":
+                    text = str(p.get("content") or p.get("text") or "")
+                    if text:
+                        content_blocks.append({"type": "text", "text": text})
+            if content_blocks:
+                out.append({"role": "user", "content": content_blocks})
+        elif role == "assistant":
+            if pending_tool_results:
+                out.append({"role": "user", "content": list(pending_tool_results)})
+                pending_tool_results = []
+            content_blocks = []
+            for p in parts:
+                if not isinstance(p, dict):
+                    continue
+                if p.get("type") == "text":
+                    text = str(p.get("content") or p.get("text") or "")
+                    if text:
+                        content_blocks.append({"type": "text", "text": text})
+                elif p.get("type") == "tool_call":
+                    args = p.get("arguments", {})
+                    content_blocks.append(
+                        {
+                            "type": "tool_use",
+                            "id": str(p.get("id", "")),
+                            "name": str(p.get("name", "")),
+                            "input": args if isinstance(args, dict) else {},
+                        }
+                    )
+            if content_blocks:
+                out.append({"role": "assistant", "content": content_blocks})
+    if pending_tool_results:
+        out.append({"role": "user", "content": pending_tool_results})
+    return out
+
+
+def _build_openai(
+    model_id: str,
+    msgs: list[dict[str, Any]],
+    sys_instructions: list[dict[str, Any]],
+    tool_defs: list[dict[str, Any]],
+    max_tokens: Any,
+    temperature: Any,
+) -> dict[str, Any]:
+    openai_msgs: list[dict[str, Any]] = []
+    sys_text = _system_text(sys_instructions)
+    if sys_text:
+        openai_msgs.append({"role": "system", "content": sys_text})
+    openai_msgs.extend(messages_to_openai(msgs))
+    body: dict[str, Any] = {"model": model_id, "messages": openai_msgs, "stream": True}
+    if max_tokens is not None:
+        body["max_tokens"] = int(max_tokens)
+    if temperature is not None:
+        body["temperature"] = float(temperature)
+    if tool_defs:
+        body["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": str(t.get("name", "")),
+                    "description": str(t.get("description", "")),
+                    "parameters": t.get("parameters") or {},
+                },
+            }
+            for t in tool_defs
+        ]
+    return body
+
+
+def _build_anthropic(
+    model_id: str,
+    msgs: list[dict[str, Any]],
+    sys_instructions: list[dict[str, Any]],
+    tool_defs: list[dict[str, Any]],
+    max_tokens: Any,
+) -> dict[str, Any]:
+    sys_text = _system_text(sys_instructions)
+    body: dict[str, Any] = {
+        "model": model_id,
+        "messages": messages_to_anthropic(msgs),
+        "max_tokens": int(max_tokens) if max_tokens is not None else 4096,
+    }
+    if sys_text:
+        body["system"] = sys_text
+    if tool_defs:
+        body["tools"] = [
+            {
+                "name": str(t.get("name", "")),
+                "description": str(t.get("description", "")),
+                "input_schema": t.get("parameters") or {},
+            }
+            for t in tool_defs
+        ]
+    return body
+
+
+def _build_curl(
+    model_id: str,
+    msgs: list[dict[str, Any]],
+    sys_instructions: list[dict[str, Any]],
+    tool_defs: list[dict[str, Any]],
+    max_tokens: Any,
+    temperature: Any,
+) -> str:
+    body = _build_openai(
+        model_id, msgs, sys_instructions, tool_defs, max_tokens, temperature
+    )
+    body_json = json.dumps(body, ensure_ascii=False)
+    escaped = body_json.replace("'", "'\"'\"'")
+    return (
+        'curl -s -X POST "${BASE_URL}/v1/chat/completions" \\\n'
+        '  -H "Authorization: Bearer ${API_KEY}" \\\n'
+        '  -H "Content-Type: application/json" \\\n'
+        f"  -d '{escaped}'"
+    )

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -670,6 +670,9 @@ class Recorder:
         run.turn_terminated_by_tool = False
         run.turn_input_messages = []
         run.turn_output_messages = []
+        # Reset per-turn stream-recording state so a partially-streamed tool
+        # call in a prior turn cannot inflate accumulated counts in this turn.
+        run.stream_tool_accumulated.clear()
 
     def _on_turn_end(self, event: TurnEndEvent) -> None:
         run = self._run

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 
 import contextvars
 import hashlib
+import json
 import time
 import traceback
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable
+from pathlib import Path
+from typing import IO, TYPE_CHECKING, Any, Callable
 
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind, Status, StatusCode
@@ -41,6 +43,7 @@ from cubepi.agent.types import (
 )
 from cubepi.providers.base import (
     StreamEvent,
+    ToolCall,
     ToolResultMessage,
     UserMessage,
 )
@@ -173,6 +176,10 @@ class _RunState:
     turn_output_messages: list[Any] = field(default_factory=list)
     # Chat-span specific tool_definitions captured at request time.
     chat_tool_definitions: list[dict] | None = None
+    # Stream recording (only used when record_stream=True).
+    stream_file: IO[str] | None = None
+    stream_start_time: float | None = None
+    stream_tool_accumulated: dict[int, int] = field(default_factory=dict)
 
 
 class Recorder:
@@ -188,10 +195,14 @@ class Recorder:
         tracer: "Tracer",
         *,
         record_content: bool = False,
+        record_stream: bool = False,
+        stream_dir: "Path | None" = None,
         redact: "Callable[[str, Any], Any] | None" = None,
     ) -> None:
         self._tracer = tracer
         self._record_content = record_content
+        self._record_stream = record_stream
+        self._stream_dir = stream_dir
         self._redact = redact
         # Active run state. cubepi agents serialize runs (one
         # ``agent.run()`` at a time per Agent), so a single slot is
@@ -451,6 +462,13 @@ class Recorder:
             except Exception:
                 pass
             # Don't null agent_span — _RunState gets dropped wholesale.
+        # Close stream file on cancellation — normal end is handled in _on_agent_end.
+        if run.stream_file is not None:
+            try:
+                run.stream_file.close()
+            except Exception:
+                pass
+            run.stream_file = None
         # Release the per-task active-run gate. A cancelled run never
         # reaches _on_agent_end, so the only reset opportunity is here
         # (detach always calls _close_open_spans). Without this a stale
@@ -502,6 +520,15 @@ class Recorder:
         # Resource carries gen_ai.agent.name at process level — agents
         # that vary per-run set their own value via _ensure_agent_name.
         self._run = _RunState(run_id=run_id, agent_span=span)
+        # Open stream file when record_stream is enabled.
+        if self._record_stream and self._stream_dir is not None:
+            try:
+                self._stream_dir.mkdir(parents=True, exist_ok=True)
+                stream_path = self._stream_dir / f"{run_id}.stream.jsonl"
+                self._run.stream_file = stream_path.open("w", encoding="utf-8")
+                self._run.stream_start_time = time.time()
+            except Exception:
+                pass
         # Claim the per-task active-run gate for this run so this
         # recorder's provider listeners act only for LLM calls made on
         # the task that owns this run (not for an inner subagent sharing
@@ -609,6 +636,12 @@ class Recorder:
         # ``_sweep_tool_span_tokens`` docstring.
         self._sweep_tool_span_tokens(run)
         run.agent_span.end()
+        if run.stream_file is not None:
+            try:
+                run.stream_file.close()
+            except Exception:
+                pass
+            run.stream_file = None
         self._reset_active_run()
         self._run = None
 
@@ -939,20 +972,88 @@ class Recorder:
     def _on_provider_chunk(self, event: StreamEvent, model: "Model") -> None:
         del model
         run = self._run
-        if run is None or run.chat_span is None or run.chat_first_chunk_recorded:
+        if run is None:
             return
         if _active_run.get() is not run:
             return
-        # Only count "content" chunks for time-to-first-chunk (not 'start').
-        if event.type in (
-            "text_delta",
-            "thinking_delta",
-            "toolcall_delta",
+        # TTFT: record once per chat span for the first content chunk.
+        if (
+            run.chat_span is not None
+            and not run.chat_first_chunk_recorded
+            and event.type in ("text_delta", "thinking_delta", "toolcall_delta")
         ):
             opened = run.chat_open_ns or time.time_ns()
             ttft_s = (time.time_ns() - opened) / 1e9
             run.chat_span.set_attribute(GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK, ttft_s)
             run.chat_first_chunk_recorded = True
+        # Stream recording: write every semantically interesting event.
+        if self._record_stream and run.stream_file is not None:
+            self._write_stream_event(run, event)
+
+    def _write_stream_event(self, run: "_RunState", event: StreamEvent) -> None:
+        if event.type in (
+            "start",
+            "text_start",
+            "text_end",
+            "thinking_start",
+            "thinking_end",
+            "done",
+        ):
+            return
+        elapsed = round(time.time() - (run.stream_start_time or time.time()), 3)
+        rec: dict[str, Any] = {"t": elapsed, "type": event.type}
+        ci = event.content_index if event.content_index is not None else 0
+
+        if event.type == "toolcall_start":
+            id_, name = "", ""
+            if event.partial is not None and ci < len(event.partial.content):
+                block = event.partial.content[ci]
+                if isinstance(block, ToolCall):
+                    id_, name = block.id, block.name
+            rec.update({"ci": ci, "id": id_, "name": name})
+
+        elif event.type == "toolcall_delta":
+            delta = event.delta or ""
+            run.stream_tool_accumulated[ci] = run.stream_tool_accumulated.get(
+                ci, 0
+            ) + len(delta)
+            rec.update(
+                {
+                    "ci": ci,
+                    "chars": len(delta),
+                    "accumulated": run.stream_tool_accumulated[ci],
+                    "preview": delta[:60],
+                }
+            )
+
+        elif event.type == "toolcall_end":
+            id_, name, args_str = "", "", ""
+            if event.partial is not None and ci < len(event.partial.content):
+                block = event.partial.content[ci]
+                if isinstance(block, ToolCall):
+                    id_, name = block.id, block.name
+                    args_str = json.dumps(block.arguments)
+            total = run.stream_tool_accumulated.pop(ci, len(args_str))
+            rec.update(
+                {
+                    "ci": ci,
+                    "id": id_,
+                    "name": name,
+                    "args_chars": total,
+                    "args_preview": args_str[:80],
+                }
+            )
+
+        elif event.type in ("text_delta", "thinking_delta"):
+            rec["chars"] = len(event.delta or "")
+
+        elif event.type == "error":
+            rec["error_message"] = event.error_message or ""
+
+        try:
+            run.stream_file.write(json.dumps(rec) + "\n")  # type: ignore[union-attr]
+        except Exception:
+            pass
 
     def _on_provider_response(
         self,

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -12,6 +12,7 @@ import atexit
 import contextlib
 import logging
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, AsyncIterator, Callable
 
 from opentelemetry.sdk.resources import Resource
@@ -72,12 +73,18 @@ class Tracer:
         agent_version: str | None = None,
         exporters: list[SpanExporter] | None = None,
         record_content: bool = False,
+        record_stream: bool = False,
+        stream_dir: "str | Path | None" = None,
         redact: "Callable[[str, Any], Any] | None" = None,
         resource: Resource | None = None,
         atexit_flush: bool = True,
         atexit_flush_timeout_seconds: float = 5.0,
     ) -> None:
         self._record_content = record_content
+        self._record_stream = record_stream
+        self._stream_dir = (
+            Path(stream_dir) if isinstance(stream_dir, str) else stream_dir
+        )
         self._redact = redact
         self._resource = resource or _build_resource(
             service_name=service_name,
@@ -177,6 +184,8 @@ class Tracer:
         recorder = Recorder(
             self,
             record_content=self._record_content,
+            record_stream=self._record_stream,
+            stream_dir=self._stream_dir,
             redact=self._redact,
         )
         recorder_detach = recorder.attach(agent)

--- a/skills/cubepi-trace/SKILL.md
+++ b/skills/cubepi-trace/SKILL.md
@@ -120,6 +120,56 @@ uv run cubepi trace stats --by model --meta user_id=usr_9
 uv run cubepi trace ls --show-meta conversation_id,user_id
 ```
 
+## Replaying a failing LLM call (`trace convert`)
+
+When the span tree + content aren't enough and you need to replay the exact API
+call — same messages, same tools, same parameters — use `trace convert` to
+reconstruct the request body from a recorded `chat` span (requires
+`record_content=True`):
+
+```bash
+# Reconstruct the last LLM call as an OpenAI JSON body
+uv run cubepi trace convert <run_id>
+
+# Pick a specific call by span_id prefix (copy [0x…] from `view`)
+uv run cubepi trace convert <run_id> --span 0xbb7eb1
+
+# Shell-executable curl (uses $BASE_URL / $API_KEY env vars)
+uv run cubepi trace convert <run_id> --span 0xbb7eb1 --format curl
+
+# Anthropic Messages API shape
+uv run cubepi trace convert <run_id> --format anthropic
+```
+
+The `[0x…]` suffix from each `chat` node in `view` output is the span_id — paste
+it directly as `--span 0x<prefix>`. No need to count turns.
+
+## Debugging streaming failures (`record_stream`)
+
+For issues where the span tree doesn't show the problem — missing tool call
+arguments, duplicate tool executions, truncated output — enable stream recording
+in the tracer:
+
+```python
+Tracer(record_content=True, record_stream=True, stream_dir="./cubepi-traces", …)
+```
+
+This writes `<stream_dir>/<run_id>.stream.jsonl` — one JSON line per raw
+`StreamEvent`. Check the file after a failing run:
+
+```bash
+# See all toolcall events for a run
+grep '"type": "toolcall' cubepi-traces/<date>/<run_id>.stream.jsonl | python -m json.tool
+
+# Check for duplicate toolcall_end (double finish_reason bug pattern):
+grep '"toolcall_end"' cubepi-traces/<date>/<run_id>.stream.jsonl | wc -l   # expect 1
+```
+
+Key fields: `t` (elapsed seconds), `type`, `ci` (content index), `accumulated`
+(running arg chars), `args_chars` (final count at end). An `args_chars: 0` at
+`toolcall_end` means no argument chunks ever arrived — the model sent an empty
+tool call.
+
 If the CLI view still isn't enough, the files are plain JSONL — one span per
 line — so you can parse them directly (e.g. with `python -c`/`jq`) to pull a
 specific attribute. Useful attribute keys:

--- a/tests/cli/trace/test_convert.py
+++ b/tests/cli/trace/test_convert.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from cubepi.cli.__main__ import main
 
 
@@ -315,7 +313,7 @@ class TestConvertSpanSelection:
         rc = main(
             ["trace", "convert", "run1", "--dir", str(tmp_path), "--span", "0xzzz"]
         )
-        err = capsys.readouterr()
+        capsys.readouterr()
         assert rc == 1
 
     def test_turn_1_selects_first_chat_span(self, tmp_path, capsys):

--- a/tests/cli/trace/test_convert.py
+++ b/tests/cli/trace/test_convert.py
@@ -204,7 +204,15 @@ class TestConvertAnthropicFormat:
     def test_anthropic_format_valid_json(self, tmp_path, capsys):
         _write_trace(tmp_path)
         rc = main(
-            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+            [
+                "trace",
+                "convert",
+                "run1",
+                "--dir",
+                str(tmp_path),
+                "--format",
+                "anthropic",
+            ]
         )
         out = capsys.readouterr().out
         assert rc == 0
@@ -215,7 +223,15 @@ class TestConvertAnthropicFormat:
     def test_anthropic_system_at_top_level(self, tmp_path, capsys):
         _write_trace(tmp_path)
         main(
-            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+            [
+                "trace",
+                "convert",
+                "run1",
+                "--dir",
+                str(tmp_path),
+                "--format",
+                "anthropic",
+            ]
         )
         out = capsys.readouterr().out
         body = json.loads(out)
@@ -225,7 +241,15 @@ class TestConvertAnthropicFormat:
     def test_anthropic_tool_use_blocks(self, tmp_path, capsys):
         _write_trace(tmp_path)
         main(
-            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+            [
+                "trace",
+                "convert",
+                "run1",
+                "--dir",
+                str(tmp_path),
+                "--format",
+                "anthropic",
+            ]
         )
         out = capsys.readouterr().out
         body = json.loads(out)
@@ -242,7 +266,15 @@ class TestConvertAnthropicFormat:
     def test_anthropic_tool_result_as_user_message(self, tmp_path, capsys):
         _write_trace(tmp_path)
         main(
-            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+            [
+                "trace",
+                "convert",
+                "run1",
+                "--dir",
+                str(tmp_path),
+                "--format",
+                "anthropic",
+            ]
         )
         out = capsys.readouterr().out
         body = json.loads(out)
@@ -258,7 +290,15 @@ class TestConvertAnthropicFormat:
     def test_anthropic_tools_use_input_schema(self, tmp_path, capsys):
         _write_trace(tmp_path)
         main(
-            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+            [
+                "trace",
+                "convert",
+                "run1",
+                "--dir",
+                str(tmp_path),
+                "--format",
+                "anthropic",
+            ]
         )
         out = capsys.readouterr().out
         body = json.loads(out)
@@ -318,9 +358,7 @@ class TestConvertSpanSelection:
 
     def test_turn_1_selects_first_chat_span(self, tmp_path, capsys):
         _write_trace(tmp_path, two_turns=True)
-        rc = main(
-            ["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "1"]
-        )
+        rc = main(["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "1"])
         out = capsys.readouterr().out
         assert rc == 0
         body = json.loads(out)
@@ -328,9 +366,7 @@ class TestConvertSpanSelection:
 
     def test_turn_2_selects_second_chat_span(self, tmp_path, capsys):
         _write_trace(tmp_path, two_turns=True)
-        rc = main(
-            ["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "2"]
-        )
+        rc = main(["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "2"])
         out = capsys.readouterr().out
         assert rc == 0
         body = json.loads(out)
@@ -338,9 +374,7 @@ class TestConvertSpanSelection:
 
     def test_turn_out_of_range_returns_1(self, tmp_path, capsys):
         _write_trace(tmp_path)
-        rc = main(
-            ["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "99"]
-        )
+        rc = main(["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "99"])
         capsys.readouterr()
         assert rc == 1
 
@@ -390,9 +424,7 @@ class TestMessagesToOpenAI:
     def test_assistant_text(self):
         from cubepi.cli.trace.convert import messages_to_openai
 
-        msgs = [
-            {"role": "assistant", "parts": [{"type": "text", "content": "hello"}]}
-        ]
+        msgs = [{"role": "assistant", "parts": [{"type": "text", "content": "hello"}]}]
         out = messages_to_openai(msgs)
         assert len(out) == 1
         assert out[0]["role"] == "assistant"
@@ -464,7 +496,11 @@ class TestMessagesToAnthropic:
         # tool result should be flushed into a user message before the text user msg
         user_msgs = [m for m in out if m["role"] == "user"]
         all_content = [b for m in user_msgs for b in (m.get("content") or [])]
-        tool_results = [b for b in all_content if isinstance(b, dict) and b.get("type") == "tool_result"]
+        tool_results = [
+            b
+            for b in all_content
+            if isinstance(b, dict) and b.get("type") == "tool_result"
+        ]
         assert tool_results
 
     def test_assistant_tool_use_block(self):

--- a/tests/cli/trace/test_convert.py
+++ b/tests/cli/trace/test_convert.py
@@ -1,0 +1,505 @@
+"""Tests for `cubepi trace convert` — reconstruct API request bodies from recorded spans."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cubepi.cli.__main__ import main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MESSAGES = json.dumps(
+    [
+        {"role": "user", "parts": [{"type": "text", "content": "hello"}]},
+        {
+            "role": "assistant",
+            "parts": [
+                {"type": "text", "content": "hi there"},
+                {
+                    "type": "tool_call",
+                    "id": "call_1",
+                    "name": "search",
+                    "arguments": {"q": "weather"},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "parts": [
+                {
+                    "type": "tool_call_response",
+                    "id": "call_1",
+                    "result": "sunny",
+                }
+            ],
+        },
+        {"role": "user", "parts": [{"type": "text", "content": "thanks"}]},
+    ]
+)
+
+_SYSTEM = json.dumps(
+    [{"role": "system", "parts": [{"type": "text", "content": "be helpful"}]}]
+)
+
+_TOOLS = json.dumps(
+    [
+        {
+            "name": "search",
+            "description": "search the web",
+            "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+        }
+    ]
+)
+
+
+def _write_trace(directory: Path, *, two_turns: bool = False) -> None:
+    f = directory / "2026-05-20" / "run1.jsonl"
+    f.parent.mkdir(parents=True)
+    rows = [
+        {
+            "name": "invoke_agent",
+            "context": {"trace_id": "0xt", "span_id": "0x1"},
+            "parent_id": None,
+            "start_time": "2026-05-20T00:00:00Z",
+            "end_time": "2026-05-20T00:00:10Z",
+            "status": {"status_code": "UNSET"},
+            "attributes": {
+                "cubepi.run_id": "run1",
+                "gen_ai.operation.name": "invoke_agent",
+            },
+        },
+        {
+            "name": "chat gpt-test",
+            "context": {"trace_id": "0xt", "span_id": "0xabc123"},
+            "parent_id": "0x1",
+            "start_time": "2026-05-20T00:00:01Z",
+            "end_time": "2026-05-20T00:00:05Z",
+            "status": {"status_code": "UNSET"},
+            "attributes": {
+                "cubepi.run_id": "run1",
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-test",
+                "gen_ai.request.max_tokens": 4096,
+                "gen_ai.request.temperature": 0.7,
+                "gen_ai.input.messages": _MESSAGES,
+                "gen_ai.system_instructions": _SYSTEM,
+                "gen_ai.tool.definitions": _TOOLS,
+            },
+        },
+    ]
+    if two_turns:
+        rows.append(
+            {
+                "name": "chat gpt-test",
+                "context": {"trace_id": "0xt", "span_id": "0xdef456"},
+                "parent_id": "0x1",
+                "start_time": "2026-05-20T00:00:06Z",
+                "end_time": "2026-05-20T00:00:09Z",
+                "status": {"status_code": "UNSET"},
+                "attributes": {
+                    "cubepi.run_id": "run1",
+                    "gen_ai.operation.name": "chat",
+                    "gen_ai.request.model": "gpt-test",
+                    "gen_ai.input.messages": _MESSAGES,
+                },
+            }
+        )
+    with f.open("w") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+
+
+def _write_trace_no_content(directory: Path) -> None:
+    f = directory / "2026-05-20" / "run_nc.jsonl"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "name": "invoke_agent",
+            "context": {"trace_id": "0xt2", "span_id": "0x1"},
+            "parent_id": None,
+            "start_time": "2026-05-20T00:00:00Z",
+            "end_time": "2026-05-20T00:00:02Z",
+            "status": {"status_code": "UNSET"},
+            "attributes": {
+                "cubepi.run_id": "run_nc",
+                "gen_ai.operation.name": "invoke_agent",
+            },
+        },
+    ]
+    with f.open("w") as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Basic output: default (OpenAI) format
+# ---------------------------------------------------------------------------
+
+
+class TestConvertDefaultFormat:
+    def test_outputs_valid_json(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        rc = main(["trace", "convert", "run1", "--dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        body = json.loads(out)
+        assert body["model"] == "gpt-test"
+        assert body["stream"] is True
+
+    def test_includes_system_message(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(["trace", "convert", "run1", "--dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        system_msgs = [m for m in body["messages"] if m["role"] == "system"]
+        assert system_msgs
+        assert "be helpful" in system_msgs[0]["content"]
+
+    def test_includes_tools(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(["trace", "convert", "run1", "--dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        assert "tools" in body
+        assert body["tools"][0]["function"]["name"] == "search"
+
+    def test_max_tokens_and_temperature(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(["trace", "convert", "run1", "--dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        assert body["max_tokens"] == 4096
+        assert abs(body["temperature"] - 0.7) < 1e-6
+
+    def test_tool_call_in_assistant_message(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(["trace", "convert", "run1", "--dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        assistant_msgs = [m for m in body["messages"] if m["role"] == "assistant"]
+        assert assistant_msgs
+        tool_calls = assistant_msgs[0].get("tool_calls", [])
+        assert any(tc["function"]["name"] == "search" for tc in tool_calls)
+
+    def test_tool_result_message(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(["trace", "convert", "run1", "--dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        tool_msgs = [m for m in body["messages"] if m["role"] == "tool"]
+        assert tool_msgs
+        assert tool_msgs[0]["content"] == "sunny"
+
+
+# ---------------------------------------------------------------------------
+# Anthropic format
+# ---------------------------------------------------------------------------
+
+
+class TestConvertAnthropicFormat:
+    def test_anthropic_format_valid_json(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        rc = main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        body = json.loads(out)
+        assert body["model"] == "gpt-test"
+        assert "messages" in body
+
+    def test_anthropic_system_at_top_level(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+        )
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        assert "system" in body
+        assert "be helpful" in body["system"]
+
+    def test_anthropic_tool_use_blocks(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+        )
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        all_content = [
+            block
+            for msg in body["messages"]
+            for block in (msg.get("content") or [])
+            if isinstance(block, dict)
+        ]
+        tool_use = [b for b in all_content if b.get("type") == "tool_use"]
+        assert tool_use
+        assert tool_use[0]["name"] == "search"
+
+    def test_anthropic_tool_result_as_user_message(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+        )
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        tool_results = [
+            block
+            for msg in body["messages"]
+            if msg["role"] == "user"
+            for block in (msg.get("content") or [])
+            if isinstance(block, dict) and block.get("type") == "tool_result"
+        ]
+        assert tool_results
+
+    def test_anthropic_tools_use_input_schema(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "anthropic"]
+        )
+        out = capsys.readouterr().out
+        body = json.loads(out)
+        assert "tools" in body
+        assert "input_schema" in body["tools"][0]
+
+
+# ---------------------------------------------------------------------------
+# curl format
+# ---------------------------------------------------------------------------
+
+
+class TestConvertCurlFormat:
+    def test_curl_format_is_shell_command(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        rc = main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "curl"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "curl" in out
+        assert "Authorization" in out
+        assert "Content-Type" in out
+
+    def test_curl_contains_model(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        main(["trace", "convert", "run1", "--dir", str(tmp_path), "--format", "curl"])
+        out = capsys.readouterr().out
+        assert "gpt-test" in out
+
+
+# ---------------------------------------------------------------------------
+# Span / turn selection
+# ---------------------------------------------------------------------------
+
+
+class TestConvertSpanSelection:
+    def test_span_prefix_selects_correct_span(self, tmp_path, capsys):
+        _write_trace(tmp_path, two_turns=True)
+        # First chat span is 0xabc123; last is 0xdef456.
+        rc = main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--span", "0xabc"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        # First span has temperature; second does not.
+        body = json.loads(out)
+        assert "temperature" in body
+
+    def test_span_prefix_no_match_returns_1(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        rc = main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--span", "0xzzz"]
+        )
+        err = capsys.readouterr()
+        assert rc == 1
+
+    def test_turn_1_selects_first_chat_span(self, tmp_path, capsys):
+        _write_trace(tmp_path, two_turns=True)
+        rc = main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "1"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        body = json.loads(out)
+        assert "temperature" in body  # first span has temperature
+
+    def test_turn_2_selects_second_chat_span(self, tmp_path, capsys):
+        _write_trace(tmp_path, two_turns=True)
+        rc = main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "2"]
+        )
+        out = capsys.readouterr().out
+        assert rc == 0
+        body = json.loads(out)
+        assert "temperature" not in body  # second span has no temperature
+
+    def test_turn_out_of_range_returns_1(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        rc = main(
+            ["trace", "convert", "run1", "--dir", str(tmp_path), "--turn", "99"]
+        )
+        capsys.readouterr()
+        assert rc == 1
+
+    def test_default_selects_last_chat_span(self, tmp_path, capsys):
+        _write_trace(tmp_path, two_turns=True)
+        rc = main(["trace", "convert", "run1", "--dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        assert rc == 0
+        body = json.loads(out)
+        # Last span has no temperature attr → key absent
+        assert "temperature" not in body
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestConvertErrors:
+    def test_run_not_found_returns_1(self, tmp_path, capsys):
+        _write_trace(tmp_path)
+        rc = main(["trace", "convert", "missing", "--dir", str(tmp_path)])
+        capsys.readouterr()
+        assert rc == 1
+
+    def test_no_chat_spans_returns_1(self, tmp_path, capsys):
+        _write_trace_no_content(tmp_path)
+        rc = main(["trace", "convert", "run_nc", "--dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "no chat spans" in out
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for message-conversion helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMessagesToOpenAI:
+    def test_user_message(self):
+        from cubepi.cli.trace.convert import messages_to_openai
+
+        msgs = [{"role": "user", "parts": [{"type": "text", "content": "hi"}]}]
+        out = messages_to_openai(msgs)
+        assert out == [{"role": "user", "content": "hi"}]
+
+    def test_assistant_text(self):
+        from cubepi.cli.trace.convert import messages_to_openai
+
+        msgs = [
+            {"role": "assistant", "parts": [{"type": "text", "content": "hello"}]}
+        ]
+        out = messages_to_openai(msgs)
+        assert len(out) == 1
+        assert out[0]["role"] == "assistant"
+        assert out[0]["content"] == "hello"
+
+    def test_assistant_tool_call(self):
+        from cubepi.cli.trace.convert import messages_to_openai
+
+        msgs = [
+            {
+                "role": "assistant",
+                "parts": [
+                    {
+                        "type": "tool_call",
+                        "id": "c1",
+                        "name": "fn",
+                        "arguments": {"x": 1},
+                    }
+                ],
+            }
+        ]
+        out = messages_to_openai(msgs)
+        tcs = out[0]["tool_calls"]
+        assert tcs[0]["id"] == "c1"
+        assert tcs[0]["function"]["name"] == "fn"
+        parsed = json.loads(tcs[0]["function"]["arguments"])
+        assert parsed == {"x": 1}
+
+    def test_tool_result(self):
+        from cubepi.cli.trace.convert import messages_to_openai
+
+        msgs = [
+            {
+                "role": "tool",
+                "parts": [{"type": "tool_call_response", "id": "c1", "result": "ok"}],
+            }
+        ]
+        out = messages_to_openai(msgs)
+        assert out == [{"role": "tool", "tool_call_id": "c1", "content": "ok"}]
+
+    def test_unknown_role_skipped(self):
+        from cubepi.cli.trace.convert import messages_to_openai
+
+        msgs = [{"role": "system", "parts": [{"type": "text", "content": "x"}]}]
+        out = messages_to_openai(msgs)
+        assert out == []
+
+
+class TestMessagesToAnthropic:
+    def test_user_message(self):
+        from cubepi.cli.trace.convert import messages_to_anthropic
+
+        msgs = [{"role": "user", "parts": [{"type": "text", "content": "hi"}]}]
+        out = messages_to_anthropic(msgs)
+        assert out[0]["role"] == "user"
+        assert out[0]["content"][0]["text"] == "hi"
+
+    def test_tool_result_batched_into_user_message(self):
+        from cubepi.cli.trace.convert import messages_to_anthropic
+
+        msgs = [
+            {
+                "role": "tool",
+                "parts": [{"type": "tool_call_response", "id": "c1", "result": "x"}],
+            },
+            {"role": "user", "parts": [{"type": "text", "content": "follow-up"}]},
+        ]
+        out = messages_to_anthropic(msgs)
+        # tool result should be flushed into a user message before the text user msg
+        user_msgs = [m for m in out if m["role"] == "user"]
+        all_content = [b for m in user_msgs for b in (m.get("content") or [])]
+        tool_results = [b for b in all_content if isinstance(b, dict) and b.get("type") == "tool_result"]
+        assert tool_results
+
+    def test_assistant_tool_use_block(self):
+        from cubepi.cli.trace.convert import messages_to_anthropic
+
+        msgs = [
+            {
+                "role": "assistant",
+                "parts": [
+                    {
+                        "type": "tool_call",
+                        "id": "c2",
+                        "name": "do_thing",
+                        "arguments": {"a": 1},
+                    }
+                ],
+            }
+        ]
+        out = messages_to_anthropic(msgs)
+        blocks = out[0]["content"]
+        assert blocks[0]["type"] == "tool_use"
+        assert blocks[0]["name"] == "do_thing"
+        assert blocks[0]["input"] == {"a": 1}
+
+    def test_trailing_tool_results_flushed(self):
+        from cubepi.cli.trace.convert import messages_to_anthropic
+
+        msgs = [
+            {
+                "role": "tool",
+                "parts": [{"type": "tool_call_response", "id": "c3", "result": "y"}],
+            }
+        ]
+        out = messages_to_anthropic(msgs)
+        assert out
+        assert out[-1]["role"] == "user"

--- a/tests/tracing/test_recorder_coverage.py
+++ b/tests/tracing/test_recorder_coverage.py
@@ -440,7 +440,9 @@ class TestStreamRecording:
         await tracer.shutdown()
 
         stream_file = next(tmp_path.glob("*.stream.jsonl"))
-        events = [json.loads(line) for line in stream_file.read_text().splitlines() if line]
+        events = [
+            json.loads(line) for line in stream_file.read_text().splitlines() if line
+        ]
         types = [e["type"] for e in events]
         assert "text_delta" in types
 

--- a/tests/tracing/test_recorder_coverage.py
+++ b/tests/tracing/test_recorder_coverage.py
@@ -7,6 +7,7 @@ the FauxProvider end-to-end tests.
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 from opentelemetry.sdk.trace import ReadableSpan
@@ -391,3 +392,124 @@ class TestTracerConfig:
         async with Tracer(service_name="t", exporters=[exporter]) as t:
             assert t.resource is not None
         # No raise — shutdown ran via __aexit__.
+
+
+# ---------------------------------------------------------------------------
+# Stream recording (record_stream=True)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamRecording:
+    async def test_stream_file_created_and_closed(self, tmp_path):
+        """record_stream=True writes a .stream.jsonl file for the run."""
+        provider = FauxProvider()
+        provider.append_responses([faux_assistant_message("hello world")])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        await agent.prompt("hi")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        files = list(tmp_path.glob("*.stream.jsonl"))
+        assert len(files) == 1
+
+    async def test_stream_file_contains_events(self, tmp_path):
+        """Each text chunk produces a text_delta line in the stream file."""
+        provider = FauxProvider(tokens_per_second=1000.0)
+        provider.append_responses([faux_assistant_message("abc")])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        await agent.prompt("hi")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        stream_file = next(tmp_path.glob("*.stream.jsonl"))
+        events = [json.loads(line) for line in stream_file.read_text().splitlines() if line]
+        types = [e["type"] for e in events]
+        assert "text_delta" in types
+
+    async def test_stream_file_closed_on_cancel(self, tmp_path):
+        """Stream file is flushed+closed even on CancelledError (via _close_open_spans)."""
+        import asyncio
+
+        provider = FauxProvider(tokens_per_second=5.0)
+        provider.append_responses([faux_assistant_message("x" * 300)])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        run = asyncio.create_task(agent.prompt("hi"))
+        await asyncio.sleep(0.05)
+        agent.abort()
+        await run
+        await tracer.shutdown()
+
+        # File must exist and be closed (readable without error).
+        files = list(tmp_path.glob("*.stream.jsonl"))
+        assert len(files) == 1
+        content = files[0].read_text()
+        # At least one event was recorded before abort.
+        assert content.strip()
+
+    async def test_no_stream_file_without_record_stream(self, tmp_path):
+        """Default (record_stream=False) must not create any stream file."""
+        provider = FauxProvider()
+        provider.append_responses([faux_assistant_message("hi")])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(service_name="t", agent_name="a", exporters=[])
+        tracer.attach(agent)
+
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        assert not list(tmp_path.glob("*.stream.jsonl"))
+
+    async def test_stream_events_have_elapsed_time_field(self, tmp_path):
+        """Every recorded stream event must carry a numeric 't' (elapsed) field."""
+        provider = FauxProvider()
+        provider.append_responses([faux_assistant_message("hi")])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        stream_file = next(tmp_path.glob("*.stream.jsonl"))
+        events = [
+            json.loads(line) for line in stream_file.read_text().splitlines() if line
+        ]
+        assert events
+        for ev in events:
+            assert "t" in ev
+            assert isinstance(ev["t"], (int, float))

--- a/tests/tracing/test_recorder_coverage.py
+++ b/tests/tracing/test_recorder_coverage.py
@@ -15,7 +15,8 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace import StatusCode
 
 from cubepi.agent.agent import Agent
-from cubepi.providers.base import Model
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import Model, TextContent, ToolCall
 from cubepi.providers.faux import FauxProvider, faux_assistant_message
 from cubepi.tracing import Tracer
 
@@ -447,9 +448,12 @@ class TestStreamRecording:
         assert "text_delta" in types
 
     async def test_stream_file_closed_on_cancel(self, tmp_path):
-        """Stream file is flushed+closed even on CancelledError (via _close_open_spans)."""
-        import asyncio
+        """Stream file is closed via _close_open_spans on asyncio.CancelledError.
 
+        _close_open_spans is only reachable when detach() is called after a
+        CancelledError-aborted run — agent.abort() goes through _on_agent_end
+        instead, so we must use task.cancel() and then explicitly call detach().
+        """
         provider = FauxProvider(tokens_per_second=5.0)
         provider.append_responses([faux_assistant_message("x" * 300)])
         agent = Agent(provider=provider, model=MODEL, system_prompt="s")
@@ -460,20 +464,73 @@ class TestStreamRecording:
             record_stream=True,
             stream_dir=tmp_path,
         )
-        tracer.attach(agent)
+        detach = tracer.attach(agent)
 
         run = asyncio.create_task(agent.prompt("hi"))
         await asyncio.sleep(0.05)
-        agent.abort()
-        await run
+        run.cancel()
+        try:
+            await run
+        except asyncio.CancelledError:
+            pass
+        # detach() calls _sync_detach → _close_open_spans, which closes the
+        # stream file on the cancellation path (lines 467-471 of recorder.py).
+        detach()
         await tracer.shutdown()
 
-        # File must exist and be closed (readable without error).
+        # File must exist and be readable (closed properly, not leaked).
         files = list(tmp_path.glob("*.stream.jsonl"))
         assert len(files) == 1
-        content = files[0].read_text()
-        # At least one event was recorded before abort.
-        assert content.strip()
+        files[0].read_text()  # raises if file handle leaked
+
+    async def test_stream_toolcall_events_recorded(self, tmp_path):
+        """toolcall_start / toolcall_delta / toolcall_end events reach the stream file."""
+        from pydantic import BaseModel
+
+        class P(BaseModel):
+            pass
+
+        async def noop(tool_call_id: str, params: P, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="done")])
+
+        tool = AgentTool(name="noop", description="d", parameters=P, execute=noop)
+        provider = FauxProvider()
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    [ToolCall(id="tc1", name="noop", arguments={"x": 1})],
+                    stop_reason="tool_use",
+                ),
+                faux_assistant_message("all done"),
+            ]
+        )
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s", tools=[tool])
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        await agent.prompt("go")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        files = list(tmp_path.glob("*.stream.jsonl"))
+        assert len(files) == 1
+        events = [
+            json.loads(line) for line in files[0].read_text().splitlines() if line
+        ]
+        types = [e["type"] for e in events]
+        assert "toolcall_start" in types
+        assert "toolcall_delta" in types
+        assert "toolcall_end" in types
+        # toolcall_end should carry accumulated arg char count
+        end_ev = next(e for e in events if e["type"] == "toolcall_end")
+        assert "args_chars" in end_ev
+        assert end_ev["args_chars"] > 0
 
     async def test_no_stream_file_without_record_stream(self, tmp_path):
         """Default (record_stream=False) must not create any stream file."""
@@ -515,3 +572,181 @@ class TestStreamRecording:
         for ev in events:
             assert "t" in ev
             assert isinstance(ev["t"], (int, float))
+
+    async def test_stream_error_event_recorded(self, tmp_path):
+        """An error stop_reason causes FauxProvider to emit an 'error' StreamEvent,
+        which _write_stream_event captures in the stream file."""
+        provider = FauxProvider()
+        provider.append_responses(
+            [faux_assistant_message("oops", stop_reason="error", error_message="boom")]
+        )
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        files = list(tmp_path.glob("*.stream.jsonl"))
+        assert len(files) == 1
+        events = [
+            json.loads(line) for line in files[0].read_text().splitlines() if line
+        ]
+        types = [e["type"] for e in events]
+        assert "error" in types
+        err_ev = next(e for e in events if e["type"] == "error")
+        assert "error_message" in err_ev
+
+    async def test_stream_write_exception_swallowed(self, tmp_path):
+        """If the stream file write raises, _write_stream_event swallows it silently."""
+        from unittest.mock import MagicMock, patch
+
+        provider = FauxProvider()
+        provider.append_responses([faux_assistant_message("hi")])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        # Run once to create the stream file and let the run finish normally.
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+
+        # Now simulate a second run where the file write raises.
+        # We directly patch the stream_file.write on the recorder's _run state
+        # after the second AgentStart so the open succeeds but every write fails.
+        import cubepi.tracing.recorder as _rec_mod
+
+        _orig_on_agent_start = _rec_mod.Recorder._on_agent_start
+
+        bad_file = MagicMock()
+        bad_file.write.side_effect = OSError("disk full")
+        bad_file.close.return_value = None
+
+        def _patched_start(self_rec):
+            _orig_on_agent_start(self_rec)
+            # Replace the freshly-opened stream_file with the bad mock.
+            if self_rec._run is not None:
+                self_rec._run.stream_file = bad_file
+
+        provider.append_responses([faux_assistant_message("ok")])
+        with patch.object(_rec_mod.Recorder, "_on_agent_start", _patched_start):
+            await agent.prompt("y")
+            await agent.wait_for_idle()
+
+        await tracer.shutdown()
+        # write was called and raised, but the agent completed without crashing.
+        bad_file.write.assert_called()
+
+    async def test_stream_open_exception_swallowed(self, tmp_path):
+        """If the stream file cannot be opened, the recorder continues without crashing."""
+        provider = FauxProvider()
+        provider.append_responses([faux_assistant_message("hi")])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        # Pass stream_dir as an existing file (not a directory) so mkdir fails.
+        bad_dir = tmp_path / "not_a_dir.txt"
+        bad_dir.write_text("i am a file")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=bad_dir,
+        )
+        tracer.attach(agent)
+
+        # Should not raise even though stream file can't be opened.
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+    async def test_stream_close_exception_swallowed_on_agent_end(self, tmp_path):
+        """If stream_file.close() raises during _on_agent_end, it is swallowed."""
+        import cubepi.tracing.recorder as _rec_mod
+        from unittest.mock import MagicMock, patch
+
+        provider = FauxProvider()
+        provider.append_responses([faux_assistant_message("hi")])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        _orig_on_agent_start = _rec_mod.Recorder._on_agent_start
+
+        bad_file: MagicMock | None = None
+
+        def _patched_start(self_rec: _rec_mod.Recorder) -> None:
+            nonlocal bad_file
+            _orig_on_agent_start(self_rec)
+            if self_rec._run is not None and self_rec._run.stream_file is not None:
+                bad_file = MagicMock()
+                bad_file.write.return_value = None
+                bad_file.close.side_effect = OSError("close error")
+                self_rec._run.stream_file = bad_file
+
+        with patch.object(_rec_mod.Recorder, "_on_agent_start", _patched_start):
+            await agent.prompt("x")
+            await agent.wait_for_idle()
+        await tracer.shutdown()
+        assert bad_file is not None
+        bad_file.close.assert_called()
+
+    async def test_stream_close_exception_swallowed_on_cancel(self, tmp_path):
+        """If stream_file.close() raises during _close_open_spans, it is swallowed."""
+        import cubepi.tracing.recorder as _rec_mod
+        from unittest.mock import MagicMock, patch
+
+        provider = FauxProvider(tokens_per_second=5.0)
+        provider.append_responses([faux_assistant_message("x" * 300)])
+        agent = Agent(provider=provider, model=MODEL, system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        detach = tracer.attach(agent)
+
+        _orig_on_agent_start = _rec_mod.Recorder._on_agent_start
+        bad_file: MagicMock | None = None
+
+        def _patched_start(self_rec: _rec_mod.Recorder) -> None:
+            nonlocal bad_file
+            _orig_on_agent_start(self_rec)
+            if self_rec._run is not None and self_rec._run.stream_file is not None:
+                bad_file = MagicMock()
+                bad_file.write.return_value = None
+                bad_file.close.side_effect = OSError("close error")
+                self_rec._run.stream_file = bad_file
+
+        with patch.object(_rec_mod.Recorder, "_on_agent_start", _patched_start):
+            run = asyncio.create_task(agent.prompt("hi"))
+            await asyncio.sleep(0.05)
+            run.cancel()
+            try:
+                await run
+            except asyncio.CancelledError:
+                pass
+        detach()
+        await tracer.shutdown()
+        assert bad_file is not None
+        bad_file.close.assert_called()

--- a/website/docs/guides/tracing/cli.md
+++ b/website/docs/guides/tracing/cli.md
@@ -73,14 +73,16 @@ cubepi trace view 1cd97cdb
 trace
 └── invoke_agent  14425.8ms  [0x1cd97cdb]
     ├── cubepi.turn  1283.1ms  [0x5cfda93e]
-    │   ├── chat claude-sonnet-4-5  1208.7ms  tok 6845/68  [0x0d130229]
+    │   ├── chat deepseek-v4-flash  1208.7ms  tok 6845/68  [0x0d130229]
     │   └── execute_tool subagent  9610.2ms  subagent  [0x38bdd10a]
-    │       └── invoke_agent  9601.0ms  [0x8094f99b]      ← subagent run, nested
+    │       └── invoke_agent  9601.0ms  [0x8094f99b]   ← subagent run, nested
     │           └── cubepi.turn  9598.4ms  [0x57c5cfc7]
-    │               ├── chat claude-sonnet-4-5  1190.3ms  [0x8205ca6b]
+    │               ├── chat deepseek-v4-flash  1190.3ms  [0x8205ca6b]
     │               └── execute_tool web_search  6500.2ms  web_search  [0xca4e59fc]
-    └── cubepi.turn  491.9ms  [0xce25f242]
-        └── chat claude-sonnet-4-5  427.2ms  [0x0bff68ec]
+    └── cubepi.turn  491.9ms  ERROR  [0xce25f242]
+        └── chat deepseek-v4-flash  427.2ms  ERROR  [0x0bff68ec]
+            └── error: Error code: 400 - ... `tool_use` ids were found without
+                `tool_result` blocks immediately after: call_01_...
 ```
 
 Read it top-down: `invoke_agent` (a run) → `cubepi.turn` (one agent-loop turn)

--- a/website/docs/guides/tracing/cli.md
+++ b/website/docs/guides/tracing/cli.md
@@ -123,6 +123,39 @@ cubepi trace stats --by model --meta user_id=usr_9
 cubepi trace stats --by tool --meta conversation_id=conv_123
 ```
 
+## `convert` — reconstruct an API request body
+
+When you need to replay a specific LLM call — reproduce a failure, test a prompt
+change, or run a raw `curl` against the same context — `convert` reads a recorded
+`chat` span and outputs the complete request body.
+
+Requires `record_content=True`.
+
+```bash
+# Default: last chat span in the trace, OpenAI JSON format
+cubepi trace convert <trace_id>
+
+# Select which LLM call to reconstruct
+cubepi trace convert <trace_id> --turn 2        # 2nd chat span (1-indexed)
+cubepi trace convert <trace_id> --span 0xbb7eb1 # by span_id prefix (from `view`)
+
+# Output formats
+cubepi trace convert <trace_id> --format openai     # default — JSON request body
+cubepi trace convert <trace_id> --format anthropic  # Anthropic Messages API body
+cubepi trace convert <trace_id> --format curl       # shell-executable curl command
+```
+
+The `[0x…]` span id from `view` output goes directly into `--span`:
+
+```
+├── chat kimi-k2.6  31704.5ms  [0xbb7eb192]   ← paste as: --span 0xbb7eb1
+├── chat kimi-k2.6  32420.2ms  [0x7c76f48d]   ← or: --span 0x7c76f4
+```
+
+The reconstructed body includes the full conversation history, the system prompt,
+all tool definitions, and request parameters (`model`, `max_tokens`,
+`temperature`). Pipe to `python -m json.tool`, `jq`, or directly to a replay script.
+
 ## Beyond the CLI
 
 The files are plain JSONL — one span per line — so you can parse them directly

--- a/website/docs/guides/tracing/content-recording.md
+++ b/website/docs/guides/tracing/content-recording.md
@@ -112,6 +112,41 @@ the raw provider response on every chat span, multi-turn agentic runs can
 get large fast. Drop or summarise via `redact` for any field over your
 budget.
 
+## Stream-level recording
+
+`record_content` captures the final assembled request and response on each `chat`
+span, but not the individual streaming chunks. For post-mortem debugging of
+streaming failures — empty tool call arguments, duplicate events, truncated
+output — enable `record_stream` to write a chunk-by-chunk event log alongside the
+main trace:
+
+```python
+tracer = Tracer(
+    record_content=True,            # needed for trace convert
+    record_stream=True,             # ← per-chunk event log
+    stream_dir="./cubepi-traces",   # where to write <run_id>.stream.jsonl
+    exporters=[JsonlSpanExporter(directory="./cubepi-traces")],
+)
+```
+
+`record_stream` writes `<stream_dir>/<run_id>.stream.jsonl` (one JSON line per
+`StreamEvent`). Every line carries `t` (elapsed seconds from run start) and
+`type`. Tool-call lines also include `ci` (content index), `id`, `name`, delta
+sizes, and argument previews:
+
+```json
+{"t": 5.873, "type": "toolcall_start", "ci": 1, "id": "toolu_...", "name": "show_widget"}
+{"t": 5.875, "type": "toolcall_delta", "ci": 1, "chars": 11, "accumulated": 11, "preview": "{\"title\": \""}
+{"t": 33.177, "type": "toolcall_end",  "ci": 1, "id": "toolu_...", "args_chars": 7465, "args_preview": "{\"title\": \"CubePi..."}
+```
+
+This makes it straightforward to confirm whether argument chunks ever arrived, or
+whether the same event fired twice (e.g. a provider that sends `finish_reason`
+twice produces two `toolcall_end` lines for the same `ci`).
+
+`record_stream` is independent of `record_content` — turn it on only in debugging
+sessions. Files can grow large for long-running, tool-heavy agents.
+
 ## Auditing what's recorded
 
 The recorder always sets `service.name`, `gen_ai.agent.name`, and

--- a/website/docs/guides/tracing/overview.md
+++ b/website/docs/guides/tracing/overview.md
@@ -14,12 +14,20 @@ Azure Monitor, …) can ingest agent runs without custom instrumentation.
 Attach a `Tracer` to an `Agent` and every prompt produces a tree of spans you
 can pivot, query, and join with the rest of your service traces:
 
-```text
-invoke_agent <agent_name>              [INTERNAL]    one per agent.prompt()
-└── cubepi.turn                        [INTERNAL]    one per LLM round-trip
-    ├── chat <model>                   [CLIENT]      the LLM call itself
-    └── execute_tool <tool_name>       [INTERNAL]    each tool invocation
-        └── tools/call <tool_name>     [CLIENT]      (MCP tools only)
+```
+trace
+└── invoke_agent  14425.8ms  [0x1cd97cdb]         ← one per agent.prompt()
+    ├── cubepi.turn  1283.1ms  [0x5cfda93e]        ← one per LLM round-trip
+    │   ├── chat deepseek-v4-flash  1208.7ms  tok 6845/68  [0x0d130229]
+    │   └── execute_tool subagent  9610.2ms  subagent  [0x38bdd10a]
+    │       └── invoke_agent  9601.0ms  [0x8094f99b]   ← subagent run, nested
+    │           └── cubepi.turn  9598.4ms  [0x57c5cfc7]
+    │               ├── chat deepseek-v4-flash  1190.3ms  [0x8205ca6b]
+    │               └── execute_tool web_search  6500.2ms  web_search  [0xca4e59fc]
+    └── cubepi.turn  491.9ms  ERROR  [0xce25f242]
+        └── chat deepseek-v4-flash  427.2ms  ERROR  [0x0bff68ec]
+            └── error: Error code: 400 - ... `tool_use` ids were found without
+                `tool_result` blocks immediately after: call_01_...
 ```
 
 Each layer carries standard `gen_ai.*` attributes — `gen_ai.operation.name`,


### PR DESCRIPTION
## Summary

- **`record_stream` / `stream_dir`** on `Tracer` and `Recorder`: when enabled, writes every `StreamEvent` to `<stream_dir>/<run_id>.stream.jsonl` alongside the main trace. Each line captures timing, event type, and key fields (tool id/name, delta sizes, argument previews). Independent of `record_content` — flip on only for debugging sessions.

- **`trace convert` subcommand**: reads a recorded `chat` span and reconstructs the full API request body (`--format openai` / `anthropic` / `curl`). Use `--span 0x<prefix>` from `trace view` output, or `--turn N`. Requires `record_content=True`.

- **Docs**: updated `cli.md`, `content-recording.md`, and the `cubepi-trace` skill with usage examples and stream JSONL format reference.

## Test plan

- [ ] 189 existing tests pass (`pytest tests/cli/trace/ tests/tracing/`)
- [ ] `Tracer(record_stream=True, stream_dir="./cubepi-traces")` creates `<run_id>.stream.jsonl` on run start and closes it on end / cancellation
- [ ] `cubepi trace convert <id> --span 0x<prefix> --format curl` reproduces the API call
- [ ] `stream_tool_accumulated` is cleared at each turn start (codex MEDIUM finding fixed)