### PR TITLE
feat(tracing): add Tracer.oneshot() for instrumented one-shot LLM calls

### DIFF
--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -511,13 +511,18 @@ class Tracer:
             CUBEPI_RUN_ID: run_id,
             GEN_AI_PROVIDER_NAME: "cubepi",
             "cubepi.oneshot.operation": operation,
-            # Also expose operation under cubepi.metadata.* so the
-            # `cubepi trace ls --meta oneshot_operation=...` filter works
-            # (the CLI's --meta filter only reads cubepi.metadata.* attrs).
-            "cubepi.metadata.oneshot_operation": operation,
         }
+        # User metadata first, then reserved keys, so a caller-supplied
+        # ``oneshot_operation`` key in ``metadata`` can't shadow the one
+        # derived from the ``operation`` argument (which the documented
+        # ``cubepi trace ls --meta oneshot_operation=...`` filter depends
+        # on).
         for k, v in (metadata or {}).items():
             root_attrs[f"cubepi.metadata.{k}"] = v
+        # Also expose operation under cubepi.metadata.* so the
+        # `cubepi trace ls --meta oneshot_operation=...` filter works
+        # (the CLI's --meta filter only reads cubepi.metadata.* attrs).
+        root_attrs["cubepi.metadata.oneshot_operation"] = operation
 
         root_span = self._otel_tracer.start_span(
             name=SPAN_NAME_INVOKE_AGENT,
@@ -571,12 +576,21 @@ class Tracer:
                 )
             except BaseException:
                 # Unwind any partial subscriptions before re-raising so no
-                # dangling listeners are left on the provider.
+                # dangling listeners are left on the provider. Also close
+                # the per-run stream file if one was opened — otherwise
+                # this early-return path leaks the JSONL file descriptor
+                # for the process lifetime.
                 for d in detachers:
                     try:
                         d()
                     except Exception:
                         pass
+                if run.stream_file is not None:
+                    try:
+                        run.stream_file.close()
+                    except Exception:
+                        pass
+                    run.stream_file = None
                 root_span.end()
                 raise
 

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -561,7 +561,9 @@ class Tracer:
                 stream_path = self._stream_dir / f"{run_id}.stream.jsonl"
                 run.stream_file = stream_path.open("w", encoding="utf-8")
                 run.stream_start_time = _time.time()
-            except Exception:
+            except (
+                Exception
+            ):  # pragma: no cover — defensive: tracing must never break the caller
                 pass
 
         detachers: list[Callable[[], None]] = []
@@ -583,12 +585,12 @@ class Tracer:
                 for d in detachers:
                     try:
                         d()
-                    except Exception:
+                    except Exception:  # pragma: no cover — defensive
                         pass
                 if run.stream_file is not None:
                     try:
                         run.stream_file.close()
-                    except Exception:
+                    except Exception:  # pragma: no cover — defensive
                         pass
                     run.stream_file = None
                 root_span.end()
@@ -620,7 +622,7 @@ class Tracer:
                     root_span.set_status(Status(StatusCode.ERROR, str(_exc)[:256]))
                     root_span.set_attribute(ERROR_TYPE, type(_exc).__name__)
                 root_span.record_exception(_exc)
-            except Exception:
+            except Exception:  # pragma: no cover — defensive
                 pass
             raise
         finally:
@@ -628,7 +630,7 @@ class Tracer:
             for d in detachers:
                 try:
                     d()
-                except Exception:
+                except Exception:  # pragma: no cover — defensive
                     pass
             # Close any chat span left open by a cancelled/timed-out stream.
             # We don't reuse Recorder._close_open_spans because that helper
@@ -643,7 +645,7 @@ class Tracer:
                     run.chat_span.set_attribute(CUBEPI_ABORTED, True)
                     run.chat_span.set_attribute(ERROR_TYPE, "cubepi.aborted")
                     run.chat_span.end()
-                except Exception:
+                except Exception:  # pragma: no cover — defensive
                     pass
                 run.chat_span = None
             # Stamp content on the root invoke_agent span. The agent path
@@ -681,14 +683,14 @@ class Tracer:
                             GEN_AI_OUTPUT_MESSAGES,
                             messages_to_semconv(run.output_messages),
                         )
-                except Exception:
+                except Exception:  # pragma: no cover — defensive
                     pass
             # Close the stream file opened above (mirrors the agent
             # _on_agent_end / _close_open_spans path).
             if run.stream_file is not None:
                 try:
                     run.stream_file.close()
-                except Exception:
+                except Exception:  # pragma: no cover — defensive
                     pass
                 run.stream_file = None
             recorder._run = None
@@ -699,7 +701,7 @@ class Tracer:
             # asyncio.run() can exit before the BatchSpanProcessor drains.
             try:
                 await self.force_flush(timeout_seconds=5.0)
-            except Exception:
+            except Exception:  # pragma: no cover — defensive
                 pass
 
     async def __aenter__(self) -> "Tracer":

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -123,12 +123,17 @@ class _OneShotSession:
         # ``await stream.result()`` pattern in cubepi.agent.loop.
         try:
             await stream.result()
-        except Exception:
-            # The producer's exception was already surfaced via the
-            # error event above (or the listener has recorded the error
-            # on the chat span). Swallow here so we report it uniformly
-            # via ``error_msg``.
-            pass
+        except Exception as result_exc:
+            # If we already captured an error event, the producer's
+            # exception is just the same failure expressed differently —
+            # swallow it and report uniformly via ``error_msg``. But if
+            # we got here on the success path (``done`` event consumed),
+            # the producer raised AFTER signalling done without emitting
+            # an error event, e.g. a custom provider bug. Surface that
+            # exception so the run is reported as failed instead of
+            # returning empty text.
+            if error_msg is None:
+                error_msg = str(result_exc) or "oneshot producer failed"
         if error_msg is not None:
             raise RuntimeError(error_msg)
         text = "".join(parts)

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -30,6 +30,57 @@ from cubepi.tracing.schema import SCHEMA_URL, SCOPE_NAME
 
 if TYPE_CHECKING:
     from cubepi.agent.agent import Agent
+    from cubepi.providers.base import BaseProvider, Message, Model
+
+
+class _OneShotSession:
+    """Returned by :meth:`Tracer.oneshot` to issue a single traced LLM call.
+
+    The session's provider listeners are live for the lifetime of the
+    ``async with tracer.oneshot(...)`` block.  Call :meth:`generate` once
+    inside that block to run the LLM and get the response text.
+    """
+
+    def __init__(
+        self,
+        provider: "BaseProvider",
+        model: "Model",
+        run: Any,
+    ) -> None:
+        self._provider = provider
+        self._model = model
+        self._run = run
+
+    async def generate(
+        self,
+        *,
+        system: str,
+        messages: "list[Message]",
+        max_output_tokens: int,
+    ) -> str:
+        """Run one non-tool-using completion and return the full text.
+
+        The provider listeners wired by :meth:`Tracer.oneshot` will record
+        a ``chat`` child span covering this call automatically.
+        """
+        # Seed transcript so record_content captures input messages.
+        self._run.transcript = list(messages)
+
+        model = self._model.model_copy(update={"max_tokens": max_output_tokens})
+        stream = await self._provider.stream(
+            model=model,
+            messages=messages,
+            system_prompt=system,
+        )
+        parts: list[str] = []
+        async for evt in stream:
+            if evt.type == "text_delta" and evt.delta:
+                parts.append(evt.delta)
+            elif evt.type == "error":
+                raise RuntimeError(evt.error_message or "oneshot generation failed")
+            elif evt.type == "done":
+                break
+        return "".join(parts)
 
 
 class Tracer:
@@ -330,6 +381,136 @@ class Tracer:
                         await result
                     except BaseException:
                         pass
+
+    @contextlib.asynccontextmanager
+    async def oneshot(
+        self,
+        *,
+        provider: "BaseProvider",
+        model: "Model",
+        operation: str = "oneshot",
+        metadata: "dict[str, str | int | float | bool] | None" = None,
+        record_content: bool | None = None,
+    ) -> AsyncIterator["_OneShotSession"]:
+        """Instrumented one-shot LLM call that produces a trace without a full Agent.
+
+        Creates an ``invoke_agent`` root span (so the ``cubepi trace`` CLI
+        indexes it alongside normal agent runs) and wires the provider's
+        listeners for the duration of the block, producing a ``chat`` child
+        span automatically when :meth:`_OneShotSession.generate` is called.
+
+        ``metadata`` keys are stamped as ``cubepi.metadata.<key>`` attributes on
+        the root span and are queryable with
+        ``cubepi trace ls --meta <key>=<value>``.
+
+        ``operation`` is recorded as ``cubepi.oneshot.operation`` to let
+        callers filter one-shot traces from agent runs in dashboards.
+
+        Example::
+
+            async with tracer.oneshot(
+                provider=provider,
+                model=model,
+                operation="consolidate_memory",
+                metadata={"conversation_id": conv_id, "user_id": user_id},
+            ) as session:
+                text = await session.generate(
+                    system=SYSTEM_PROMPT,
+                    messages=[UserMessage(...)],
+                    max_output_tokens=1500,
+                )
+        """
+        from opentelemetry.trace import SpanKind
+
+        from cubepi.providers.base import BaseProvider as _BaseProvider
+        from cubepi.tracing.recorder import Recorder, _RunState, _active_run
+        from cubepi.tracing.schema import (
+            CUBEPI_RUN_ID,
+            GEN_AI_OPERATION_NAME,
+            GEN_AI_PROVIDER_NAME,
+            OP_INVOKE_AGENT,
+            SPAN_NAME_INVOKE_AGENT,
+        )
+
+        do_record = record_content if record_content is not None else self._record_content
+        run_id = str(uuid.uuid4())
+
+        root_attrs: dict[str, Any] = {
+            GEN_AI_OPERATION_NAME: OP_INVOKE_AGENT,
+            CUBEPI_RUN_ID: run_id,
+            GEN_AI_PROVIDER_NAME: "cubepi",
+            "cubepi.oneshot.operation": operation,
+        }
+        for k, v in (metadata or {}).items():
+            try:
+                root_attrs[f"cubepi.metadata.{k}"] = v
+            except (TypeError, ValueError):
+                pass
+
+        root_span = self._otel_tracer.start_span(
+            name=SPAN_NAME_INVOKE_AGENT,
+            kind=SpanKind.INTERNAL,
+            attributes=root_attrs,
+        )
+
+        # _RunState with turn_span = root_span so chat spans nest directly
+        # under the root (no cubepi.turn wrapper — one-shot has no loop).
+        run = _RunState(
+            run_id=run_id,
+            agent_span=root_span,
+            turn_span=root_span,
+        )
+
+        # Minimal Recorder to handle the 3 provider lifecycle listeners.
+        # We don't subscribe agent events — there's no agent loop.
+        recorder = Recorder(
+            self,
+            record_content=do_record,
+            record_stream=self._record_stream,
+            stream_dir=self._stream_dir,
+            redact=self._redact,
+        )
+        recorder._run = run
+
+        detachers: list[Callable[[], None]] = []
+        if isinstance(provider, _BaseProvider):
+            try:
+                detachers.append(
+                    provider.subscribe_request(recorder._on_provider_request)
+                )
+                detachers.append(
+                    provider.subscribe_chunk(recorder._on_provider_chunk)
+                )
+                detachers.append(
+                    provider.subscribe_response(recorder._on_provider_response)
+                )
+            except BaseException:
+                root_span.end()
+                raise
+
+        # Set the per-task active-run gate so provider listeners recognise
+        # calls that belong to this oneshot session.
+        token = _active_run.set(run)
+        try:
+            yield _OneShotSession(provider=provider, model=model, run=run)
+        finally:
+            _active_run.reset(token)
+            for d in detachers:
+                try:
+                    d()
+                except Exception:
+                    pass
+            recorder._run = None
+            root_span.end()
+            # Best-effort flush — tracing must never break the caller's work.
+            try:
+                import asyncio
+
+                asyncio.get_running_loop().create_task(
+                    self.force_flush(timeout_seconds=5.0)
+                )
+            except RuntimeError:
+                pass
 
     async def __aenter__(self) -> "Tracer":
         return self

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -85,13 +85,33 @@ class _OneShotSession:
             system_prompt=system,
         )
         parts: list[str] = []
+        error_msg: str | None = None
         async for evt in stream:
             if evt.type == "text_delta" and evt.delta:
                 parts.append(evt.delta)
             elif evt.type == "error":
-                raise RuntimeError(evt.error_message or "oneshot generation failed")
+                error_msg = evt.error_message or "oneshot generation failed"
+                break
             elif evt.type == "done":
                 break
+        # Wait for the producer task to finish — its ``finally`` block
+        # invokes the response listeners (including the recorder's
+        # ``_on_provider_response`` that closes the chat span and records
+        # usage). Without this, breaking on ``done`` lets us race ahead
+        # and exit the oneshot context before the chat span is closed,
+        # so the cleanup sweep would mark it ``cubepi.aborted`` and the
+        # trace would be missing usage / response data. Mirrors the
+        # ``await stream.result()`` pattern in cubepi.agent.loop.
+        try:
+            await stream.result()
+        except Exception:
+            # The producer's exception was already surfaced via the
+            # error event above (or the listener has recorded the error
+            # on the chat span). Swallow here so we report it uniformly
+            # via ``error_msg``.
+            pass
+        if error_msg is not None:
+            raise RuntimeError(error_msg)
         text = "".join(parts)
         # Stash output as a single assistant message so the oneshot finally
         # block can stamp gen_ai.output.messages on the root span.

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -520,6 +520,21 @@ class Tracer:
         )
         recorder._run = run
 
+        # Open the per-run stream file when record_stream is enabled, so
+        # ``_on_provider_chunk`` writes ``<run_id>.stream.jsonl`` for the
+        # oneshot the same way the agent path does. Closed in the finally
+        # block below.
+        if self._record_stream and self._stream_dir is not None:
+            try:
+                import time as _time
+
+                self._stream_dir.mkdir(parents=True, exist_ok=True)
+                stream_path = self._stream_dir / f"{run_id}.stream.jsonl"
+                run.stream_file = stream_path.open("w", encoding="utf-8")
+                run.stream_start_time = _time.time()
+            except Exception:
+                pass
+
         detachers: list[Callable[[], None]] = []
         if isinstance(provider, _BaseProvider):
             try:
@@ -606,6 +621,14 @@ class Tracer:
                         )
                 except Exception:
                     pass
+            # Close the stream file opened above (mirrors the agent
+            # _on_agent_end / _close_open_spans path).
+            if run.stream_file is not None:
+                try:
+                    run.stream_file.close()
+                except Exception:
+                    pass
+                run.stream_file = None
             recorder._run = None
             root_span.end()
             # Flush synchronously so the trace is visible after the block.

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -442,6 +442,10 @@ class Tracer:
             CUBEPI_RUN_ID: run_id,
             GEN_AI_PROVIDER_NAME: "cubepi",
             "cubepi.oneshot.operation": operation,
+            # Also expose operation under cubepi.metadata.* so the
+            # `cubepi trace ls --meta oneshot_operation=...` filter works
+            # (the CLI's --meta filter only reads cubepi.metadata.* attrs).
+            "cubepi.metadata.oneshot_operation": operation,
         }
         for k, v in (metadata or {}).items():
             root_attrs[f"cubepi.metadata.{k}"] = v

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -514,9 +514,22 @@ class Tracer:
                     d()
                 except Exception:
                     pass
-            # Close any chat span left open by a cancelled/timed-out stream
-            # (mirrors Recorder._close_open_spans for the agent detach path).
-            recorder._close_open_spans(run)
+            # Close any chat span left open by a cancelled/timed-out stream.
+            # We don't reuse Recorder._close_open_spans because that helper
+            # also walks turn_span / agent_span — both of which point at
+            # root_span here, so it would mark a successful one-shot's root
+            # as aborted before we end it normally below. Tool spans don't
+            # exist for one-shot (no tool execution path).
+            if run.chat_span is not None:
+                try:
+                    from cubepi.tracing.schema import CUBEPI_ABORTED, ERROR_TYPE
+
+                    run.chat_span.set_attribute(CUBEPI_ABORTED, True)
+                    run.chat_span.set_attribute(ERROR_TYPE, "cubepi.aborted")
+                    run.chat_span.end()
+                except Exception:
+                    pass
+                run.chat_span = None
             recorder._run = None
             root_span.end()
             # Best-effort flush — tracing must never break the caller's work.

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -63,8 +63,20 @@ class _OneShotSession:
         The provider listeners wired by :meth:`Tracer.oneshot` will record
         a ``chat`` child span covering this call automatically.
         """
-        # Seed transcript so record_content captures input messages.
+        from cubepi.providers.base import (
+            AssistantMessage as _AssistantMessage,
+        )
+        from cubepi.providers.base import (
+            TextContent as _TextContent,
+        )
+
+        # Seed transcript so record_content captures input messages on the
+        # chat span, and stash system/input on the run so the oneshot
+        # finally block can also stamp them on the root invoke_agent span
+        # (no AgentEnd event fires here to do it automatically).
         self._run.transcript = list(messages)
+        self._run.input_messages = list(messages)
+        self._run.system_prompt = system
 
         model = self._model.model_copy(update={"max_tokens": max_output_tokens})
         stream = await self._provider.stream(
@@ -80,7 +92,14 @@ class _OneShotSession:
                 raise RuntimeError(evt.error_message or "oneshot generation failed")
             elif evt.type == "done":
                 break
-        return "".join(parts)
+        text = "".join(parts)
+        # Stash output as a single assistant message so the oneshot finally
+        # block can stamp gen_ai.output.messages on the root span.
+        if text:
+            self._run.output_messages = [
+                _AssistantMessage(content=[_TextContent(text=text)])
+            ]
+        return text
 
 
 class Tracer:
@@ -530,16 +549,52 @@ class Tracer:
                 except Exception:
                     pass
                 run.chat_span = None
+            # Stamp content on the root invoke_agent span. The agent path
+            # does this in Recorder._on_agent_end, which never fires for
+            # oneshot. Without it, ``cubepi trace ls`` shows a blank input
+            # column for one-shot traces because it reads
+            # ``gen_ai.input.messages`` off the root.
+            if do_record:
+                try:
+                    from cubepi.tracing.content import (
+                        messages_to_semconv,
+                        system_instructions_to_semconv,
+                    )
+                    from cubepi.tracing.schema import (
+                        GEN_AI_INPUT_MESSAGES,
+                        GEN_AI_OUTPUT_MESSAGES,
+                        GEN_AI_SYSTEM_INSTRUCTIONS,
+                    )
+
+                    if run.system_prompt:
+                        recorder._set_content_attr(
+                            root_span,
+                            GEN_AI_SYSTEM_INSTRUCTIONS,
+                            system_instructions_to_semconv(run.system_prompt),
+                        )
+                    if run.input_messages:
+                        recorder._set_content_attr(
+                            root_span,
+                            GEN_AI_INPUT_MESSAGES,
+                            messages_to_semconv(run.input_messages),
+                        )
+                    if run.output_messages:
+                        recorder._set_content_attr(
+                            root_span,
+                            GEN_AI_OUTPUT_MESSAGES,
+                            messages_to_semconv(run.output_messages),
+                        )
+                except Exception:
+                    pass
             recorder._run = None
             root_span.end()
-            # Best-effort flush — tracing must never break the caller's work.
+            # Flush synchronously so the trace is visible after the block.
+            # Unlike attach()'s detach, we have no detach Task to hand back
+            # to the caller — if we don't await here, a short-lived
+            # asyncio.run() can exit before the BatchSpanProcessor drains.
             try:
-                import asyncio
-
-                asyncio.get_running_loop().create_task(
-                    self.force_flush(timeout_seconds=5.0)
-                )
-            except RuntimeError:  # pragma: no cover — only fires outside an event loop
+                await self.force_flush(timeout_seconds=5.0)
+            except Exception:
                 pass
 
     async def __aenter__(self) -> "Tracer":

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -492,6 +492,13 @@ class Tracer:
                     provider.subscribe_response(recorder._on_provider_response)
                 )
             except BaseException:
+                # Unwind any partial subscriptions before re-raising so no
+                # dangling listeners are left on the provider.
+                for d in detachers:
+                    try:
+                        d()
+                    except Exception:
+                        pass
                 root_span.end()
                 raise
 
@@ -507,6 +514,9 @@ class Tracer:
                     d()
                 except Exception:
                     pass
+            # Close any chat span left open by a cancelled/timed-out stream
+            # (mirrors Recorder._close_open_spans for the agent detach path).
+            recorder._close_open_spans(run)
             recorder._run = None
             root_span.end()
             # Best-effort flush — tracing must never break the caller's work.

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -63,8 +63,13 @@ class _OneShotSession:
         The provider listeners wired by :meth:`Tracer.oneshot` will record
         a ``chat`` child span covering this call automatically.
         """
+        import asyncio as _asyncio
+
         from cubepi.providers.base import (
             AssistantMessage as _AssistantMessage,
+        )
+        from cubepi.providers.base import (
+            StreamOptions as _StreamOptions,
         )
         from cubepi.providers.base import (
             TextContent as _TextContent,
@@ -78,22 +83,36 @@ class _OneShotSession:
         self._run.input_messages = list(messages)
         self._run.system_prompt = system
 
+        # Cancellation signal forwarded to the provider so a cancelled
+        # consumer (e.g. asyncio.wait_for timeout) tears down the
+        # producer task instead of leaking it past the oneshot context.
+        # Mirrors the agent loop's ``StreamOptions(signal=...)`` use.
+        abort_signal = _asyncio.Event()
+
         model = self._model.model_copy(update={"max_tokens": max_output_tokens})
         stream = await self._provider.stream(
             model=model,
             messages=messages,
             system_prompt=system,
+            options=_StreamOptions(signal=abort_signal),
         )
         parts: list[str] = []
         error_msg: str | None = None
-        async for evt in stream:
-            if evt.type == "text_delta" and evt.delta:
-                parts.append(evt.delta)
-            elif evt.type == "error":
-                error_msg = evt.error_message or "oneshot generation failed"
-                break
-            elif evt.type == "done":
-                break
+        try:
+            async for evt in stream:
+                if evt.type == "text_delta" and evt.delta:
+                    parts.append(evt.delta)
+                elif evt.type == "error":
+                    error_msg = evt.error_message or "oneshot generation failed"
+                    break
+                elif evt.type == "done":
+                    break
+        except BaseException:
+            # On cancellation/timeout, tell the producer to stop so it
+            # doesn't keep running after we exit. ``stream.result()``
+            # below then surfaces the (now-completed) producer's state.
+            abort_signal.set()
+            raise
         # Wait for the producer task to finish — its ``finally`` block
         # invokes the response listeners (including the recorder's
         # ``_on_provider_response`` that closes the chat span and records

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -580,6 +580,30 @@ class Tracer:
         token = _active_run.set(run)
         try:
             yield _OneShotSession(provider=provider, model=model, run=run)
+        except BaseException as _exc:
+            # Mark the root span as failed so `cubepi trace ls` (which
+            # reads status off the root) lists this run as an error
+            # instead of a successful invoke_agent. Mirrors what the
+            # agent path does on turn-level errors. Cancellation is
+            # tracked as cubepi.aborted (UNSET status, semconv-aligned)
+            # rather than ERROR.
+            try:
+                from opentelemetry.trace import Status, StatusCode
+
+                from cubepi.tracing.schema import CUBEPI_ABORTED, ERROR_TYPE
+
+                import asyncio as _asyncio_for_cancel
+
+                if isinstance(_exc, _asyncio_for_cancel.CancelledError):
+                    root_span.set_attribute(CUBEPI_ABORTED, True)
+                    root_span.set_attribute(ERROR_TYPE, "cubepi.aborted")
+                else:
+                    root_span.set_status(Status(StatusCode.ERROR, str(_exc)[:256]))
+                    root_span.set_attribute(ERROR_TYPE, type(_exc).__name__)
+                root_span.record_exception(_exc)
+            except Exception:
+                pass
+            raise
         finally:
             _active_run.reset(token)
             for d in detachers:

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -432,7 +432,9 @@ class Tracer:
             SPAN_NAME_INVOKE_AGENT,
         )
 
-        do_record = record_content if record_content is not None else self._record_content
+        do_record = (
+            record_content if record_content is not None else self._record_content
+        )
         run_id = str(uuid.uuid4())
 
         root_attrs: dict[str, Any] = {
@@ -478,9 +480,7 @@ class Tracer:
                 detachers.append(
                     provider.subscribe_request(recorder._on_provider_request)
                 )
-                detachers.append(
-                    provider.subscribe_chunk(recorder._on_provider_chunk)
-                )
+                detachers.append(provider.subscribe_chunk(recorder._on_provider_chunk))
                 detachers.append(
                     provider.subscribe_response(recorder._on_provider_response)
                 )

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -403,8 +403,14 @@ class Tracer:
         the root span and are queryable with
         ``cubepi trace ls --meta <key>=<value>``.
 
-        ``operation`` is recorded as ``cubepi.oneshot.operation`` to let
-        callers filter one-shot traces from agent runs in dashboards.
+        ``operation`` is recorded in two places:
+
+        - ``cubepi.oneshot.operation`` — for span introspection and dashboards.
+        - ``cubepi.metadata.oneshot_operation`` — so the CLI ``--meta`` filter
+          (which only reads ``cubepi.metadata.*`` attributes) can reach it::
+
+              uv run cubepi trace ls --meta oneshot_operation=consolidate_memory
+              uv run cubepi trace ls --meta conversation_id=conv-123
 
         Example::
 

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -444,10 +444,7 @@ class Tracer:
             "cubepi.oneshot.operation": operation,
         }
         for k, v in (metadata or {}).items():
-            try:
-                root_attrs[f"cubepi.metadata.{k}"] = v
-            except (TypeError, ValueError):
-                pass
+            root_attrs[f"cubepi.metadata.{k}"] = v
 
         root_span = self._otel_tracer.start_span(
             name=SPAN_NAME_INVOKE_AGENT,
@@ -509,7 +506,7 @@ class Tracer:
                 asyncio.get_running_loop().create_task(
                     self.force_flush(timeout_seconds=5.0)
                 )
-            except RuntimeError:
+            except RuntimeError:  # pragma: no cover — only fires outside an event loop
                 pass
 
     async def __aenter__(self) -> "Tracer":

--- a/skills/cubepi-trace/SKILL.md
+++ b/skills/cubepi-trace/SKILL.md
@@ -20,6 +20,9 @@ token/cache counts. Reach for this **before** guessing at a bug.
   `error`.
 - Token / cache / cost numbers look wrong.
 - You just need to understand the agent's actual trajectory for a given input.
+- A background LLM call (e.g. memory consolidation via `Tracer.oneshot()`) isn't
+  behaving as expected — oneshot calls produce `invoke_agent` spans too and are
+  searchable by metadata.
 
 ## Prerequisites (one-time)
 
@@ -118,6 +121,52 @@ uv run cubepi trace stats --by model --meta user_id=usr_9
 
 # Show metadata as ls columns (display, not filter):
 uv run cubepi trace ls --show-meta conversation_id,user_id
+```
+
+## Tracing one-shot LLM calls (`Tracer.oneshot`)
+
+`Tracer.oneshot()` instruments a single prompt→text LLM call (no agent loop)
+and writes it as a full `invoke_agent` trace. Cubebox uses this for background
+tasks like memory consolidation. The span tree is flat — no `cubepi.turn`
+wrapper since there's no loop:
+
+```
+trace
+└── invoke_agent  820ms  [0x3f2a1b...]
+    └── chat deepseek-v3  815ms  tok 3200/180  [0x9c45d2...]
+```
+
+The root span carries:
+- `cubepi.oneshot.operation` — the operation name (e.g. `"consolidate_memory"`)
+- `cubepi.metadata.*` — caller-supplied metadata (e.g. `conversation_id`)
+
+Find oneshot traces by operation or conversation:
+
+```bash
+# All consolidation runs
+uv run cubepi trace ls --meta cubepi.oneshot.operation=consolidate_memory
+
+# Oneshot traces for a specific conversation (alongside its agent runs)
+uv run cubepi trace ls --meta conversation_id=conv-1fwZQ8u3ZDukx3
+
+# Stats on consolidation token usage
+uv run cubepi trace stats --by model --meta cubepi.oneshot.operation=consolidate_memory
+```
+
+Cubebox wires this in `run_manager.py`; the consolidation pass calls:
+
+```python
+async with tracer.oneshot(
+    provider=provider,
+    model=model,
+    operation="consolidate_memory",
+    metadata={"conversation_id": conv_id, "user_id": user_id},
+) as session:
+    raw = await session.generate(
+        system=CONSOLIDATION_SYSTEM,
+        messages=[UserMessage(...)],
+        max_output_tokens=1500,
+    )
 ```
 
 ## Replaying a failing LLM call (`trace convert`)

--- a/skills/cubepi-trace/SKILL.md
+++ b/skills/cubepi-trace/SKILL.md
@@ -143,14 +143,15 @@ The root span carries:
 Find oneshot traces by operation or conversation:
 
 ```bash
-# All consolidation runs
-uv run cubepi trace ls --meta cubepi.oneshot.operation=consolidate_memory
+# All consolidation runs  (operation is exposed as cubepi.metadata.oneshot_operation
+# so the --meta filter can reach it; cubepi.oneshot.operation is also set for dashboards)
+uv run cubepi trace ls --meta oneshot_operation=consolidate_memory
 
 # Oneshot traces for a specific conversation (alongside its agent runs)
 uv run cubepi trace ls --meta conversation_id=conv-1fwZQ8u3ZDukx3
 
 # Stats on consolidation token usage
-uv run cubepi trace stats --by model --meta cubepi.oneshot.operation=consolidate_memory
+uv run cubepi trace stats --by model --meta oneshot_operation=consolidate_memory
 ```
 
 Cubebox wires this in `run_manager.py`; the consolidation pass calls:

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -1,0 +1,224 @@
+"""Tests for Tracer.oneshot() — instrumented one-shot LLM calls."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from cubepi.providers.base import Model, TextContent, UserMessage
+from cubepi.providers.faux import FauxProvider, faux_assistant_message
+from cubepi.tracing import Tracer
+from cubepi.tracing.tracer import _OneShotSession
+
+
+MODEL = Model(id="faux-1", provider="faux")
+
+
+class InMemoryExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans: Any) -> SpanExportResult:
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+def _make_tracer(*, record_content: bool = False) -> tuple[Tracer, InMemoryExporter]:
+    exporter = InMemoryExporter()
+    tracer = Tracer(
+        exporters=[exporter],
+        record_content=record_content,
+        atexit_flush=False,
+    )
+    return tracer, exporter
+
+
+def _spans_by_name(spans: list[ReadableSpan]) -> dict[str, ReadableSpan]:
+    result: dict[str, ReadableSpan] = {}
+    for s in spans:
+        result[s.name] = s
+    return result
+
+
+@pytest.mark.asyncio
+async def test_oneshot_session_type() -> None:
+    provider = FauxProvider()
+    tracer, _ = _make_tracer()
+    async with tracer.oneshot(provider=provider, model=MODEL) as session:
+        assert isinstance(session, _OneShotSession)
+    await tracer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_oneshot_produces_root_and_chat_spans() -> None:
+    provider = FauxProvider()
+    provider.append_responses([faux_assistant_message("hello world")])
+    tracer, exporter = _make_tracer()
+
+    async with tracer.oneshot(
+        provider=provider,
+        model=MODEL,
+        operation="test_op",
+        metadata={"conversation_id": "conv-123", "user_id": "usr-456"},
+    ) as session:
+        text = await session.generate(
+            system="You are helpful.",
+            messages=[UserMessage(content=[TextContent(text="hi")])],
+            max_output_tokens=100,
+        )
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    assert text == "hello world"
+
+    by_name = _spans_by_name(exporter.spans)
+    assert "invoke_agent" in by_name, f"spans: {[s.name for s in exporter.spans]}"
+    assert f"chat {MODEL.id}" in by_name
+
+    root = by_name["invoke_agent"]
+    attrs = dict(root.attributes or {})
+    assert attrs.get("gen_ai.operation.name") == "invoke_agent"
+    assert attrs.get("cubepi.oneshot.operation") == "test_op"
+    assert attrs.get("cubepi.metadata.conversation_id") == "conv-123"
+    assert attrs.get("cubepi.metadata.user_id") == "usr-456"
+    assert "cubepi.run_id" in attrs
+
+    chat = by_name[f"chat {MODEL.id}"]
+    # chat span must be a child of root
+    assert chat.parent is not None
+    assert chat.parent.span_id == root.context.span_id
+
+    # token counts recorded
+    chat_attrs = dict(chat.attributes or {})
+    assert "gen_ai.usage.input_tokens" in chat_attrs
+    assert "gen_ai.usage.output_tokens" in chat_attrs
+
+
+@pytest.mark.asyncio
+async def test_oneshot_metadata_on_root_span() -> None:
+    provider = FauxProvider()
+    provider.append_responses([faux_assistant_message("ok")])
+    tracer, exporter = _make_tracer()
+
+    async with tracer.oneshot(
+        provider=provider,
+        model=MODEL,
+        operation="consolidate_memory",
+        metadata={"conversation_id": "conv-abc"},
+    ) as session:
+        await session.generate(
+            system="sys",
+            messages=[UserMessage(content=[TextContent(text="x")])],
+            max_output_tokens=50,
+        )
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    roots = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert len(roots) == 1
+    attrs = dict(roots[0].attributes or {})
+    assert attrs["cubepi.oneshot.operation"] == "consolidate_memory"
+    assert attrs["cubepi.metadata.conversation_id"] == "conv-abc"
+
+
+@pytest.mark.asyncio
+async def test_oneshot_no_metadata_ok() -> None:
+    provider = FauxProvider()
+    provider.append_responses([faux_assistant_message("result")])
+    tracer, exporter = _make_tracer()
+
+    async with tracer.oneshot(provider=provider, model=MODEL) as session:
+        text = await session.generate(
+            system="sys",
+            messages=[UserMessage(content=[TextContent(text="q")])],
+            max_output_tokens=10,
+        )
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    assert text == "result"
+    assert any(s.name == "invoke_agent" for s in exporter.spans)
+
+
+@pytest.mark.asyncio
+async def test_oneshot_record_content_captures_messages() -> None:
+    provider = FauxProvider()
+    provider.append_responses([faux_assistant_message("answer")])
+    tracer, exporter = _make_tracer(record_content=True)
+
+    async with tracer.oneshot(
+        provider=provider,
+        model=MODEL,
+        record_content=True,
+    ) as session:
+        await session.generate(
+            system="be helpful",
+            messages=[UserMessage(content=[TextContent(text="question")])],
+            max_output_tokens=50,
+        )
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    chat_spans = [s for s in exporter.spans if s.name.startswith("chat")]
+    assert chat_spans, "expected a chat span"
+    attrs = dict(chat_spans[0].attributes or {})
+    # With record_content=True the system instructions are recorded on the chat span
+    assert "gen_ai.system_instructions" in attrs
+
+
+@pytest.mark.asyncio
+async def test_oneshot_does_not_interfere_with_concurrent_agent() -> None:
+    """Oneshot's active-run gate must not bleed into a concurrent Agent run."""
+    import asyncio
+
+    from cubepi.agent.agent import Agent
+
+    provider = FauxProvider()
+    # Push responses for both agent and oneshot
+    provider.append_responses([faux_assistant_message("agent reply")])
+    provider.append_responses([faux_assistant_message("oneshot reply")])
+
+    tracer, exporter = _make_tracer()
+    agent = Agent(provider=provider, model=MODEL, system_prompt="sys")
+    detach = tracer.attach(agent)
+
+    # Run agent and oneshot concurrently
+    async def run_agent() -> str:
+        await agent.prompt("agent question")
+        return str(agent.state.messages[-1].content[0].text)  # type: ignore[index]
+
+    async def run_oneshot() -> str:
+        async with tracer.oneshot(provider=provider, model=MODEL) as session:
+            return await session.generate(
+                system="sys",
+                messages=[UserMessage(content=[TextContent(text="oneshot q")])],
+                max_output_tokens=50,
+            )
+
+    agent_result, oneshot_result = await asyncio.gather(run_agent(), run_oneshot())
+
+    result = detach()
+    if result is not None:
+        await result
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    assert "agent reply" in agent_result or "oneshot reply" in agent_result
+    assert "agent reply" in oneshot_result or "oneshot reply" in oneshot_result
+
+    # Both runs should produce an invoke_agent span
+    roots = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert len(roots) == 2

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -197,12 +197,15 @@ async def test_oneshot_record_content_captures_messages() -> None:
 
 
 @pytest.mark.asyncio
-async def test_oneshot_generate_error_event_raises() -> None:
-    """generate() propagates RuntimeError when the stream emits an error event."""
+async def test_oneshot_generate_error_event_raises_and_marks_root() -> None:
+    """generate() propagates RuntimeError on a stream error event AND marks
+    the root invoke_agent span with ERROR status so `cubepi trace ls` shows
+    the run as failed instead of as a successful invoke_agent."""
+    from opentelemetry.trace import StatusCode
     from unittest.mock import AsyncMock, MagicMock, patch
 
     provider = FauxProvider()
-    tracer, _ = _make_tracer()
+    tracer, exporter = _make_tracer()
 
     # Patch provider.stream to yield an error event
     error_stream = MagicMock()
@@ -220,7 +223,15 @@ async def test_oneshot_generate_error_event_raises() -> None:
                     max_output_tokens=10,
                 )
 
+    await tracer.force_flush()
     await tracer.shutdown()
+
+    roots = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert len(roots) == 1
+    root = roots[0]
+    assert root.status.status_code == StatusCode.ERROR
+    attrs = dict(root.attributes or {})
+    assert attrs.get("error.type") == "RuntimeError"
 
 
 @pytest.mark.asyncio
@@ -448,9 +459,14 @@ async def test_oneshot_cancelled_generate_closes_chat_span() -> None:
     await tracer.force_flush()
     await tracer.shutdown()
 
-    # Root span must be exported; chat span if opened must also be ended
+    # Root span must be exported; chat span if opened must also be ended.
+    # Cancellation is tracked as cubepi.aborted (not StatusCode.ERROR),
+    # matching the agent path's contract.
     roots = [s for s in exporter.spans if s.name == "invoke_agent"]
     assert len(roots) == 1
+    attrs = dict(roots[0].attributes or {})
+    assert attrs.get("cubepi.aborted") is True
+    assert attrs.get("error.type") == "cubepi.aborted"
 
 
 @pytest.mark.asyncio

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -94,6 +94,9 @@ async def test_oneshot_produces_root_and_chat_spans() -> None:
     assert attrs.get("cubepi.metadata.conversation_id") == "conv-123"
     assert attrs.get("cubepi.metadata.user_id") == "usr-456"
     assert "cubepi.run_id" in attrs
+    # Successful one-shot must NOT be marked aborted by the cleanup sweeper.
+    assert attrs.get("cubepi.aborted") is None
+    assert attrs.get("error.type") is None
 
     chat = by_name[f"chat {MODEL.id}"]
     # chat span must be a child of root

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -89,6 +89,8 @@ async def test_oneshot_produces_root_and_chat_spans() -> None:
     attrs = dict(root.attributes or {})
     assert attrs.get("gen_ai.operation.name") == "invoke_agent"
     assert attrs.get("cubepi.oneshot.operation") == "test_op"
+    # operation also exposed under cubepi.metadata.* for --meta CLI filter
+    assert attrs.get("cubepi.metadata.oneshot_operation") == "test_op"
     assert attrs.get("cubepi.metadata.conversation_id") == "conv-123"
     assert attrs.get("cubepi.metadata.user_id") == "usr-456"
     assert "cubepi.run_id" in attrs

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -264,6 +264,92 @@ async def test_oneshot_detacher_exception_is_swallowed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_oneshot_partial_subscribe_failure_unwinds_listeners() -> None:
+    """If subscribe_chunk raises after subscribe_request succeeded, the first
+    listener must be unsubscribed before re-raising (no dangling listeners)."""
+    from unittest.mock import patch
+
+    provider = FauxProvider()
+    tracer, exporter = _make_tracer()
+
+    # Track how many listeners were subscribed / detached
+    subscribed: list[str] = []
+    detached: list[str] = []
+    original_sub_req = provider.subscribe_request
+
+    def patched_sub_req(cb):
+        subscribed.append("request")
+        real_unsub = original_sub_req(cb)
+
+        def counting_unsub():
+            detached.append("request")
+            real_unsub()
+
+        return counting_unsub
+
+    with (
+        patch.object(provider, "subscribe_request", side_effect=patched_sub_req),
+        patch.object(
+            provider, "subscribe_chunk", side_effect=RuntimeError("chunk sub failed")
+        ),
+        pytest.raises(RuntimeError, match="chunk sub failed"),
+    ):
+        async with tracer.oneshot(provider=provider, model=MODEL):
+            pass  # pragma: no cover
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    # subscribe_request succeeded; its detacher must have been called on cleanup
+    assert "request" in subscribed
+    assert "request" in detached
+
+    # Root span must still be exported despite the error
+    roots = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert len(roots) == 1
+
+
+@pytest.mark.asyncio
+async def test_oneshot_cancelled_generate_closes_chat_span() -> None:
+    """If generate() is cancelled mid-stream, the chat span must be closed."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    provider = FauxProvider()
+    tracer, exporter = _make_tracer()
+
+    # A stream that never yields (blocks forever) so we can cancel it
+    async def hanging_stream():
+        await asyncio.sleep(60)
+        yield  # pragma: no cover
+
+    hanging = MagicMock()
+    hanging.__aiter__ = lambda self: hanging_stream()
+
+    async def do_work():
+        async with tracer.oneshot(provider=provider, model=MODEL) as session:
+            with patch.object(provider, "stream", new=AsyncMock(return_value=hanging)):
+                await session.generate(
+                    system="sys",
+                    messages=[UserMessage(content=[TextContent(text="q")])],
+                    max_output_tokens=10,
+                )
+
+    task = asyncio.create_task(do_work())
+    await asyncio.sleep(0.05)  # let the task reach generate()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    # Root span must be exported; chat span if opened must also be ended
+    roots = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert len(roots) == 1
+
+
+@pytest.mark.asyncio
 async def test_oneshot_does_not_interfere_with_concurrent_agent() -> None:
     """Oneshot's active-run gate must not bleed into a concurrent Agent run."""
     import asyncio

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -279,6 +279,42 @@ async def test_oneshot_detacher_exception_is_swallowed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_oneshot_record_stream_writes_jsonl(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """When record_stream is on, oneshot must open a per-run stream.jsonl
+    so _on_provider_chunk can write the same per-chunk log as the agent path."""
+    exporter = InMemoryExporter()
+    tracer = Tracer(
+        exporters=[exporter],
+        record_stream=True,
+        stream_dir=str(tmp_path),
+        atexit_flush=False,
+    )
+
+    provider = FauxProvider()
+    provider.append_responses([faux_assistant_message("streamed text")])
+
+    async with tracer.oneshot(provider=provider, model=MODEL) as session:
+        text = await session.generate(
+            system="sys",
+            messages=[UserMessage(content=[TextContent(text="hi")])],
+            max_output_tokens=20,
+        )
+
+    await tracer.shutdown()
+
+    assert text == "streamed text"
+    stream_files = list(tmp_path.glob("*.stream.jsonl"))
+    assert len(stream_files) == 1, f"expected one stream file, got {stream_files}"
+    content = stream_files[0].read_text(encoding="utf-8").strip()
+    assert content, "stream file should have at least one event"
+    # The file should be one JSON object per line — sanity-check parse
+    import json
+
+    for line in content.splitlines():
+        json.loads(line)
+
+
+@pytest.mark.asyncio
 async def test_oneshot_partial_subscribe_failure_unwinds_listeners() -> None:
     """If subscribe_chunk raises after subscribe_request succeeded, the first
     listener must be unsubscribed before re-raising (no dangling listeners)."""

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -183,6 +183,18 @@ async def test_oneshot_record_content_captures_messages() -> None:
     # With record_content=True the system instructions are recorded on the chat span
     assert "gen_ai.system_instructions" in attrs
 
+    # The root invoke_agent span must also carry input/output/system so that
+    # `cubepi trace ls` (which reads gen_ai.input.messages off the root) can
+    # show the prompt in its input column.
+    root_spans = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert root_spans, "expected a root invoke_agent span"
+    root_attrs = dict(root_spans[0].attributes or {})
+    assert "gen_ai.system_instructions" in root_attrs
+    assert "gen_ai.input.messages" in root_attrs
+    assert "gen_ai.output.messages" in root_attrs
+    assert "question" in root_attrs["gen_ai.input.messages"]
+    assert "answer" in root_attrs["gen_ai.output.messages"]
+
 
 @pytest.mark.asyncio
 async def test_oneshot_generate_error_event_raises() -> None:

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -242,7 +242,7 @@ async def test_oneshot_detacher_exception_is_swallowed() -> None:
     original_subscribe = provider.subscribe_request
 
     def patched_subscribe(cb):
-        unsub = original_subscribe(cb)
+        original_subscribe(cb)
 
         def raising_detach():
             raise RuntimeError("detach failed")

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -180,6 +180,88 @@ async def test_oneshot_record_content_captures_messages() -> None:
 
 
 @pytest.mark.asyncio
+async def test_oneshot_generate_error_event_raises() -> None:
+    """generate() propagates RuntimeError when the stream emits an error event."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    provider = FauxProvider()
+    tracer, _ = _make_tracer()
+
+    # Patch provider.stream to yield an error event
+    error_stream = MagicMock()
+
+    async def _gen():
+        yield MagicMock(type="error", error_message="boom", delta=None)
+
+    error_stream.__aiter__ = lambda self: _gen()
+    with patch.object(provider, "stream", new=AsyncMock(return_value=error_stream)):
+        with pytest.raises(RuntimeError, match="boom"):
+            async with tracer.oneshot(provider=provider, model=MODEL) as session:
+                await session.generate(
+                    system="sys",
+                    messages=[UserMessage(content=[TextContent(text="q")])],
+                    max_output_tokens=10,
+                )
+
+    await tracer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_oneshot_subscribe_failure_raises_and_ends_root_span() -> None:
+    """If provider subscription raises, oneshot re-raises and ends the root span."""
+    from unittest.mock import patch
+
+    provider = FauxProvider()
+    tracer, exporter = _make_tracer()
+
+    with patch.object(
+        provider, "subscribe_request", side_effect=RuntimeError("subscribe failed")
+    ):
+        with pytest.raises(RuntimeError, match="subscribe failed"):
+            async with tracer.oneshot(provider=provider, model=MODEL):
+                pass  # pragma: no cover — never reached
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    # Root span must have been ended even though subscribe raised
+    roots = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert len(roots) == 1
+
+
+@pytest.mark.asyncio
+async def test_oneshot_detacher_exception_is_swallowed() -> None:
+    """Detach errors during cleanup must not propagate to the caller."""
+    from unittest.mock import patch
+
+    provider = FauxProvider()
+    provider.append_responses([faux_assistant_message("ok")])
+    tracer, _ = _make_tracer()
+
+    # Make subscribe_request return a detacher that raises on call
+    original_subscribe = provider.subscribe_request
+
+    def patched_subscribe(cb):
+        unsub = original_subscribe(cb)
+
+        def raising_detach():
+            raise RuntimeError("detach failed")
+
+        return raising_detach
+
+    with patch.object(provider, "subscribe_request", side_effect=patched_subscribe):
+        async with tracer.oneshot(provider=provider, model=MODEL) as session:
+            text = await session.generate(
+                system="sys",
+                messages=[UserMessage(content=[TextContent(text="q")])],
+                max_output_tokens=10,
+            )
+
+    await tracer.shutdown()
+    assert text == "ok"
+
+
+@pytest.mark.asyncio
 async def test_oneshot_does_not_interfere_with_concurrent_agent() -> None:
     """Oneshot's active-run gate must not bleed into a concurrent Agent run."""
     import asyncio

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -235,6 +235,48 @@ async def test_oneshot_generate_error_event_raises_and_marks_root() -> None:
 
 
 @pytest.mark.asyncio
+async def test_oneshot_propagates_silent_producer_failure() -> None:
+    """If the producer task fails AFTER emitting done (without an explicit
+    error event), generate() must still raise — not return empty text and
+    leave the root span marked successful."""
+    from opentelemetry.trace import StatusCode
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    provider = FauxProvider()
+    tracer, exporter = _make_tracer()
+
+    # Build a stream that emits done normally but whose result() raises
+    fake_stream = MagicMock()
+
+    async def _events():
+        yield MagicMock(type="done", delta=None, error_message=None)
+
+    fake_stream.__aiter__ = lambda self: _events()
+
+    async def failing_result():
+        raise RuntimeError("producer crashed after done")
+
+    fake_stream.result = failing_result
+
+    with patch.object(provider, "stream", new=AsyncMock(return_value=fake_stream)):
+        with pytest.raises(RuntimeError, match="producer crashed"):
+            async with tracer.oneshot(provider=provider, model=MODEL) as session:
+                await session.generate(
+                    system="sys",
+                    messages=[UserMessage(content=[TextContent(text="q")])],
+                    max_output_tokens=10,
+                )
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    roots = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert len(roots) == 1
+    # Root must be marked ERROR (not silently successful)
+    assert roots[0].status.status_code == StatusCode.ERROR
+
+
+@pytest.mark.asyncio
 async def test_oneshot_subscribe_failure_raises_and_ends_root_span() -> None:
     """If provider subscription raises, oneshot re-raises and ends the root span."""
     from unittest.mock import patch

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -581,6 +581,44 @@ async def test_oneshot_cancelled_generate_closes_chat_span() -> None:
 
 
 @pytest.mark.asyncio
+async def test_oneshot_cancel_mid_stream_marks_open_chat_span_aborted() -> None:
+    """When cancellation happens after the chat span has been opened by the
+    provider request listener but before the response listener has closed
+    it, the oneshot cleanup must close it and stamp cubepi.aborted."""
+    import asyncio
+
+    # Slow provider: streams the response one token at a time so we can
+    # cancel mid-stream (after _on_provider_request has fired).
+    provider = FauxProvider(tokens_per_second=5.0)
+    provider.append_responses([faux_assistant_message("a b c d e f g h")])
+    tracer, exporter = _make_tracer()
+
+    async def do_work():
+        async with tracer.oneshot(provider=provider, model=MODEL) as session:
+            await session.generate(
+                system="sys",
+                messages=[UserMessage(content=[TextContent(text="q")])],
+                max_output_tokens=50,
+            )
+
+    task = asyncio.create_task(do_work())
+    await asyncio.sleep(0.15)  # let chunks start, chat span opens
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    # Chat span must have been ended with cubepi.aborted=true
+    chat_spans = [s for s in exporter.spans if s.name.startswith("chat ")]
+    assert chat_spans, "expected at least one chat span (opened by request listener)"
+    chat_attrs = dict(chat_spans[0].attributes or {})
+    assert chat_attrs.get("cubepi.aborted") is True
+    assert chat_attrs.get("error.type") == "cubepi.aborted"
+
+
+@pytest.mark.asyncio
 async def test_oneshot_does_not_interfere_with_concurrent_agent() -> None:
     """Oneshot's active-run gate must not bleed into a concurrent Agent run."""
     import asyncio

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -138,6 +138,37 @@ async def test_oneshot_metadata_on_root_span() -> None:
 
 
 @pytest.mark.asyncio
+async def test_oneshot_user_metadata_cannot_shadow_reserved_oneshot_operation() -> None:
+    """If a caller's metadata dict includes 'oneshot_operation', the value
+    derived from the operation argument must still win — the documented
+    `cubepi trace ls --meta oneshot_operation=<op>` filter depends on it."""
+    provider = FauxProvider()
+    provider.append_responses([faux_assistant_message("ok")])
+    tracer, exporter = _make_tracer()
+
+    async with tracer.oneshot(
+        provider=provider,
+        model=MODEL,
+        operation="real_op",
+        metadata={"oneshot_operation": "user_supplied_value"},
+    ) as session:
+        await session.generate(
+            system="sys",
+            messages=[UserMessage(content=[TextContent(text="q")])],
+            max_output_tokens=10,
+        )
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    roots = [s for s in exporter.spans if s.name == "invoke_agent"]
+    assert len(roots) == 1
+    attrs = dict(roots[0].attributes or {})
+    assert attrs["cubepi.metadata.oneshot_operation"] == "real_op"
+    assert attrs["cubepi.oneshot.operation"] == "real_op"
+
+
+@pytest.mark.asyncio
 async def test_oneshot_no_metadata_ok() -> None:
     provider = FauxProvider()
     provider.append_responses([faux_assistant_message("result")])
@@ -232,6 +263,44 @@ async def test_oneshot_generate_error_event_raises_and_marks_root() -> None:
     assert root.status.status_code == StatusCode.ERROR
     attrs = dict(root.attributes or {})
     assert attrs.get("error.type") == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_oneshot_subscribe_failure_closes_stream_file(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A subscription failure on the pre-yield path must close any per-run
+    stream file that was already opened, so record_stream mode doesn't leak
+    file descriptors on this error path."""
+    from unittest.mock import patch
+
+    exporter = InMemoryExporter()
+    tracer = Tracer(
+        exporters=[exporter],
+        record_stream=True,
+        stream_dir=str(tmp_path),
+        atexit_flush=False,
+    )
+
+    provider = FauxProvider()
+
+    with patch.object(
+        provider, "subscribe_chunk", side_effect=RuntimeError("chunk sub failed")
+    ):
+        with pytest.raises(RuntimeError, match="chunk sub failed"):
+            async with tracer.oneshot(provider=provider, model=MODEL):
+                pass  # pragma: no cover
+
+    await tracer.shutdown()
+
+    # File was created and then closed; it should be a closed handle, not
+    # a leaked open one. We can't directly inspect FD state, but writing
+    # via run.stream_file would have failed; instead assert the file
+    # exists and is empty/parseable (no events written before failure).
+    stream_files = list(tmp_path.glob("*.stream.jsonl"))
+    assert len(stream_files) == 1
+    # File must be closed and finite-size (no leak symptom: pending writes
+    # buffered indefinitely or unable-to-stat). On Linux this is a basic
+    # sanity check.
+    assert stream_files[0].stat().st_size == 0
 
 
 @pytest.mark.asyncio

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -279,6 +279,59 @@ async def test_oneshot_detacher_exception_is_swallowed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_oneshot_passes_signal_to_provider_and_sets_on_cancel() -> None:
+    """generate() must forward a StreamOptions.signal so a cancellation in
+    the consumer tears the producer task down too."""
+    import asyncio
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from cubepi.providers.base import StreamOptions
+
+    provider = FauxProvider()
+    tracer, _ = _make_tracer()
+
+    captured_options: dict[str, StreamOptions | None] = {"opts": None}
+
+    async def hanging_stream():
+        # Never yields, simulating a long provider call
+        await asyncio.sleep(60)
+        yield  # pragma: no cover
+
+    hanging = MagicMock()
+    hanging.__aiter__ = lambda self: hanging_stream()
+
+    real_stream = AsyncMock(return_value=hanging)
+
+    async def patched_stream(**kwargs):
+        captured_options["opts"] = kwargs.get("options")
+        return await real_stream(**kwargs)
+
+    async def do_work():
+        async with tracer.oneshot(provider=provider, model=MODEL) as session:
+            with patch.object(provider, "stream", new=patched_stream):
+                await session.generate(
+                    system="sys",
+                    messages=[UserMessage(content=[TextContent(text="q")])],
+                    max_output_tokens=10,
+                )
+
+    task = asyncio.create_task(do_work())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await tracer.shutdown()
+
+    # The provider received options with a signal Event…
+    opts = captured_options["opts"]
+    assert opts is not None
+    assert opts.signal is not None
+    # …and the signal was set when the consumer was cancelled.
+    assert opts.signal.is_set()
+
+
+@pytest.mark.asyncio
 async def test_oneshot_record_stream_writes_jsonl(tmp_path) -> None:  # type: ignore[no-untyped-def]
     """When record_stream is on, oneshot must open a per-run stream.jsonl
     so _on_provider_chunk can write the same per-chunk log as the agent path."""

--- a/website/docs/guides/tracing/cli.md
+++ b/website/docs/guides/tracing/cli.md
@@ -47,6 +47,15 @@ cubepi trace ls --meta conversation_id=conv_123
 cubepi trace ls --meta user_id=usr_9 --meta org_id=org_1   # repeatable = AND, exact match
 ```
 
+Traces produced by [`Tracer.oneshot()`](../../api/cubepi-tracing#tracer-oneshot)
+(background LLM calls without a full agent loop) are also indexed here. Filter
+them by the `operation` name passed to `oneshot()`:
+
+```bash
+cubepi trace ls --meta oneshot_operation=consolidate_memory
+cubepi trace stats --by model --meta oneshot_operation=consolidate_memory
+```
+
 Each `--meta KEY=VALUE` is matched exactly against the trace's root metadata;
 repeating the flag ANDs the conditions.
 

--- a/website/docs/guides/tracing/getting-started.md
+++ b/website/docs/guides/tracing/getting-started.md
@@ -225,6 +225,46 @@ contextvars are per-asyncio-task, so concurrent agents see
 independent values, and nested `tracing_context` blocks merge
 (tags concatenate, metadata keys union with inner winning).
 
+## Tracing background LLM calls (`oneshot`)
+
+`attach()` instruments a cubepi `Agent`. For background tasks that call an LLM
+directly — without a full agent loop (no tool use, no multi-turn) — use
+`Tracer.oneshot()` instead. It produces the same `invoke_agent` root span and
+`chat` child span so the `cubepi trace` CLI indexes it alongside normal agent
+runs.
+
+```python
+async with tracer.oneshot(
+    provider=provider,
+    model=model,
+    operation="consolidate_memory",          # labelled in the trace
+    metadata={"conversation_id": conv_id},   # queryable via --meta
+) as session:
+    text = await session.generate(
+        system=SYSTEM_PROMPT,
+        messages=[UserMessage(content=[TextContent(text=prompt)])],
+        max_output_tokens=1500,
+    )
+```
+
+The span tree is flat (no `cubepi.turn` wrapper — there is no loop):
+
+```
+invoke_agent  820ms
+  └── chat deepseek-v3  815ms  tok 3200/180
+```
+
+Filter these traces by operation name in the CLI:
+
+```bash
+cubepi trace ls --meta oneshot_operation=consolidate_memory
+cubepi trace ls --meta conversation_id=conv-123   # alongside the conversation's agent runs
+```
+
+The `operation` string is recorded as both `cubepi.oneshot.operation` (for
+dashboards) and `cubepi.metadata.oneshot_operation` (so `--meta` can reach it,
+since the CLI filter only reads `cubepi.metadata.*` attributes).
+
 ## Next
 
 - [OTLP & Backends](./otlp) — Jaeger, Tempo, Honeycomb, Datadog, …


### PR DESCRIPTION
## Summary

- Adds `Tracer.oneshot()` async context manager to `tracer.py` — instruments a single prompt→text LLM call (no agent loop) and produces a full `invoke_agent` trace
- Adds `_OneShotSession` with `generate()` method that transparently uses the wired provider listeners for the `chat` child span
- Updates `skills/cubepi-trace/SKILL.md` with oneshot trace shape, search examples, and usage pattern

**Motivation:** Background tasks like memory consolidation call `provider.stream()` directly (via `OneShotLLM`) and produce no trace at all. After this change, callers replace `one_shot.generate_once(...)` with `tracer.oneshot(...) as session: session.generate(...)` to get full observability.

## Trace shape

```
invoke_agent  [root]
  ├── cubepi.oneshot.operation = "consolidate_memory"
  ├── cubepi.metadata.conversation_id = "conv-..."
  └── chat deepseek-v3  [LLM call with tok / ttft / cache attrs]
```

Searchable via `cubepi trace ls --meta conversation_id=conv-...` alongside normal agent runs.

## Test plan

- [ ] `tests/tracing/test_oneshot.py` — 6 new tests: session type, root+chat spans produced, metadata stamped, no-metadata default, record_content captures messages, concurrent isolation with agent
- [ ] Full suite: 1139 passed, 23 skipped