### PR TITLE
feat(skills): add cubepi skill + skills badge + tracing discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Docs](https://img.shields.io/badge/docs-cubepi.ai-blue)](https://cubepi.ai)
 [![Ask DeepWiki](https://img.shields.io/badge/Ask-DeepWiki-1f6feb)](https://deepwiki.com/cubeplexai/cubepi)
+[![skills.sh](https://skills.sh/b/cubeplexai/cubepi)](https://skills.sh/cubeplexai/cubepi)
 
 CubePi is a Pythonic, async-native agent framework designed for high performance, readability, and production-grade persistence. It provides a leaner alternative to graph-based agent runtimes by modeling agent logic as a linear while loop that developers can easily trace and debug.
 
@@ -303,9 +304,22 @@ is a subset of it. From trace fields, cache hit rate is
 `cache_read / input_tokens` (≤ 100%) — do **not** add `cache_read` to the
 denominator.
 
-Coding agents debugging cubepi/consumer apps can install the bundled
+Coding agents debugging cubepi/consumer apps can install the
 [`cubepi-trace` skill](skills/cubepi-trace/SKILL.md):
-`npx skills add https://github.com/cubeplexai/cubepi/tree/main/skills/cubepi-trace -a claude-code`.
+
+```bash
+npx skills add cubeplexai/cubepi@cubepi-trace -a claude-code
+```
+
+## AI Agents
+
+Two skills are available for coding agents (Claude Code, Cursor, Codex, …) working
+with this repo:
+
+| Skill | Install | Purpose |
+|-------|---------|---------|
+| `cubepi` | `npx skills add cubeplexai/cubepi@cubepi -a claude-code` | Build agents — API reference, tools, middleware, checkpointing, MCP, HITL |
+| `cubepi-trace` | `npx skills add cubeplexai/cubepi@cubepi-trace -a claude-code` | Debug runs — inspect OTel spans, token counts, tool results, streaming failures |
 
 ## Requirements
 

--- a/skills/cubepi-trace/SKILL.md
+++ b/skills/cubepi-trace/SKILL.md
@@ -212,3 +212,9 @@ Mind the convention — it differs between the trace and cubebox's UI:
 - **Backend vs frontend**: the trace shows what the backend/agent did. If the
   trace shows correct data but the UI is wrong, the bug is in the frontend
   (SSE handling / rendering) — the trace won't see that; use a browser instead.
+
+## Source and contributing
+
+Skill source and cubepi source: https://github.com/cubeplexai/cubepi  
+If the docs or skill are unclear, read the source — it's the authoritative reference.  
+Bugs or missing coverage: open an issue or PR at https://github.com/cubeplexai/cubepi/issues

--- a/skills/cubepi/SKILL.md
+++ b/skills/cubepi/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: cubepi
+description: Use when building, extending, or debugging agents with the CubePi framework. Covers the Agent API, providers, tools, middleware, checkpointing, MCP integration, and HITL. References the cubepi-trace skill for run debugging.
+---
+
+# Building agents with CubePi
+
+CubePi is a Pythonic, async-native agent framework. The agent loop is a plain
+`while` loop — no graph nodes, no state machines. You can read the full runtime
+in a few minutes.
+
+**Docs:** https://cubepi.ai/docs  
+**Source:** https://github.com/cubeplexai/cubepi  
+**Issues / PRs:** https://github.com/cubeplexai/cubepi/issues
+
+If anything in the docs is unclear or missing, read the source directly — the
+code is the authoritative reference. If you hit a bug or find a gap, open an
+issue or PR on the repo.
+
+## Install
+
+```bash
+pip install cubepi                              # core
+pip install cubepi[mcp]                        # MCP tool loaders
+pip install cubepi[tracing,trace-cli]          # OpenTelemetry + cubepi trace CLI
+pip install cubepi[sqlite]                     # SQLite checkpointer
+pip install cubepi[postgres]                   # Postgres checkpointer
+```
+
+## Core concepts
+
+### Agent + Provider + Model
+
+```python
+from cubepi import Agent, AgentTool, Model
+from cubepi.providers.anthropic import AnthropicProvider
+from cubepi.providers.openai import OpenAIProvider
+
+provider = AnthropicProvider()              # or OpenAIProvider()
+model = Model(id="claude-opus-4-5-20251001")
+agent = Agent(provider=provider, model=model, system_prompt="You are helpful.")
+
+await agent.prompt("Hello")
+await agent.wait_for_idle()
+```
+
+### Tools
+
+```python
+from pydantic import BaseModel
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+
+class SearchInput(BaseModel):
+    query: str
+
+async def search(tool_call_id: str, params: SearchInput, *, signal=None, on_update=None):
+    result = await do_search(params.query)
+    return AgentToolResult(content=[TextContent(text=result)])
+
+tool = AgentTool(name="search", description="Search the web", parameters=SearchInput, execute=search)
+agent = Agent(..., tools=[tool])
+```
+
+Full tool docs: https://cubepi.ai/docs/guides/tools
+
+### Streaming responses
+
+```python
+async for event in agent.stream("What is 2+2?"):
+    if event.type == "text_delta":
+        print(event.delta, end="", flush=True)
+```
+
+Event types: `text_delta`, `thinking_delta`, `toolcall_start`, `toolcall_delta`,
+`toolcall_end`, `message_start`, `message_end`. Full reference:
+https://cubepi.ai/docs/guides/streaming
+
+### Middleware
+
+Seven typed hooks (`before_model_request`, `after_model_response`,
+`before_tool_call`, `after_tool_call`, `on_turn_start`, `on_turn_end`,
+`on_agent_end`). Declare with `@middleware` and compose with `compose_middleware`:
+
+```python
+from cubepi.middleware import middleware, compose_middleware
+
+@middleware
+async def log_calls(ctx, next):
+    print(f"tool: {ctx.tool_name}")
+    return await next(ctx)
+
+agent = Agent(..., middleware=compose_middleware(log_calls, other_middleware))
+```
+
+Full docs: https://cubepi.ai/docs/guides/middleware
+
+### Checkpointing
+
+```python
+from cubepi.checkpointer.sqlite import SqliteCheckpointer
+
+checkpointer = await SqliteCheckpointer.create("./state.db")
+agent = Agent(..., checkpointer=checkpointer)
+
+# Resume a conversation
+await agent.resume(conversation_id="conv_123")
+await agent.prompt("Continue from where we left off")
+```
+
+Full docs: https://cubepi.ai/docs/guides/checkpointing
+
+### MCP tools
+
+```python
+from cubepi.mcp import MCPToolLoader
+
+loader = MCPToolLoader(server_url="http://localhost:8080")
+tools = await loader.load()
+agent = Agent(..., tools=tools)
+```
+
+Full docs: https://cubepi.ai/docs/guides/mcp
+
+### Human-in-the-loop (HITL)
+
+Use `before_tool_call` middleware to intercept and approve tool calls, or use
+the built-in `ApprovalPolicyMiddleware` for policy-driven approval:
+
+Full docs: https://cubepi.ai/docs/guides/hitl
+
+## Debugging runs
+
+Install the `cubepi-trace` skill — it gives you the full protocol for
+inspecting recorded OTel spans without re-running the agent:
+
+```bash
+npx skills add cubeplexai/cubepi@cubepi-trace -a claude-code
+```
+
+The skill covers `cubepi trace ls / view / follow / stats / convert`, token
+and cache-rate conventions, and streaming failure debugging.
+
+## Getting help
+
+- **Docs:** https://cubepi.ai/docs  
+- **Source:** https://github.com/cubeplexai/cubepi (read it — it's short)  
+- **Issues:** https://github.com/cubeplexai/cubepi/issues  
+- **PRs welcome** for bugs, missing docs, or new provider support

--- a/website/docs/guides/tracing/cli.md
+++ b/website/docs/guides/tracing/cli.md
@@ -169,4 +169,8 @@ span **event** named `gen_ai.client.operation.exception`.
 A bundled `cubepi-trace` skill drives this CLI for debugging ("why did the run
 end with no reply?", "the tool result is wrong"). It encodes the fast path
 (`ls` → `view <prefix>`) and the token/cache-rate conventions.
+
+```bash
+npx skills add cubeplexai/cubepi@cubepi-trace -a claude-code
+```
 :::


### PR DESCRIPTION
## Summary

- **New skill `skills/cubepi/SKILL.md`**: covers Agent API, tools, middleware, checkpointing, MCP, HITL with quick code examples + links to docs. References `cubepi-trace` skill with install command so agents actively install it. Points contributors to GitHub issues/PRs and source as authoritative reference.
- **`skills/cubepi-trace/SKILL.md`**: added source/contributing footer.
- **README.md**: added `skills.sh` badge; new "AI Agents" section with install table for both skills; updated cubepi-trace install line to short `cubeplexai/cubepi@cubepi-trace` syntax.
- **`website/docs/guides/tracing/cli.md`**: added install command inside the existing "For AI agents" tip block.

## Install commands (after indexing)

```bash
npx skills add cubeplexai/cubepi@cubepi -a claude-code        # agent dev
npx skills add cubeplexai/cubepi@cubepi-trace -a claude-code  # trace debugging
```