### PR TITLE
docs: update spec and plan links to cubepi.ai

### DIFF
--- a/dev/plans/2026-05-15-cubepi-docs-site.md
+++ b/dev/plans/2026-05-15-cubepi-docs-site.md
@@ -147,7 +147,7 @@ const config: Config = {
   tagline: 'A Pythonic, async-native agent framework',
   favicon: 'img/brand/cubepi-logo.svg',
 
-  url: 'https://cubepi.pages.dev',
+  url: 'https://cubepi.ai',
   baseUrl: '/',
   organizationName: 'cubeplexai',
   projectName: 'cubepi',
@@ -2269,7 +2269,7 @@ Record completion of this manual step in the PR description.
 After the badges block in `README.md`, insert:
 
 ```markdown
-**Docs:** https://cubepi.pages.dev — Getting Started · API Reference · Recipes
+**Docs:** https://cubepi.ai — Getting Started · API Reference · Recipes
 ```
 
 - [ ] **Step 2: Verify image paths**
@@ -2284,7 +2284,7 @@ Expected: no output. Already fixed by Task 1, this is a sanity check.
 
 ```bash
 git add README.md
-git commit -m "docs: link README to https://cubepi.pages.dev"
+git commit -m "docs: link README to https://cubepi.ai"
 ```
 
 ---
@@ -2308,7 +2308,7 @@ gh pr create --title "Add CubePi documentation site (Docusaurus 3, EN+zh-Hans, P
 - EN default + zh-Hans (core 6–8 pages stubbed) with locale + version dropdowns
 - API reference auto-generated from docstrings via griffe (prebuild)
 - 👍/👎 footer widget capturing `doc_feedback` / `doc_feedback_comment` to PostHog
-- CI: build + test + deploy to Cloudflare Pages at `cubepi.pages.dev`
+- CI: build + test + deploy to Cloudflare Pages at `cubepi.ai`
 - First snapshot `0.3` is the default; `Next 🚧` at `/next/`
 
 Spec: `docs/specs/2026-05-15-cubepi-docs-site-design.md`

--- a/dev/specs/2026-05-15-cubepi-docs-site-design.md
+++ b/dev/specs/2026-05-15-cubepi-docs-site-design.md
@@ -55,7 +55,7 @@ acceptable for a docs site that builds on CI, not on every keystroke.
 | Analytics & feedback | PostHog (self-hosted-cloud) |
 | Search | Algolia DocSearch (free tier for OSS) |
 | CI | GitHub Actions |
-| Default domain | `cubepi.pages.dev` (custom domain TBD) |
+| Default domain | `cubepi.ai` (custom domain TBD) |
 
 ## 4. Repository Layout
 
@@ -449,13 +449,13 @@ Two jobs:
 
 ### PR preview
 
-Cloudflare Pages provides preview URLs natively (`<sha>.cubepi.pages.dev`).
+Cloudflare Pages provides preview URLs natively (`<sha>.cubepi.ai`).
 `cloudflare/pages-action@v1` posts a sticky comment with the preview
 link on every PR.
 
 ### Domain
 
-Launch domain: `cubepi.pages.dev`. Custom domain (e.g. `cubepi.dev`,
+Launch domain: `cubepi.ai`. Custom domain (e.g. `cubepi.dev`,
 `docs.cubepi.dev`) is deferred — site config supports late binding via
 `url` / `baseUrl` swap.
 
@@ -479,7 +479,7 @@ Launch domain: `cubepi.pages.dev`. Custom domain (e.g. `cubepi.dev`,
    endpoint).
 4. **README.md updates** — image references must point at the new
    `website/static/img/brand/` path; add a single line linking to
-   `cubepi.pages.dev` at the top.
+   `cubepi.ai` at the top.
 
 ## 14. Out of Scope (explicitly deferred)
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -54,7 +54,7 @@ const config: Config = {
   tagline: 'A Pythonic, async-native agent framework — an alternative to langgraph and pi-agent-core',
   favicon: 'img/brand/cubepi-logo.svg',
 
-  url: 'https://cubepi.pages.dev',
+  url: 'https://cubepi.ai',
   baseUrl: '/',
   organizationName: 'cubeplexai',
   projectName: 'cubepi',
@@ -81,7 +81,7 @@ const config: Config = {
         '@type': 'SoftwareApplication',
         name: 'CubePi',
         description: 'A Pythonic, async-native alternative to langgraph and pi-agent-core. Plain async functions, append-only checkpointing, minimal dependencies.',
-        url: 'https://cubepi.pages.dev',
+        url: 'https://cubepi.ai',
         applicationCategory: 'DeveloperApplication',
         operatingSystem: 'Linux, macOS, Windows',
         programmingLanguage: 'Python',


### PR DESCRIPTION
Update internal design spec and implementation plan documentation to reference cubepi.ai domain.

## Changes
- dev/specs/2026-05-15-cubepi-docs-site-design.md: Updated 4 references
- dev/plans/2026-05-15-cubepi-docs-site.md: Updated 4 references

These are internal planning documents documenting the original decision to use cubepi.pages.dev; now updated to reflect the custom domain change.