### PR TITLE
feat(agent-tools): format ValidationError as model-friendly tool result

### DIFF
--- a/cubepi/agent/tools.py
+++ b/cubepi/agent/tools.py
@@ -67,6 +67,50 @@ def _error_result(message: str) -> AgentToolResult:
     return AgentToolResult(content=[TextContent(text=message)])
 
 
+def _format_validation_error(exc: ValidationError, tool_name: str) -> str:
+    """Render a pydantic ValidationError as text the LLM can act on.
+
+    The default ``str(exc)`` leaks pydantic-internal model names and a
+    documentation URL — the model can read it but cannot reliably extract
+    the fix from it. This produces one short line per error, naming the
+    field path, the constraint, and (for discriminated unions) the allowed
+    discriminator values, so the model can correct the call without
+    another round-trip.
+    """
+    lines = [f"Invalid arguments for tool '{tool_name}':"]
+    for err in exc.errors():
+        loc_parts = [str(p) for p in err.get("loc", ())]
+        loc = ".".join(loc_parts) if loc_parts else "<root>"
+        etype = err.get("type", "")
+        msg = err.get("msg", "")
+        ctx = err.get("ctx") or {}
+
+        if etype == "union_tag_not_found":
+            # pydantic stores discriminator wrapped in single quotes, e.g.
+            # "'operation'" — strip for readability. expected_tags is not
+            # populated for this error type; the model has the JSON Schema
+            # to enumerate allowed values.
+            disc = str(ctx.get("discriminator", "?")).strip("'\"")
+            lines.append(f"- {loc}: missing required discriminator key '{disc}'")
+        elif etype == "union_tag_invalid":
+            disc = str(ctx.get("discriminator", "?")).strip("'\"")
+            tag = ctx.get("tag", "")
+            allowed = ctx.get("expected_tags") or ""
+            lines.append(
+                f"- {loc}: discriminator '{disc}'={tag!r} is not one of: {allowed}"
+            )
+        elif etype == "missing":
+            lines.append(f"- {loc}: field required")
+        elif etype == "literal_error":
+            expected = ctx.get("expected", "")
+            lines.append(f"- {loc}: must be one of {expected}")
+        elif etype == "extra_forbidden":
+            lines.append(f"- {loc}: unexpected field")
+        else:
+            lines.append(f"- {loc}: {msg}")
+    return "\n".join(lines)
+
+
 def _merge_hitl_details(base: Any, hitl: dict | None) -> Any:
     if hitl is None:
         return base
@@ -114,7 +158,10 @@ async def _prepare_tool_call(
     try:
         validated_args = tool.parameters.model_validate(tool_call.arguments)
     except ValidationError as exc:
-        return _ImmediateOutcome(result=_error_result(str(exc)), is_error=True)
+        return _ImmediateOutcome(
+            result=_error_result(_format_validation_error(exc, tool.name)),
+            is_error=True,
+        )
     except Exception as exc:  # pragma: no cover — defensive
         return _ImmediateOutcome(result=_error_result(str(exc)), is_error=True)
 
@@ -149,7 +196,10 @@ async def _prepare_tool_call(
                     before_result.edited_args
                 )
             except ValidationError as exc:  # pragma: no cover — defensive
-                return _ImmediateOutcome(result=_error_result(str(exc)), is_error=True)
+                return _ImmediateOutcome(
+                    result=_error_result(_format_validation_error(exc, tool.name)),
+                    is_error=True,
+                )
 
         hitl_trace_carry = before_result.hitl_trace if before_result else None
     else:

--- a/tests/agent/test_tools.py
+++ b/tests/agent/test_tools.py
@@ -372,6 +372,124 @@ class TestToolExecutionError:
         assert batch.messages[0].is_error
 
 
+class TestValidationErrorFormatting:
+    """Pin the contract that ValidationError text is model-friendly.
+
+    A raw str(ValidationError) names pydantic's internal model class and
+    points at the pydantic docs site, which the LLM cannot act on. The
+    formatter must produce field-path-anchored lines the model can use to
+    self-correct without a second round-trip.
+    """
+
+    async def test_missing_required_field_names_the_field(self):
+        tool = make_echo_tool()
+        ctx = make_context([tool])
+        msg = make_assistant_msg([ToolCall(id="t1", name="echo", arguments={})])
+
+        batch = await execute_tool_calls(
+            ctx, msg, tool_execution="sequential", emit=lambda e: None
+        )
+
+        text = batch.messages[0].content[0].text
+        assert "Invalid arguments for tool 'echo'" in text
+        assert "value" in text
+        assert "field required" in text
+        # Raw pydantic decoration must NOT leak to the model.
+        assert "errors.pydantic.dev" not in text
+        assert "validation error" not in text.lower()[: len("validation error")] or (
+            "validation error" not in text.lower().split("\n")[0]
+        )
+
+    async def test_discriminator_failure_lists_allowed_tags(self):
+        from typing import Annotated, Literal, Union
+
+        from pydantic import Field, RootModel
+
+        class ListOp(BaseModel):
+            operation: Literal["list"]
+
+        class CreateOp(BaseModel):
+            operation: Literal["create"]
+            name: str
+
+        union_type = Annotated[
+            Union[ListOp, CreateOp],
+            Field(discriminator="operation"),
+        ]
+        union_root = RootModel[union_type]
+
+        async def execute_fn(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="ok")])
+
+        tool = AgentTool(
+            name="opt",
+            description="discriminated tool",
+            parameters=union_root,
+            execute=execute_fn,
+        )
+        ctx = make_context([tool])
+
+        msg = make_assistant_msg(
+            [ToolCall(id="t1", name="opt", arguments={"operation": "delete"})]
+        )
+
+        batch = await execute_tool_calls(
+            ctx, msg, tool_execution="sequential", emit=lambda e: None
+        )
+
+        text = batch.messages[0].content[0].text
+        assert "discriminator" in text
+        # Allowed tags must be enumerated so the model can self-correct.
+        assert "list" in text
+        assert "create" in text
+
+    async def test_missing_discriminator_key_is_named(self):
+        from typing import Annotated, Literal, Union
+
+        from pydantic import Field, RootModel
+
+        class ListOp(BaseModel):
+            operation: Literal["list"]
+
+        class CreateOp(BaseModel):
+            operation: Literal["create"]
+            name: str
+
+        union_type = Annotated[
+            Union[ListOp, CreateOp],
+            Field(discriminator="operation"),
+        ]
+        union_root = RootModel[union_type]
+
+        async def execute_fn(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="ok")])
+
+        tool = AgentTool(
+            name="opt",
+            description="discriminated tool",
+            parameters=union_root,
+            execute=execute_fn,
+        )
+        ctx = make_context([tool])
+
+        # Wrong top-level key — pydantic raises union_tag_not_found.
+        # That error type does not carry expected_tags in its ctx, but the
+        # error must still name the discriminator key so the model can find
+        # it in the tool's JSON Schema and self-correct.
+        msg = make_assistant_msg(
+            [ToolCall(id="t1", name="opt", arguments={"action": "list"})]
+        )
+
+        batch = await execute_tool_calls(
+            ctx, msg, tool_execution="sequential", emit=lambda e: None
+        )
+
+        text = batch.messages[0].content[0].text
+        assert "missing required discriminator key 'operation'" in text
+        # Surrounding quotes from pydantic's ctx must be stripped.
+        assert "''operation''" not in text
+
+
 class TestTermination:
     async def test_all_terminate_stops_loop(self):
         async def term_execute(tool_call_id, params, *, signal=None, on_update=None):

--- a/tests/agent/test_tools.py
+++ b/tests/agent/test_tools.py
@@ -489,6 +489,76 @@ class TestValidationErrorFormatting:
         # Surrounding quotes from pydantic's ctx must be stripped.
         assert "''operation''" not in text
 
+    async def test_literal_error_lists_allowed_values(self):
+        from typing import Literal
+
+        from pydantic import BaseModel
+
+        class LiteralParams(BaseModel):
+            mode: Literal["fast", "slow"]
+
+        async def execute_fn(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="ok")])
+
+        tool = AgentTool(
+            name="lit",
+            description="literal tool",
+            parameters=LiteralParams,
+            execute=execute_fn,
+        )
+        ctx = make_context([tool])
+
+        msg = make_assistant_msg(
+            [ToolCall(id="t1", name="lit", arguments={"mode": "medium"})]
+        )
+
+        batch = await execute_tool_calls(
+            ctx, msg, tool_execution="sequential", emit=lambda e: None
+        )
+
+        text = batch.messages[0].content[0].text
+        assert "mode" in text
+        assert "must be one of" in text
+        # The allowed values must be enumerated so the model can self-correct.
+        assert "fast" in text
+        assert "slow" in text
+
+    async def test_extra_forbidden_names_the_unexpected_field(self):
+        from pydantic import BaseModel, ConfigDict
+
+        class StrictParams(BaseModel):
+            model_config = ConfigDict(extra="forbid")
+            value: str
+
+        async def execute_fn(tool_call_id, params, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="ok")])
+
+        tool = AgentTool(
+            name="strict",
+            description="strict tool",
+            parameters=StrictParams,
+            execute=execute_fn,
+        )
+        ctx = make_context([tool])
+
+        msg = make_assistant_msg(
+            [
+                ToolCall(
+                    id="t1",
+                    name="strict",
+                    arguments={"value": "hi", "stray_key": 1},
+                )
+            ]
+        )
+
+        batch = await execute_tool_calls(
+            ctx, msg, tool_execution="sequential", emit=lambda e: None
+        )
+
+        text = batch.messages[0].content[0].text
+        assert "stray_key" in text
+        assert "unexpected field" in text
+
 
 class TestTermination:
     async def test_all_terminate_stops_loop(self):


### PR DESCRIPTION
## Summary
- Add `_format_validation_error` that renders pydantic `ValidationError` as model-friendly text — one short line per error, with field path + constraint, plus inline allowed-tag enumeration for `union_tag_invalid`.
- Wire it into the two `ValidationError` catch points in `_prepare_tool_call`, replacing `str(exc)`.

The default `str(ValidationError)` ends up in the tool-result text the LLM reads, e.g.
```
1 validation error for scheduled_tasks_Input
Unable to extract tag using discriminator 'operation'
For further information visit https://errors.pydantic.dev/2.13/v/union_tag_not_found
```
That names a pydantic-internal model class the LLM doesn't know about and points at a doc URL it can't follow. When the tool's input is a discriminated union with N operations (the common shape for capability tools), the model usually has to retry several times to guess the right shape — each retry is a full round-trip with the entire context replayed.

After this change the same failure surfaces as:
```
Invalid arguments for tool 'scheduled_tasks':
- <root>: missing required discriminator key 'operation'
```
Which is enough for the model to find the `operation` field in the tool's JSON Schema and self-correct on the next call.

## Why now
Driven by a real cubebox trace where kimi-k2.6 called `scheduled_tasks` five times before the first success. Three of those retries were the model decoding pydantic-internal error messages one field at a time. cubebox PR https://github.com/xfgong/cubebox/pull/193 addresses the schema side; this PR addresses the error-message side so the same fix benefits every capability tool in the repo.

## Test plan
- [x] `tests/agent/test_tools.py::TestValidationErrorFormatting` — new class with three tests covering: missing required field, invalid discriminator tag (allowed values enumerated), missing discriminator key (key named, surrounding quotes stripped).
- [x] Existing `test_invalid_parameters_returns_error` still passes (asserts `is_error=True` on bad input — the new formatter is a superset of that).
- [x] Full cubepi test suite: 1131 passed, 23 skipped.
- [x] ruff check + ruff format clean.