### PR TITLE
feat(middleware): add compaction and subagent middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Use `ctx.extra` for middleware state that should survive checkpointing. This
   release does not include old-signature compatibility shims.
+- **Breaking:** custom providers must implement `Provider.generate(...)` or
+  inherit from `BaseProvider`, which supplies `generate()` by consuming
+  `stream()`.
 
 ## [0.6.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Provider.generate(...)` one-shot helper** — providers now expose a
+  non-streaming call that consumes `stream()` and returns the final
+  `AssistantMessage`. It supports per-call overrides for
+  `max_output_tokens`, `temperature`, `thinking`, and `thinking_budgets`.
+- **Compaction middleware** — `cubepi.middleware.CompactionMiddleware`
+  summarizes older conversation turns into JSON-safe `AgentContext.extra`
+  state and sends the model a compressed view while preserving full agent
+  history.
+- **Subagent middleware** — `cubepi.middleware.SubagentMiddleware` adds a
+  `subagent` tool that runs an ephemeral child `Agent`, supports shared tools
+  and middleware inheritance, captures child events, and exposes host callbacks
+  for application-specific event streaming.
 - **`on_run_end` middleware hook** — fires exactly once after all turns and tool
   calls complete, before `AgentEndEvent`. Return a `list[Message]` to inject
   additional messages and run one extra model turn (e.g. a memory-reflection
@@ -20,6 +32,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     runs (`stop_reason in ("error", "aborted")`) skip the hook.
   - HITL-interrupted runs (HitlDetached / HitlAborted) also skip the hook —
     the conversation is paused, not finished.
+
+### Changed
+
+- **Breaking:** pre-model middleware hooks now receive `AgentContext` directly.
+  Update custom middleware and explicit hook callables from the old signatures:
+  - `transform_context(messages, *, signal=None)`
+  - `transform_system_prompt(system_prompt, *, signal=None)`
+  - `convert_to_llm(messages)`
+
+  to the new signatures:
+  - `transform_context(messages, *, ctx, signal=None)`
+  - `transform_system_prompt(system_prompt, *, ctx, signal=None)`
+  - `convert_to_llm(messages, *, ctx)`
+
+  Use `ctx.extra` for middleware state that should survive checkpointing. This
+  release does not include old-signature compatibility shims.
 
 ## [0.6.0] - 2026-05-31
 

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -42,7 +42,10 @@ from cubepi.providers.base import (
 TMessage = TypeVar("TMessage")
 
 
-def _default_convert_to_llm(messages: list[Message]) -> list[Message]:
+def _default_convert_to_llm(
+    messages: list[Message], *, ctx: AgentContext
+) -> list[Message]:
+    del ctx
     return list(messages)
 
 
@@ -130,7 +133,7 @@ class Agent(Generic[TMessage]):
         system_prompt: str = "",
         tools: list[AgentTool] | None = None,
         thinking: ThinkingLevel = "off",
-        convert_to_llm: Callable[[list[Message]], list[Message]] | None = None,
+        convert_to_llm: Callable[..., list[Message]] | None = None,
         transform_context: Callable | None = None,
         transform_system_prompt: Callable | None = None,
         after_model_response: Callable | None = None,

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -159,8 +159,14 @@ class Agent(Generic[TMessage]):
         )
         if tools:
             self._state.tools = tools
+        middleware = middleware or []
+        middleware_tools: list[AgentTool] = []
+        for mw in middleware:
+            middleware_tools.extend(getattr(mw, "tools", []) or [])
+        if middleware_tools:
+            self._state.tools = [*self._state.tools, *middleware_tools]
         # Compose middleware hooks, then let explicit callables override.
-        _mw_hooks = compose_middleware(middleware or [])
+        _mw_hooks = compose_middleware(middleware)
         self.convert_to_llm = (
             convert_to_llm or _mw_hooks.get("convert_to_llm") or _default_convert_to_llm
         )

--- a/cubepi/agent/loop.py
+++ b/cubepi/agent/loop.py
@@ -677,9 +677,9 @@ async def _stream_assistant_response(
 ) -> AssistantMessage:
     messages = context.messages
     if transform_context:
-        messages = await transform_context(messages, signal=options.signal)
+        messages = await transform_context(messages, ctx=context, signal=options.signal)
 
-    llm_messages = convert_to_llm(messages)
+    llm_messages = convert_to_llm(messages, ctx=context)
     if asyncio.iscoroutine(llm_messages):
         llm_messages = await llm_messages
 
@@ -689,7 +689,7 @@ async def _stream_assistant_response(
 
     sp = context.system_prompt
     if transform_system_prompt:
-        sp = await transform_system_prompt(sp, signal=options.signal)
+        sp = await transform_system_prompt(sp, ctx=context, signal=options.signal)
 
     stream = await provider.stream(
         model,

--- a/cubepi/middleware/__init__.py
+++ b/cubepi/middleware/__init__.py
@@ -1,3 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
 from cubepi.middleware.base import Middleware, TurnAction, compose_middleware
 
-__all__ = ["Middleware", "TurnAction", "compose_middleware"]
+__all__ = [
+    "CompactionMiddleware",
+    "CompactionState",
+    "Middleware",
+    "SubagentMiddleware",
+    "SubagentRequest",
+    "SubagentResult",
+    "SubagentSpec",
+    "TurnAction",
+    "compose_middleware",
+]
+
+_LAZY = {
+    "CompactionMiddleware": ("cubepi.middleware.compaction", "CompactionMiddleware"),
+    "CompactionState": ("cubepi.middleware.compaction", "CompactionState"),
+    "SubagentMiddleware": ("cubepi.middleware.subagents", "SubagentMiddleware"),
+    "SubagentRequest": ("cubepi.middleware.subagents", "SubagentRequest"),
+    "SubagentResult": ("cubepi.middleware.subagents", "SubagentResult"),
+    "SubagentSpec": ("cubepi.middleware.subagents", "SubagentSpec"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attr = _LAZY[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    import importlib
+
+    module = importlib.import_module(module_name)
+    return getattr(module, attr)

--- a/cubepi/middleware/base.py
+++ b/cubepi/middleware/base.py
@@ -22,10 +22,10 @@ class TurnAction:
 
 
 class Middleware:
-    async def transform_context(self, messages: list, *, signal=None) -> list:
+    async def transform_context(self, messages: list, *, ctx: Any, signal=None) -> list:
         raise NotImplementedError
 
-    async def convert_to_llm(self, messages: list) -> list:
+    async def convert_to_llm(self, messages: list, *, ctx: Any) -> list:
         raise NotImplementedError
 
     async def before_tool_call(self, ctx: Any, *, signal=None) -> Any:
@@ -38,6 +38,7 @@ class Middleware:
         self,
         system_prompt: str,
         *,
+        ctx: Any,
         signal=None,
     ) -> str:
         raise NotImplementedError
@@ -75,10 +76,10 @@ def compose_middleware(middlewares: list[Middleware]) -> dict[str, Callable]:
     transform_chain = [m for m in middlewares if _has_method(m, "transform_context")]
     if transform_chain:
 
-        async def composed_transform(messages, *, signal=None):
+        async def composed_transform(messages, *, ctx, signal=None):
             result = messages
             for mw in transform_chain:
-                result = await mw.transform_context(result, signal=signal)
+                result = await mw.transform_context(result, ctx=ctx, signal=signal)
             return result
 
         hooks["transform_context"] = composed_transform
@@ -87,8 +88,8 @@ def compose_middleware(middlewares: list[Middleware]) -> dict[str, Callable]:
     if convert_impls:
         last = convert_impls[-1]
 
-        async def composed_convert(messages):
-            return await last.convert_to_llm(messages)
+        async def composed_convert(messages, *, ctx):
+            return await last.convert_to_llm(messages, ctx=ctx)
 
         hooks["convert_to_llm"] = composed_convert
 
@@ -160,10 +161,12 @@ def compose_middleware(middlewares: list[Middleware]) -> dict[str, Callable]:
     sp_chain = [m for m in middlewares if _has_method(m, "transform_system_prompt")]
     if sp_chain:
 
-        async def composed_sp(system_prompt, *, signal=None):
+        async def composed_sp(system_prompt, *, ctx, signal=None):
             result = system_prompt
             for mw in sp_chain:
-                result = await mw.transform_system_prompt(result, signal=signal)
+                result = await mw.transform_system_prompt(
+                    result, ctx=ctx, signal=signal
+                )
             return result
 
         hooks["transform_system_prompt"] = composed_sp

--- a/cubepi/middleware/compaction/__init__.py
+++ b/cubepi/middleware/compaction/__init__.py
@@ -65,7 +65,6 @@ class CompactionMiddleware(Middleware):
         ctx: AgentContext,
         signal: object = None,
     ) -> list[Message]:
-        del signal
         state = _load_state(ctx.extra.get("compaction"))
         boundary = int(ctx.extra.get("compaction_until_msg_index") or 0)
         if boundary >= len(messages):
@@ -93,6 +92,7 @@ class CompactionMiddleware(Middleware):
                 messages_to_summarize=messages[boundary:new_boundary],
                 existing=state,
                 max_summary_tokens=self._max_summary_tokens,
+                abort_signal=signal,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("CompactionMiddleware summarizer failed, skipping: %s", exc)

--- a/cubepi/middleware/compaction/__init__.py
+++ b/cubepi/middleware/compaction/__init__.py
@@ -68,6 +68,11 @@ class CompactionMiddleware(Middleware):
         del signal
         state = _load_state(ctx.extra.get("compaction"))
         boundary = int(ctx.extra.get("compaction_until_msg_index") or 0)
+        if boundary >= len(messages):
+            boundary = 0
+            state = None
+            ctx.extra.pop("compaction", None)
+            ctx.extra.pop("compaction_until_msg_index", None)
         compressed = _compressed_view(messages, state, boundary)
 
         if approx_tokens(compressed) < self._max_tokens_before:

--- a/cubepi/middleware/compaction/__init__.py
+++ b/cubepi/middleware/compaction/__init__.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from cubepi.agent.types import AgentContext
+from cubepi.middleware.base import Middleware
+from cubepi.middleware.compaction.boundary import safe_boundary
+from cubepi.middleware.compaction.state import CompactionState
+from cubepi.middleware.compaction.summarizer import summarize
+from cubepi.middleware.compaction.tokens import approx_tokens
+from cubepi.providers.base import Message, Model, Provider, TextContent, UserMessage
+
+SUMMARY_PREFIX = "[Conversation summary so far]\n"
+logger = logging.getLogger(__name__)
+
+
+def _compressed_view(
+    messages: list[Message],
+    state: CompactionState | None,
+    boundary: int | None,
+) -> list[Message]:
+    if state and boundary and boundary > 0:
+        summary = UserMessage(
+            content=[TextContent(text=SUMMARY_PREFIX + state.summary)],
+        )
+        return [summary, *messages[boundary:]]
+    return list(messages)
+
+
+def _load_state(value: Any) -> CompactionState | None:
+    if value is None:
+        return None
+    if isinstance(value, CompactionState):
+        return value
+    if isinstance(value, dict):
+        return CompactionState.model_validate(value)
+    return None
+
+
+class CompactionMiddleware(Middleware):
+    """Keep long histories within context by summarizing older turns."""
+
+    def __init__(
+        self,
+        *,
+        summary_provider: Provider,
+        summary_model: Model,
+        max_tokens_before_compact: int,
+        keep_recent_messages: int = 8,
+        max_summary_tokens: int = 1024,
+        min_compact_messages: int = 4,
+    ) -> None:
+        self._summary_provider = summary_provider
+        self._summary_model = summary_model
+        self._max_tokens_before = max_tokens_before_compact
+        self._keep_recent = keep_recent_messages
+        self._max_summary_tokens = max_summary_tokens
+        self._min_compact = min_compact_messages
+
+    async def transform_context(
+        self,
+        messages: list[Message],
+        *,
+        ctx: AgentContext,
+        signal: object = None,
+    ) -> list[Message]:
+        del signal
+        state = _load_state(ctx.extra.get("compaction"))
+        boundary = int(ctx.extra.get("compaction_until_msg_index") or 0)
+        compressed = _compressed_view(messages, state, boundary)
+
+        if approx_tokens(compressed) < self._max_tokens_before:
+            return compressed
+
+        new_boundary = safe_boundary(
+            messages,
+            keep_recent=self._keep_recent,
+            min_compact=max(self._min_compact, boundary + 1),
+        )
+        if new_boundary is None or new_boundary <= boundary:
+            return compressed
+
+        try:
+            new_state = await summarize(
+                provider=self._summary_provider,
+                model=self._summary_model,
+                messages_to_summarize=messages[boundary:new_boundary],
+                existing=state,
+                max_summary_tokens=self._max_summary_tokens,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("CompactionMiddleware summarizer failed, skipping: %s", exc)
+            return compressed
+
+        ctx.extra["compaction"] = new_state.model_dump()
+        ctx.extra["compaction_until_msg_index"] = new_boundary
+        return _compressed_view(messages, new_state, new_boundary)
+
+
+__all__ = [
+    "CompactionMiddleware",
+    "CompactionState",
+]

--- a/cubepi/middleware/compaction/__init__.py
+++ b/cubepi/middleware/compaction/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from pydantic import ValidationError
+
 from cubepi.agent.types import AgentContext
 from cubepi.middleware.base import Middleware
 from cubepi.middleware.compaction.boundary import safe_boundary
@@ -34,7 +36,10 @@ def _load_state(value: Any) -> CompactionState | None:
     if isinstance(value, CompactionState):
         return value
     if isinstance(value, dict):
-        return CompactionState.model_validate(value)
+        try:
+            return CompactionState.model_validate(value)
+        except ValidationError:
+            return None
     return None
 
 
@@ -85,6 +90,9 @@ class CompactionMiddleware(Middleware):
     ) -> list[Message]:
         state = _load_state(ctx.extra.get("compaction"))
         boundary = int(ctx.extra.get("compaction_until_msg_index") or 0)
+        if state is None and ("compaction" in ctx.extra or boundary > 0):
+            boundary = 0
+            _clear_state(ctx)
         if boundary >= len(messages) or not _state_matches_history(
             messages, state, boundary
         ):

--- a/cubepi/middleware/compaction/__init__.py
+++ b/cubepi/middleware/compaction/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 from cubepi.agent.types import AgentContext
 from cubepi.middleware.base import Middleware
 from cubepi.middleware.compaction.boundary import safe_boundary
-from cubepi.middleware.compaction.state import CompactionState
+from cubepi.middleware.compaction.state import CompactionState, message_refs
 from cubepi.middleware.compaction.summarizer import summarize
 from cubepi.middleware.compaction.tokens import approx_tokens
 from cubepi.providers.base import Message, Model, Provider, TextContent, UserMessage
@@ -38,6 +38,24 @@ def _load_state(value: Any) -> CompactionState | None:
     return None
 
 
+def _clear_state(ctx: AgentContext) -> None:
+    ctx.extra.pop("compaction", None)
+    ctx.extra.pop("compaction_until_msg_index", None)
+
+
+def _state_matches_history(
+    messages: list[Message],
+    state: CompactionState | None,
+    boundary: int,
+) -> bool:
+    if state is None or boundary <= 0:
+        return True
+    refs = state.summarized_message_refs
+    if len(refs) != boundary:
+        return False
+    return refs == message_refs(messages[:boundary])
+
+
 class CompactionMiddleware(Middleware):
     """Keep long histories within context by summarizing older turns."""
 
@@ -67,11 +85,12 @@ class CompactionMiddleware(Middleware):
     ) -> list[Message]:
         state = _load_state(ctx.extra.get("compaction"))
         boundary = int(ctx.extra.get("compaction_until_msg_index") or 0)
-        if boundary >= len(messages):
+        if boundary >= len(messages) or not _state_matches_history(
+            messages, state, boundary
+        ):
             boundary = 0
             state = None
-            ctx.extra.pop("compaction", None)
-            ctx.extra.pop("compaction_until_msg_index", None)
+            _clear_state(ctx)
         compressed = _compressed_view(messages, state, boundary)
 
         if approx_tokens(compressed) < self._max_tokens_before:

--- a/cubepi/middleware/compaction/boundary.py
+++ b/cubepi/middleware/compaction/boundary.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+
+
+def safe_boundary(
+    messages: list[Message],
+    *,
+    keep_recent: int,
+    min_compact: int = 1,
+) -> int | None:
+    """Return a message index that can be summarized safely."""
+    if len(messages) <= keep_recent:
+        return None
+
+    candidate = len(messages) - keep_recent
+    while candidate > 0:
+        if not isinstance(messages[candidate], UserMessage):
+            candidate -= 1
+            continue
+        if not _suffix_is_self_contained(messages[candidate:]):
+            candidate -= 1
+            continue
+        if candidate < min_compact:
+            return None
+        return candidate
+
+    return None
+
+
+def _suffix_is_self_contained(suffix: list[Message]) -> bool:
+    available_call_ids: set[str] = set()
+    for message in suffix:
+        if isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, ToolCall) and block.id:
+                    available_call_ids.add(block.id)
+        elif isinstance(message, ToolResultMessage):
+            if message.tool_call_id and message.tool_call_id not in available_call_ids:
+                return False
+    return True

--- a/cubepi/middleware/compaction/state.py
+++ b/cubepi/middleware/compaction/state.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CompactionState(BaseModel):
+    """JSON-safe summary state stored in ``AgentContext.extra``."""
+
+    summary: str
+    summarized_message_ids: list[str] = Field(default_factory=list)
+    last_summarized_message_id: str | None = None

--- a/cubepi/middleware/compaction/state.py
+++ b/cubepi/middleware/compaction/state.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import hashlib
+import json
+
 from pydantic import BaseModel, Field
+
+from cubepi.providers.base import Message
 
 
 class CompactionState(BaseModel):
@@ -8,4 +13,18 @@ class CompactionState(BaseModel):
 
     summary: str
     summarized_message_ids: list[str] = Field(default_factory=list)
+    summarized_message_refs: list[str] = Field(default_factory=list)
     last_summarized_message_id: str | None = None
+
+
+def message_ref(message: Message) -> str:
+    message_id = str(getattr(message, "id", "") or "")
+    if message_id:
+        return f"id:{message_id}"
+    payload = message.model_dump(mode="json", exclude_none=True)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def message_refs(messages: list[Message]) -> list[str]:
+    return [message_ref(message) for message in messages]

--- a/cubepi/middleware/compaction/summarizer.py
+++ b/cubepi/middleware/compaction/summarizer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
-from cubepi.middleware.compaction.state import CompactionState
+from cubepi.middleware.compaction.state import CompactionState, message_refs
 from cubepi.providers.base import (
     Message,
     Model,
@@ -89,6 +89,7 @@ async def summarize(
     ]
     new_ids = [message_id for message_id in new_ids if message_id]
     prior_ids = list(existing.summarized_message_ids) if existing else []
+    prior_refs = list(existing.summarized_message_refs) if existing else []
     last_id = (
         new_ids[-1]
         if new_ids
@@ -98,5 +99,6 @@ async def summarize(
     return CompactionState(
         summary=text.strip(),
         summarized_message_ids=prior_ids + new_ids,
+        summarized_message_refs=prior_refs + message_refs(messages_to_summarize),
         last_summarized_message_id=last_id,
     )

--- a/cubepi/middleware/compaction/summarizer.py
+++ b/cubepi/middleware/compaction/summarizer.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import asyncio
+
 from cubepi.middleware.compaction.state import CompactionState
 from cubepi.providers.base import (
     Message,
     Model,
     Provider,
+    StreamOptions,
     TextContent,
     ToolCall,
     UserMessage,
@@ -55,6 +58,7 @@ async def summarize(
     messages_to_summarize: list[Message],
     existing: CompactionState | None,
     max_summary_tokens: int = 1024,
+    abort_signal: asyncio.Event | None = None,
 ) -> CompactionState:
     system_prompt = SUMMARIZER_SYSTEM_PROMPT
     if existing and existing.summary:
@@ -68,6 +72,7 @@ async def summarize(
             )
         ],
         system_prompt=system_prompt,
+        options=StreamOptions(signal=abort_signal),
         max_output_tokens=max_summary_tokens,
         temperature=0.0,
         thinking="off",

--- a/cubepi/middleware/compaction/summarizer.py
+++ b/cubepi/middleware/compaction/summarizer.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from cubepi.middleware.compaction.state import CompactionState
+from cubepi.providers.base import (
+    Message,
+    Model,
+    Provider,
+    TextContent,
+    ToolCall,
+    UserMessage,
+)
+
+SUMMARIZER_SYSTEM_PROMPT = """\
+You compress a chat transcript into a brief, faithful narrative for an AI assistant
+that is continuing the conversation. Rules:
+
+1. Preserve facts, user goals, decisions made, and unresolved questions.
+2. Preserve every citation marker verbatim. Do not renumber, merge, or drop them.
+3. Do not quote long tool outputs. Reference them by their citation markers instead.
+4. Keep the language of the original conversation.
+5. Output the summary directly. No preamble, no JSON, no markdown headers.
+"""
+
+EXISTING_SUMMARY_SUFFIX = """\
+A previous summary already covers earlier turns:
+
+<previous_summary>
+{prev}
+</previous_summary>
+
+Merge it with the new turns below. Output the updated summary."""
+
+
+def _format_message_for_summary(message: Message) -> str:
+    role = message.__class__.__name__.removesuffix("Message").lower() or "message"
+    parts: list[str] = []
+    for block in getattr(message, "content", []):
+        if isinstance(block, TextContent):
+            parts.append(block.text)
+        elif isinstance(block, ToolCall):
+            parts.append(f"[tool_call:{block.name}]")
+        elif hasattr(block, "text"):
+            parts.append(str(getattr(block, "text", "")))
+    return f"[{role}] " + " ".join(parts)
+
+
+def _format_transcript(messages: list[Message]) -> str:
+    return "\n\n".join(_format_message_for_summary(message) for message in messages)
+
+
+async def summarize(
+    *,
+    provider: Provider,
+    model: Model,
+    messages_to_summarize: list[Message],
+    existing: CompactionState | None,
+    max_summary_tokens: int = 1024,
+) -> CompactionState:
+    system_prompt = SUMMARIZER_SYSTEM_PROMPT
+    if existing and existing.summary:
+        system_prompt += "\n\n" + EXISTING_SUMMARY_SUFFIX.format(prev=existing.summary)
+
+    response = await provider.generate(
+        model=model,
+        messages=[
+            UserMessage(
+                content=[TextContent(text=_format_transcript(messages_to_summarize))]
+            )
+        ],
+        system_prompt=system_prompt,
+        max_output_tokens=max_summary_tokens,
+        temperature=0.0,
+        thinking="off",
+    )
+
+    text = "".join(
+        block.text for block in response.content if isinstance(block, TextContent)
+    )
+    if response.error_message is not None:
+        raise RuntimeError(response.error_message)
+
+    new_ids = [
+        str(getattr(message, "id", "") or "") for message in messages_to_summarize
+    ]
+    new_ids = [message_id for message_id in new_ids if message_id]
+    prior_ids = list(existing.summarized_message_ids) if existing else []
+    last_id = (
+        new_ids[-1]
+        if new_ids
+        else (existing.last_summarized_message_id if existing else None)
+    )
+
+    return CompactionState(
+        summary=text.strip(),
+        summarized_message_ids=prior_ids + new_ids,
+        last_summarized_message_id=last_id,
+    )

--- a/cubepi/middleware/compaction/tokens.py
+++ b/cubepi/middleware/compaction/tokens.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+
+_CHARS_PER_TOKEN = 2.0
+_SCALE_MIN_TOKENS = 100
+
+
+def approx_tokens(messages: list[Message]) -> int:
+    """Conservative token estimate for the exact message view sent to the LLM."""
+    if not messages:
+        return 0
+
+    total_chars = 0
+    scale_factor: float | None = None
+
+    for message in messages:
+        if isinstance(message, UserMessage):
+            for block in message.content:
+                if isinstance(block, TextContent):
+                    total_chars += len(block.text)
+        elif isinstance(message, AssistantMessage):
+            for block in message.content:
+                if isinstance(block, TextContent):
+                    total_chars += len(block.text)
+                elif isinstance(block, ToolCall):
+                    total_chars += len(json.dumps(block.arguments or {}))
+            usage = message.usage
+            if (
+                usage
+                and usage.input_tokens >= _SCALE_MIN_TOKENS
+                and scale_factor is None
+            ):
+                chars_estimate = usage.input_tokens * _CHARS_PER_TOKEN
+                if chars_estimate > 0:
+                    raw_factor = total_chars / chars_estimate
+                    scale_factor = max(1.0, min(raw_factor, 1.25))
+        elif isinstance(message, ToolResultMessage):
+            for block in message.content:
+                if isinstance(block, TextContent):
+                    total_chars += len(block.text)
+
+    estimate = total_chars / _CHARS_PER_TOKEN
+    if scale_factor is not None:
+        return int(estimate * scale_factor)
+    return int(estimate)

--- a/cubepi/middleware/subagents.py
+++ b/cubepi/middleware/subagents.py
@@ -156,11 +156,9 @@ class SubagentMiddleware(Middleware):
 
         agent_id = f"subagent:{tool_call_id}"
         events: list[Any] = []
-        text_parts: list[str] = []
 
         async def listener(event: AgentEvent, signal: Any = None) -> None:
             del signal
-            self._collect_text(event, text_parts)
             await self._handle_event(agent_id, event, events)
 
         child.subscribe(listener)
@@ -171,7 +169,7 @@ class SubagentMiddleware(Middleware):
         finally:
             await self._detach_tracer(detach)
 
-        text = "".join(text_parts) or "[subagent produced no output]"
+        text = self._final_assistant_text(child) or "[subagent produced no output]"
         error = self._child_error(child)
         return SubagentResult(agent_id=agent_id, text=text, events=events, error=error)
 
@@ -191,15 +189,16 @@ class SubagentMiddleware(Middleware):
         return None
 
     @staticmethod
-    def _collect_text(event: AgentEvent, text_parts: list[str]) -> None:
-        if event.type != "message_end":
-            return
-        message = event.message
-        if getattr(message, "role", None) != "assistant":
-            return
-        for block in getattr(message, "content", []):
-            if isinstance(block, TextContent):
-                text_parts.append(block.text)
+    def _final_assistant_text(child: Agent[Any]) -> str:
+        for message in reversed(child.state.messages):
+            if not isinstance(message, AssistantMessage):
+                continue
+            return "".join(
+                block.text
+                for block in message.content
+                if isinstance(block, TextContent)
+            )
+        return ""
 
     async def _handle_event(
         self,

--- a/cubepi/middleware/subagents.py
+++ b/cubepi/middleware/subagents.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import inspect
 import logging
 from collections.abc import Awaitable, Callable, Sequence
@@ -103,9 +105,9 @@ class SubagentMiddleware(Middleware):
             signal: Any = None,
             on_update: Any = None,
         ) -> AgentToolResult:
-            del signal, on_update
+            del on_update
             try:
-                result = await self._run_subagent(tool_call_id, args)
+                result = await self._run_subagent(tool_call_id, args, signal=signal)
             except Exception as exc:
                 logger.error("Subagent %s failed: %s", args.subagent_type, exc)
                 return AgentToolResult(
@@ -137,6 +139,8 @@ class SubagentMiddleware(Middleware):
         self,
         tool_call_id: str,
         request: SubagentRequest,
+        *,
+        signal: Any = None,
     ) -> SubagentResult:
         spec = self._subagents.get(
             request.subagent_type,
@@ -163,10 +167,12 @@ class SubagentMiddleware(Middleware):
 
         child.subscribe(listener)
 
+        abort_task = self._start_abort_forwarder(child, signal)
         detach = self._attach_tracer(child)
         try:
             await child.prompt(request.prompt)
         finally:
+            await self._stop_abort_forwarder(abort_task)
             await self._detach_tracer(detach)
 
         text = self._final_assistant_text(child) or "[subagent produced no output]"
@@ -211,7 +217,10 @@ class SubagentMiddleware(Middleware):
         mapped = self._event_mapper(event)
         if mapped is None:
             return
-        payloads = list(mapped) if isinstance(mapped, Sequence) else [mapped]
+        if isinstance(mapped, Sequence) and not isinstance(mapped, (str, bytes)):
+            payloads = list(mapped)
+        else:
+            payloads = [mapped]
         for payload in payloads:
             events.append(payload)
             if self._event_handler is not None:
@@ -227,6 +236,27 @@ class SubagentMiddleware(Middleware):
         except Exception as exc:  # noqa: BLE001
             logger.debug("subagent tracer attach failed: %s", exc)
             return None
+
+    def _start_abort_forwarder(
+        self, child: Agent[Any], signal: Any
+    ) -> asyncio.Task | None:
+        if signal is None:
+            return None
+
+        async def forward_abort() -> None:
+            await signal.wait()
+            while not child.state.is_streaming:
+                await asyncio.sleep(0)
+            child.abort()
+
+        return asyncio.create_task(forward_abort())
+
+    async def _stop_abort_forwarder(self, task: asyncio.Task | None) -> None:
+        if task is None or task.done():
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
     async def _detach_tracer(self, detach: Any) -> None:
         if detach is None:

--- a/cubepi/middleware/subagents.py
+++ b/cubepi/middleware/subagents.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic import BaseModel
+
+from cubepi.agent.agent import Agent
+from cubepi.agent.types import AgentEvent, AgentTool, AgentToolResult
+from cubepi.middleware.base import Middleware
+from cubepi.providers.base import AssistantMessage, Model, Provider, TextContent
+
+logger = logging.getLogger(__name__)
+
+EventMapper = Callable[[AgentEvent], Sequence[Any] | Any | None]
+EventHandler = Callable[[str, Any], Awaitable[None] | None]
+
+
+@dataclass(frozen=True)
+class SubagentSpec:
+    name: str
+    description: str
+    system_prompt: str
+    provider: Provider | None = None
+    model: Model | None = None
+    tools: Sequence[AgentTool[Any]] = field(default_factory=tuple)
+    middleware: Sequence[Middleware] = field(default_factory=tuple)
+
+
+class SubagentRequest(BaseModel):
+    name: str
+    role: str
+    task: str
+    prompt: str
+    subagent_type: str = "general-purpose"
+
+
+@dataclass(frozen=True)
+class SubagentResult:
+    agent_id: str
+    text: str
+    events: list[Any]
+    error: str | None = None
+
+
+class SubagentMiddleware(Middleware):
+    """Inject a tool that delegates one task to an ephemeral child agent."""
+
+    def __init__(
+        self,
+        *,
+        subagents: dict[str, SubagentSpec],
+        default_provider: Provider,
+        default_model: Model,
+        shared_tools: Sequence[AgentTool[Any]] = (),
+        inherited_middleware: Sequence[Middleware] = (),
+        excluded_tool_names: set[str] | None = None,
+        event_mapper: EventMapper | None = None,
+        event_handler: EventHandler | None = None,
+        tracer: Any = None,
+    ) -> None:
+        if "general-purpose" not in subagents:
+            subagents = {
+                **subagents,
+                "general-purpose": SubagentSpec(
+                    name="general-purpose",
+                    description="A general-purpose AI assistant",
+                    system_prompt="You are a helpful AI assistant.",
+                ),
+            }
+
+        excluded = excluded_tool_names or {"subagent"}
+        self._subagents = dict(subagents)
+        self._default_provider = default_provider
+        self._default_model = default_model
+        self._shared_tools = tuple(
+            tool for tool in shared_tools if tool.name not in excluded
+        )
+        self._inherited_middleware = tuple(inherited_middleware)
+        self._event_mapper = event_mapper
+        self._event_handler = event_handler
+        self._tracer = tracer
+        self.tools: list[AgentTool[Any]] = [self._make_tool()]
+
+    @property
+    def subagents(self) -> dict[str, SubagentSpec]:
+        return dict(self._subagents)
+
+    @property
+    def shared_tools(self) -> tuple[AgentTool[Any], ...]:
+        return self._shared_tools
+
+    def _make_tool(self) -> AgentTool[SubagentRequest]:
+        available = ", ".join(f'"{name}"' for name in self._subagents)
+
+        async def execute(
+            tool_call_id: str,
+            args: SubagentRequest,
+            *,
+            signal: Any = None,
+            on_update: Any = None,
+        ) -> AgentToolResult:
+            del signal, on_update
+            try:
+                result = await self._run_subagent(tool_call_id, args)
+            except Exception as exc:
+                logger.error("Subagent %s failed: %s", args.subagent_type, exc)
+                return AgentToolResult(
+                    content=[TextContent(text=f"[error: {exc}]")],
+                    is_error=True,
+                )
+            if result.error is not None:
+                return AgentToolResult(
+                    content=[TextContent(text=f"[error: {result.error}]")],
+                    details={"subagent_events": result.events},
+                    is_error=True,
+                )
+            return AgentToolResult(
+                content=[TextContent(text=result.text)],
+                details={"subagent_events": result.events},
+            )
+
+        return AgentTool(
+            name="subagent",
+            description=(
+                f"Delegate a task to a subagent. Available subagent types: {available}. "
+                "Provide a name, role, task, and self-contained prompt."
+            ),
+            parameters=SubagentRequest,
+            execute=execute,
+        )
+
+    async def _run_subagent(
+        self,
+        tool_call_id: str,
+        request: SubagentRequest,
+    ) -> SubagentResult:
+        spec = self._subagents.get(
+            request.subagent_type,
+            self._subagents["general-purpose"],
+        )
+        provider = spec.provider or self._default_provider
+        model = spec.model or self._default_model
+        tools = [*self._shared_tools, *spec.tools]
+        middleware = [*self._inherited_middleware, *spec.middleware]
+        child = Agent(
+            provider=provider,
+            model=model,
+            system_prompt=spec.system_prompt,
+            tools=tools,
+            middleware=middleware,
+        )
+
+        agent_id = f"subagent:{tool_call_id}"
+        events: list[Any] = []
+        text_parts: list[str] = []
+
+        async def listener(event: AgentEvent, signal: Any = None) -> None:
+            del signal
+            self._collect_text(event, text_parts)
+            await self._handle_event(agent_id, event, events)
+
+        child.subscribe(listener)
+
+        detach = self._attach_tracer(child)
+        try:
+            await child.prompt(request.prompt)
+        finally:
+            await self._detach_tracer(detach)
+
+        text = "".join(text_parts) or "[subagent produced no output]"
+        error = self._child_error(child)
+        return SubagentResult(agent_id=agent_id, text=text, events=events, error=error)
+
+    @staticmethod
+    def _child_error(child: Agent[Any]) -> str | None:
+        if child.state.error_message:
+            return child.state.error_message
+        if not child.state.messages:
+            return None
+        last = child.state.messages[-1]
+        if not isinstance(last, AssistantMessage):
+            return None
+        if last.error_message is not None:
+            return last.error_message
+        if last.stop_reason == "error":
+            return "subagent failed"
+        return None
+
+    @staticmethod
+    def _collect_text(event: AgentEvent, text_parts: list[str]) -> None:
+        if event.type != "message_end":
+            return
+        message = event.message
+        if getattr(message, "role", None) != "assistant":
+            return
+        for block in getattr(message, "content", []):
+            if isinstance(block, TextContent):
+                text_parts.append(block.text)
+
+    async def _handle_event(
+        self,
+        agent_id: str,
+        event: AgentEvent,
+        events: list[Any],
+    ) -> None:
+        if self._event_mapper is None:
+            return
+        mapped = self._event_mapper(event)
+        if mapped is None:
+            return
+        payloads = list(mapped) if isinstance(mapped, Sequence) else [mapped]
+        for payload in payloads:
+            events.append(payload)
+            if self._event_handler is not None:
+                result = self._event_handler(agent_id, payload)
+                if inspect.isawaitable(result):
+                    await result
+
+    def _attach_tracer(self, child: Agent[Any]) -> Any:
+        if self._tracer is None:
+            return None
+        try:
+            return self._tracer.attach(child)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("subagent tracer attach failed: %s", exc)
+            return None
+
+    async def _detach_tracer(self, detach: Any) -> None:
+        if detach is None:
+            return
+        try:
+            result = detach()
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("subagent tracer detach failed: %s", exc)
+
+
+__all__ = [
+    "SubagentMiddleware",
+    "SubagentRequest",
+    "SubagentResult",
+    "SubagentSpec",
+]

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -577,6 +577,20 @@ class Provider(Protocol):
         options: StreamOptions | None = None,
     ) -> MessageStream: ...
 
+    async def generate(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        thinking: ThinkingLevel | None = None,
+        thinking_budgets: ThinkingBudgets | None = None,
+    ) -> AssistantMessage: ...
+
 
 class BaseProvider:
     """Concrete base class for built-in cubepi providers.
@@ -613,6 +627,49 @@ class BaseProvider:
         options: StreamOptions | None = None,
     ) -> MessageStream:
         raise NotImplementedError
+
+    async def generate(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        thinking: ThinkingLevel | None = None,
+        thinking_budgets: ThinkingBudgets | None = None,
+    ) -> AssistantMessage:
+        """Run a single provider call and return the final assistant message."""
+        model_updates: dict[str, int | float] = {}
+        if max_output_tokens is not None:
+            model_updates["max_tokens"] = max_output_tokens
+        if temperature is not None:
+            model_updates["temperature"] = temperature
+        if model_updates:
+            model = model.model_copy(update=model_updates)
+
+        option_updates: dict[str, ThinkingLevel | ThinkingBudgets] = {}
+        if thinking is not None:
+            option_updates["thinking"] = thinking
+        if thinking_budgets is not None:
+            option_updates["thinking_budgets"] = thinking_budgets
+        if option_updates:
+            base_options = options or StreamOptions()
+            options = base_options.model_copy(update=option_updates)
+
+        stream = await self.stream(
+            model=model,
+            messages=messages,
+            system_prompt=system_prompt,
+            tools=tools,
+            options=options,
+        )
+        async for event in stream:
+            if event.type in ("done", "error"):
+                break
+        return await stream.result()
 
     def _error_message(self, exc: BaseException, model: Model) -> str:
         """Format a failed-call error with provider/model/base_url + cause."""

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -597,9 +597,9 @@ class BaseProvider:
 
     Built-in providers (Anthropic, OpenAI, OpenAI Responses, Faux) inherit
     from this class to gain the persistent listener registry used by
-    ``cubepi.tracing`` and other observers. User-defined providers may also
-    inherit from ``BaseProvider`` to opt in, or remain duck-typed against
-    the ``Provider`` Protocol (which only requires ``stream()``).
+    ``cubepi.tracing`` and other observers. User-defined providers should
+    inherit from ``BaseProvider`` unless they implement the full ``Provider``
+    protocol themselves.
 
     Concrete subclasses must implement ``stream()`` and call
     ``_fire_listeners`` at three points: after the request payload is

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -66,9 +66,6 @@ class _OneShotSession:
         import asyncio as _asyncio
 
         from cubepi.providers.base import (
-            AssistantMessage as _AssistantMessage,
-        )
-        from cubepi.providers.base import (
             StreamOptions as _StreamOptions,
         )
         from cubepi.providers.base import (
@@ -89,60 +86,31 @@ class _OneShotSession:
         # Mirrors the agent loop's ``StreamOptions(signal=...)`` use.
         abort_signal = _asyncio.Event()
 
-        model = self._model.model_copy(update={"max_tokens": max_output_tokens})
-        stream = await self._provider.stream(
-            model=model,
-            messages=messages,
-            system_prompt=system,
-            options=_StreamOptions(signal=abort_signal),
-        )
-        parts: list[str] = []
-        error_msg: str | None = None
         try:
-            async for evt in stream:
-                if evt.type == "text_delta" and evt.delta:
-                    parts.append(evt.delta)
-                elif evt.type == "error":
-                    error_msg = evt.error_message or "oneshot generation failed"
-                    break
-                elif evt.type == "done":
-                    break
+            response = await self._provider.generate(
+                model=self._model,
+                messages=messages,
+                system_prompt=system,
+                options=_StreamOptions(signal=abort_signal),
+                max_output_tokens=max_output_tokens,
+            )
         except BaseException:
             # On cancellation/timeout, tell the producer to stop so it
-            # doesn't keep running after we exit. ``stream.result()``
-            # below then surfaces the (now-completed) producer's state.
+            # doesn't keep running after we exit.
             abort_signal.set()
             raise
-        # Wait for the producer task to finish — its ``finally`` block
-        # invokes the response listeners (including the recorder's
-        # ``_on_provider_response`` that closes the chat span and records
-        # usage). Without this, breaking on ``done`` lets us race ahead
-        # and exit the oneshot context before the chat span is closed,
-        # so the cleanup sweep would mark it ``cubepi.aborted`` and the
-        # trace would be missing usage / response data. Mirrors the
-        # ``await stream.result()`` pattern in cubepi.agent.loop.
-        try:
-            await stream.result()
-        except Exception as result_exc:
-            # If we already captured an error event, the producer's
-            # exception is just the same failure expressed differently —
-            # swallow it and report uniformly via ``error_msg``. But if
-            # we got here on the success path (``done`` event consumed),
-            # the producer raised AFTER signalling done without emitting
-            # an error event, e.g. a custom provider bug. Surface that
-            # exception so the run is reported as failed instead of
-            # returning empty text.
-            if error_msg is None:
-                error_msg = str(result_exc) or "oneshot producer failed"
-        if error_msg is not None:
-            raise RuntimeError(error_msg)
+
+        if response.error_message is not None:
+            raise RuntimeError(response.error_message)
+
+        parts = [
+            block.text for block in response.content if isinstance(block, _TextContent)
+        ]
         text = "".join(parts)
         # Stash output as a single assistant message so the oneshot finally
         # block can stamp gen_ai.output.messages on the root span.
         if text:
-            self._run.output_messages = [
-                _AssistantMessage(content=[_TextContent(text=text)])
-            ]
+            self._run.output_messages = [response]
         return text
 
 

--- a/tests/agent/test_agent.py
+++ b/tests/agent/test_agent.py
@@ -4,6 +4,7 @@ import pytest
 
 from cubepi.agent.agent import Agent, _MessageQueue
 from cubepi.agent.types import AgentTool
+from cubepi.middleware.base import Middleware
 from cubepi.providers.base import (
     AssistantMessage,
     Model,
@@ -11,6 +12,7 @@ from cubepi.providers.base import (
     UserMessage,
 )
 from cubepi.providers.faux import FauxProvider, faux_assistant_message
+from pydantic import BaseModel
 
 
 def make_model() -> Model:
@@ -42,6 +44,31 @@ class TestAgentInit:
 
         assert agent.state.system_prompt == "You are a helpful assistant."
         assert agent.state.thinking == "low"
+
+    def test_middleware_tools_are_registered_on_agent(self):
+        class Params(BaseModel):
+            pass
+
+        async def execute(tool_call_id, params, *, signal=None, on_update=None):
+            return None
+
+        tool = AgentTool(
+            name="from_middleware",
+            description="middleware tool",
+            parameters=Params,
+            execute=execute,
+        )
+
+        class ToolMiddleware(Middleware):
+            tools = [tool]
+
+        agent = Agent(
+            provider=FauxProvider(),
+            model=make_model(),
+            middleware=[ToolMiddleware()],
+        )
+
+        assert agent.state.tools == [tool]
 
 
 class TestAgentSubscribe:

--- a/tests/agent/test_loop.py
+++ b/tests/agent/test_loop.py
@@ -34,7 +34,8 @@ def make_user_message(text: str) -> UserMessage:
     return UserMessage(content=[TextContent(text=text)])
 
 
-def identity_converter(messages: list[Any]) -> list[Message]:
+def identity_converter(messages: list[Any], *, ctx: AgentContext) -> list[Message]:
+    del ctx
     return [
         m
         for m in messages
@@ -102,7 +103,8 @@ class TestAgentLoop:
 
         converted: list[Message] = []
 
-        def converter(messages):
+        def converter(messages, *, ctx):
+            del ctx
             result = [
                 m
                 for m in messages
@@ -141,14 +143,16 @@ class TestAgentLoop:
         transformed_len = []
         converted_len = []
 
-        async def transform(messages, *, signal=None):
+        async def transform(messages, *, ctx, signal=None):
+            del ctx, signal
             result = messages[-2:]
             transformed_len.append(len(result))
             return result
 
-        def converter(messages):
+        def converter(messages, *, ctx):
+            del ctx
             converted_len.append(len(messages))
-            return identity_converter(messages)
+            return identity_converter(messages, ctx=context)
 
         await run_agent_loop(
             prompts=[make_user_message("new")],
@@ -573,8 +577,13 @@ class TestAsyncConvertToLlm:
         context = AgentContext(system_prompt="", messages=[], tools=[])
         converter_called = False
 
-        async def async_converter(messages: list[Any]) -> list[Message]:
+        async def async_converter(
+            messages: list[Any],
+            *,
+            ctx: AgentContext,
+        ) -> list[Message]:
             nonlocal converter_called
+            del ctx
             converter_called = True
             return [
                 m

--- a/tests/middleware/compaction/test_boundary.py
+++ b/tests/middleware/compaction/test_boundary.py
@@ -47,6 +47,12 @@ def test_returns_boundary_at_user_message_start() -> None:
     assert safe_boundary(messages, keep_recent=2, min_compact=1) == 4
 
 
+def test_short_history_has_no_safe_boundary() -> None:
+    messages: list[Message] = [_user("q1"), _assistant("a1")]
+
+    assert safe_boundary(messages, keep_recent=2) is None
+
+
 def test_rejects_suffix_with_orphan_tool_result() -> None:
     call = ToolCall(id="c1", name="search", arguments={})
     messages: list[Message] = [
@@ -59,6 +65,20 @@ def test_rejects_suffix_with_orphan_tool_result() -> None:
     ]
 
     assert safe_boundary(messages, keep_recent=2, min_compact=1) is None
+
+
+def test_accepts_suffix_with_matching_tool_call_and_result() -> None:
+    call = ToolCall(id="c1", name="search", arguments={})
+    messages: list[Message] = [
+        _user("q1"),
+        _assistant("a1"),
+        _user("q2"),
+        _assistant(tool_calls=[call]),
+        _tool_result("c1"),
+        _assistant("done"),
+    ]
+
+    assert safe_boundary(messages, keep_recent=3, min_compact=1) == 2
 
 
 def test_enforces_min_compact() -> None:

--- a/tests/middleware/compaction/test_boundary.py
+++ b/tests/middleware/compaction/test_boundary.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from cubepi.middleware.compaction.boundary import safe_boundary
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+
+
+def _user(text: str) -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)])
+
+
+def _assistant(
+    text: str = "", tool_calls: list[ToolCall] | None = None
+) -> AssistantMessage:
+    content = []
+    if text:
+        content.append(TextContent(text=text))
+    if tool_calls:
+        content.extend(tool_calls)
+    return AssistantMessage(content=content)
+
+
+def _tool_result(call_id: str) -> ToolResultMessage:
+    return ToolResultMessage(
+        tool_call_id=call_id,
+        tool_name="tool",
+        content=[TextContent(text="ok")],
+    )
+
+
+def test_returns_boundary_at_user_message_start() -> None:
+    messages: list[Message] = [
+        _user("q1"),
+        _assistant("a1"),
+        _user("q2"),
+        _assistant("a2"),
+        _user("q3"),
+        _assistant("a3"),
+    ]
+
+    assert safe_boundary(messages, keep_recent=2, min_compact=1) == 4
+
+
+def test_rejects_suffix_with_orphan_tool_result() -> None:
+    call = ToolCall(id="c1", name="search", arguments={})
+    messages: list[Message] = [
+        _user("q1"),
+        _assistant(tool_calls=[call]),
+        _tool_result("c1"),
+        _user("q2"),
+        _tool_result("orphan"),
+        _assistant("done"),
+    ]
+
+    assert safe_boundary(messages, keep_recent=2, min_compact=1) is None
+
+
+def test_enforces_min_compact() -> None:
+    messages: list[Message] = [
+        _user("q1"),
+        _assistant("a1"),
+        _user("q2"),
+        _assistant("a2"),
+    ]
+
+    assert safe_boundary(messages, keep_recent=2, min_compact=3) is None
+    assert safe_boundary(messages, keep_recent=2, min_compact=1) == 2

--- a/tests/middleware/compaction/test_summarizer.py
+++ b/tests/middleware/compaction/test_summarizer.py
@@ -73,6 +73,7 @@ async def test_summarize_uses_provider_generate_with_common_overrides() -> None:
 
     assert isinstance(result, CompactionState)
     assert result.summary == "Compressed summary."
+    assert len(result.summarized_message_refs) == 2
     assert provider.calls[0]["max_output_tokens"] == 512
     assert provider.calls[0]["temperature"] == 0.0
     assert provider.calls[0]["thinking"] == "off"

--- a/tests/middleware/compaction/test_summarizer.py
+++ b/tests/middleware/compaction/test_summarizer.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+from cubepi.middleware.compaction import CompactionState
+from cubepi.middleware.compaction.summarizer import summarize
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    Model,
+    StreamOptions,
+    TextContent,
+    ToolDefinition,
+    UserMessage,
+)
+
+
+class _FakeProvider:
+    def __init__(self, reply: str) -> None:
+        self.reply = reply
+        self.calls: list[dict[str, Any]] = []
+
+    async def generate(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        thinking=None,
+        thinking_budgets=None,
+    ) -> AssistantMessage:
+        self.calls.append(
+            {
+                "model": model,
+                "messages": messages,
+                "system_prompt": system_prompt,
+                "tools": tools,
+                "options": options,
+                "max_output_tokens": max_output_tokens,
+                "temperature": temperature,
+                "thinking": thinking,
+                "thinking_budgets": thinking_budgets,
+            }
+        )
+        return AssistantMessage(content=[TextContent(text=self.reply)])
+
+
+async def test_summarize_uses_provider_generate_with_common_overrides() -> None:
+    provider = _FakeProvider(" Compressed summary. ")
+    model = Model(id="summary-model", provider="faux")
+
+    result = await summarize(
+        provider=provider,
+        model=model,
+        messages_to_summarize=[
+            UserMessage(content=[TextContent(text="hello")]),
+            AssistantMessage(content=[TextContent(text="hi")]),
+        ],
+        existing=None,
+        max_summary_tokens=512,
+    )
+
+    assert isinstance(result, CompactionState)
+    assert result.summary == "Compressed summary."
+    assert provider.calls[0]["max_output_tokens"] == 512
+    assert provider.calls[0]["temperature"] == 0.0
+    assert provider.calls[0]["thinking"] == "off"
+
+
+async def test_summarize_merges_existing_state() -> None:
+    provider = _FakeProvider("Merged summary.")
+    existing = CompactionState(summary="Older context.")
+
+    result = await summarize(
+        provider=provider,
+        model=Model(id="summary-model", provider="faux"),
+        messages_to_summarize=[UserMessage(content=[TextContent(text="new")])],
+        existing=existing,
+    )
+
+    assert "Older context." in provider.calls[0]["system_prompt"]
+    assert result.summary == "Merged summary."

--- a/tests/middleware/compaction/test_summarizer.py
+++ b/tests/middleware/compaction/test_summarizer.py
@@ -131,15 +131,21 @@ async def test_summarize_raises_on_provider_error_message() -> None:
 
 
 def test_format_message_for_summary_includes_tool_calls_and_text_like_blocks() -> None:
-    message = AssistantMessage(
-        content=[
+    class _TextLike:
+        text = "extra text"
+
+    class _Transcript:
+        content = [
             TextContent(text="checking"),
             ToolCall(id="t1", name="lookup", arguments={"q": "x"}),
+            _TextLike(),
         ]
-    )
 
-    formatted = _format_message_for_summary(message)
+    message = _Transcript()
 
-    assert "[assistant]" in formatted
+    formatted = _format_message_for_summary(message)  # type: ignore[arg-type]
+
+    assert "[_transcript]" in formatted
     assert "checking" in formatted
     assert "[tool_call:lookup]" in formatted
+    assert "extra text" in formatted

--- a/tests/middleware/compaction/test_summarizer.py
+++ b/tests/middleware/compaction/test_summarizer.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from cubepi.middleware.compaction import CompactionState
-from cubepi.middleware.compaction.summarizer import summarize
+from cubepi.middleware.compaction.summarizer import (
+    _format_message_for_summary,
+    summarize,
+)
 from cubepi.providers.base import (
     AssistantMessage,
     Message,
     Model,
     StreamOptions,
     TextContent,
+    ToolCall,
     ToolDefinition,
     UserMessage,
 )
@@ -52,6 +57,7 @@ class _FakeProvider:
 async def test_summarize_uses_provider_generate_with_common_overrides() -> None:
     provider = _FakeProvider(" Compressed summary. ")
     model = Model(id="summary-model", provider="faux")
+    signal = asyncio.Event()
 
     result = await summarize(
         provider=provider,
@@ -62,6 +68,7 @@ async def test_summarize_uses_provider_generate_with_common_overrides() -> None:
         ],
         existing=None,
         max_summary_tokens=512,
+        abort_signal=signal,
     )
 
     assert isinstance(result, CompactionState)
@@ -69,6 +76,7 @@ async def test_summarize_uses_provider_generate_with_common_overrides() -> None:
     assert provider.calls[0]["max_output_tokens"] == 512
     assert provider.calls[0]["temperature"] == 0.0
     assert provider.calls[0]["thinking"] == "off"
+    assert provider.calls[0]["options"].signal is signal
 
 
 async def test_summarize_merges_existing_state() -> None:
@@ -84,3 +92,54 @@ async def test_summarize_merges_existing_state() -> None:
 
     assert "Older context." in provider.calls[0]["system_prompt"]
     assert result.summary == "Merged summary."
+
+
+async def test_summarize_raises_on_provider_error_message() -> None:
+    class _ErrorProvider(_FakeProvider):
+        async def generate(
+            self,
+            model: Model,
+            messages: list[Message],
+            *,
+            system_prompt: str = "",
+            tools: list[ToolDefinition] | None = None,
+            options: StreamOptions | None = None,
+            max_output_tokens: int | None = None,
+            temperature: float | None = None,
+            thinking=None,
+            thinking_budgets=None,
+        ) -> AssistantMessage:
+            del model, messages, system_prompt, tools, options
+            del max_output_tokens, temperature, thinking, thinking_budgets
+            return AssistantMessage(
+                content=[],
+                stop_reason="error",
+                error_message="summary failed",
+            )
+
+    try:
+        await summarize(
+            provider=_ErrorProvider(""),
+            model=Model(id="summary-model", provider="faux"),
+            messages_to_summarize=[UserMessage(content=[TextContent(text="new")])],
+            existing=None,
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "summary failed"
+    else:  # pragma: no cover
+        raise AssertionError("provider error was not raised")
+
+
+def test_format_message_for_summary_includes_tool_calls_and_text_like_blocks() -> None:
+    message = AssistantMessage(
+        content=[
+            TextContent(text="checking"),
+            ToolCall(id="t1", name="lookup", arguments={"q": "x"}),
+        ]
+    )
+
+    formatted = _format_message_for_summary(message)
+
+    assert "[assistant]" in formatted
+    assert "checking" in formatted
+    assert "[tool_call:lookup]" in formatted

--- a/tests/middleware/compaction/test_tokens.py
+++ b/tests/middleware/compaction/test_tokens.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from cubepi.middleware.compaction.tokens import approx_tokens
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolResultMessage,
+    Usage,
+    UserMessage,
+)
+
+
+def test_empty_returns_zero() -> None:
+    assert approx_tokens([]) == 0
+
+
+def test_text_chars_use_conservative_cjk_safe_estimate() -> None:
+    messages = [UserMessage(content=[TextContent(text="x" * 200)])]
+
+    assert approx_tokens(messages) == 100
+
+
+def test_usage_metadata_scales_estimate_up() -> None:
+    messages = [
+        UserMessage(content=[TextContent(text="x" * 900)]),
+        AssistantMessage(
+            content=[TextContent(text="y" * 100)],
+            usage=Usage(input_tokens=400, output_tokens=10),
+        ),
+    ]
+
+    assert approx_tokens(messages) == 625
+
+
+def test_tool_result_text_is_counted() -> None:
+    messages = [
+        ToolResultMessage(
+            tool_call_id="c1",
+            tool_name="search",
+            content=[TextContent(text="x" * 200)],
+        )
+    ]
+
+    assert approx_tokens(messages) == 100

--- a/tests/middleware/compaction/test_tokens.py
+++ b/tests/middleware/compaction/test_tokens.py
@@ -4,6 +4,7 @@ from cubepi.middleware.compaction.tokens import approx_tokens
 from cubepi.providers.base import (
     AssistantMessage,
     TextContent,
+    ToolCall,
     ToolResultMessage,
     Usage,
     UserMessage,
@@ -42,3 +43,19 @@ def test_tool_result_text_is_counted() -> None:
     ]
 
     assert approx_tokens(messages) == 100
+
+
+def test_tool_call_arguments_are_counted() -> None:
+    messages = [
+        AssistantMessage(
+            content=[
+                ToolCall(
+                    id="c1",
+                    name="search",
+                    arguments={"query": "x" * 20},
+                )
+            ],
+        )
+    ]
+
+    assert approx_tokens(messages) > 0

--- a/tests/middleware/test_base.py
+++ b/tests/middleware/test_base.py
@@ -23,45 +23,76 @@ class TestComposeMiddlewareEmpty:
 
 
 class TestTransformContext:
-    async def test_chained_transform_context(self):
+    async def test_chained_transform_context_receives_agent_context(self):
         class AddPrefix(Middleware):
-            async def transform_context(self, messages, *, signal=None):
+            async def transform_context(self, messages, *, ctx, signal=None):
+                ctx.extra["prefix_called"] = True
                 return [UserMessage(content=[TextContent(text="PREFIX")])] + list(
                     messages
                 )
 
         class AddSuffix(Middleware):
-            async def transform_context(self, messages, *, signal=None):
+            async def transform_context(self, messages, *, ctx, signal=None):
+                ctx.extra["suffix_called"] = True
                 return list(messages) + [
                     UserMessage(content=[TextContent(text="SUFFIX")])
                 ]
 
         hooks = compose_middleware([AddPrefix(), AddSuffix()])
+        ctx = AgentContext(system_prompt="", messages=[])
         result = await hooks["transform_context"](
-            [UserMessage(content=[TextContent(text="middle")])], signal=None
+            [UserMessage(content=[TextContent(text="middle")])], ctx=ctx, signal=None
         )
 
         assert len(result) == 3
         assert result[0].content[0].text == "PREFIX"
         assert result[1].content[0].text == "middle"
         assert result[2].content[0].text == "SUFFIX"
+        assert ctx.extra == {"prefix_called": True, "suffix_called": True}
 
 
 class TestConvertToLlm:
-    async def test_last_implementation_wins(self):
+    async def test_last_implementation_wins_and_receives_agent_context(self):
         class First(Middleware):
-            async def convert_to_llm(self, messages):
+            async def convert_to_llm(self, messages, *, ctx):
+                ctx.extra["first_called"] = True
                 return [UserMessage(content=[TextContent(text="first")])]
 
         class Second(Middleware):
-            async def convert_to_llm(self, messages):
+            async def convert_to_llm(self, messages, *, ctx):
+                ctx.extra["second_called"] = True
                 return [UserMessage(content=[TextContent(text="second")])]
 
         hooks = compose_middleware([First(), Second()])
-        result = await hooks["convert_to_llm"]([])
+        ctx = AgentContext(system_prompt="", messages=[])
+        result = await hooks["convert_to_llm"]([], ctx=ctx)
 
         assert len(result) == 1
         assert result[0].content[0].text == "second"
+        assert ctx.extra == {"second_called": True}
+
+
+class TestTransformSystemPrompt:
+    async def test_chained_transform_system_prompt_receives_agent_context(self):
+        class AddPrefix(Middleware):
+            async def transform_system_prompt(self, system_prompt, *, ctx, signal=None):
+                ctx.extra["prompt_prefix_called"] = True
+                return f"prefix {system_prompt}"
+
+        class AddSuffix(Middleware):
+            async def transform_system_prompt(self, system_prompt, *, ctx, signal=None):
+                ctx.extra["prompt_suffix_called"] = True
+                return f"{system_prompt} suffix"
+
+        hooks = compose_middleware([AddPrefix(), AddSuffix()])
+        ctx = AgentContext(system_prompt="base", messages=[])
+        result = await hooks["transform_system_prompt"]("base", ctx=ctx, signal=None)
+
+        assert result == "prefix base suffix"
+        assert ctx.extra == {
+            "prompt_prefix_called": True,
+            "prompt_suffix_called": True,
+        }
 
 
 class TestBeforeToolCall:
@@ -177,9 +208,10 @@ class TestAgentMiddlewareWiring:
         captured: dict = {}
 
         class MarkConvert(Middleware):
-            async def convert_to_llm(self, messages):
+            async def convert_to_llm(self, messages, *, ctx):
                 captured["called"] = True
                 captured["count"] = len(messages)
+                captured["ctx"] = ctx
                 return list(messages)
 
         provider = FauxProvider()
@@ -191,12 +223,13 @@ class TestAgentMiddlewareWiring:
         )
         await agent.prompt("hi")
         assert captured.get("called") is True
+        assert isinstance(captured.get("ctx"), AgentContext)
 
 
 class TestPartialMiddleware:
     async def test_middleware_with_only_some_hooks(self):
         class OnlyTransform(Middleware):
-            async def transform_context(self, messages, *, signal=None):
+            async def transform_context(self, messages, *, ctx, signal=None):
                 return messages
 
         hooks = compose_middleware([OnlyTransform()])
@@ -217,13 +250,17 @@ class TestBaseMiddlewareDefaults:
         import pytest
 
         with pytest.raises(NotImplementedError):
-            await Middleware().transform_context([], signal=None)
+            await Middleware().transform_context(
+                [], ctx=AgentContext(system_prompt="", messages=[]), signal=None
+            )
 
     async def test_convert_to_llm_raises(self):
         import pytest
 
         with pytest.raises(NotImplementedError):
-            await Middleware().convert_to_llm([])
+            await Middleware().convert_to_llm(
+                [], ctx=AgentContext(system_prompt="", messages=[])
+            )
 
     async def test_before_tool_call_raises(self):
         import pytest
@@ -241,7 +278,9 @@ class TestBaseMiddlewareDefaults:
         import pytest
 
         with pytest.raises(NotImplementedError):
-            await Middleware().transform_system_prompt("hello", signal=None)
+            await Middleware().transform_system_prompt(
+                "hello", ctx=AgentContext(system_prompt="", messages=[]), signal=None
+            )
 
     async def test_should_stop_after_turn_raises(self):
         import pytest

--- a/tests/middleware/test_compaction.py
+++ b/tests/middleware/test_compaction.py
@@ -6,6 +6,7 @@ from typing import Any
 from cubepi.agent.types import AgentContext
 from cubepi.middleware.compaction import CompactionMiddleware, CompactionState
 from cubepi.middleware.compaction import _load_state
+from cubepi.middleware.compaction.state import message_refs
 from cubepi.providers.base import (
     AssistantMessage,
     Message,
@@ -92,7 +93,10 @@ async def test_under_threshold_returns_existing_compressed_view() -> None:
         system_prompt="",
         messages=messages,
         extra={
-            "compaction": CompactionState(summary="old summary").model_dump(),
+            "compaction": CompactionState(
+                summary="old summary",
+                summarized_message_refs=message_refs(messages[:2]),
+            ).model_dump(),
             "compaction_until_msg_index": 2,
         },
     )
@@ -187,5 +191,39 @@ async def test_stale_boundary_larger_than_history_is_ignored() -> None:
     result = await middleware.transform_context(messages, ctx=ctx)
 
     assert result == messages
+    assert "compaction" not in ctx.extra
+    assert "compaction_until_msg_index" not in ctx.extra
+
+
+async def test_stale_boundary_from_replaced_history_is_ignored() -> None:
+    provider = _FakeSummaryProvider()
+    middleware = _make_middleware(provider, max_tokens_before=100_000)
+    old_messages: list[Message] = [
+        _user("old turn 1"),
+        _assistant("old reply 1"),
+        _user("old turn 2"),
+        _assistant("old reply 2"),
+    ]
+    new_messages: list[Message] = [
+        _user("new turn 1"),
+        _assistant("new reply 1"),
+        _user("new turn 2"),
+        _assistant("new reply 2"),
+    ]
+    ctx = AgentContext(
+        system_prompt="",
+        messages=new_messages,
+        extra={
+            "compaction": CompactionState(
+                summary="old summary",
+                summarized_message_refs=message_refs(old_messages[:2]),
+            ).model_dump(),
+            "compaction_until_msg_index": 2,
+        },
+    )
+
+    result = await middleware.transform_context(new_messages, ctx=ctx)
+
+    assert result == new_messages
     assert "compaction" not in ctx.extra
     assert "compaction_until_msg_index" not in ctx.extra

--- a/tests/middleware/test_compaction.py
+++ b/tests/middleware/test_compaction.py
@@ -227,3 +227,23 @@ async def test_stale_boundary_from_replaced_history_is_ignored() -> None:
     assert result == new_messages
     assert "compaction" not in ctx.extra
     assert "compaction_until_msg_index" not in ctx.extra
+
+
+async def test_malformed_persisted_state_is_cleared() -> None:
+    provider = _FakeSummaryProvider()
+    middleware = _make_middleware(provider, max_tokens_before=100_000)
+    messages: list[Message] = [_user("new question")]
+    ctx = AgentContext(
+        system_prompt="",
+        messages=messages,
+        extra={
+            "compaction": {},
+            "compaction_until_msg_index": 1,
+        },
+    )
+
+    result = await middleware.transform_context(messages, ctx=ctx)
+
+    assert result == messages
+    assert "compaction" not in ctx.extra
+    assert "compaction_until_msg_index" not in ctx.extra

--- a/tests/middleware/test_compaction.py
+++ b/tests/middleware/test_compaction.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from cubepi.agent.types import AgentContext
 from cubepi.middleware.compaction import CompactionMiddleware, CompactionState
+from cubepi.middleware.compaction import _load_state
 from cubepi.providers.base import (
     AssistantMessage,
     Message,
@@ -105,6 +106,13 @@ async def test_under_threshold_returns_existing_compressed_view() -> None:
     assert provider.calls == []
 
 
+def test_load_state_accepts_state_and_ignores_unknown_values() -> None:
+    state = CompactionState(summary="cached")
+
+    assert _load_state(state) is state
+    assert _load_state("not-state") is None
+
+
 async def test_over_threshold_writes_json_safe_state_to_ctx_extra() -> None:
     provider = _FakeSummaryProvider(reply="New summary")
     middleware = _make_middleware(provider, max_tokens_before=1)
@@ -127,6 +135,21 @@ async def test_over_threshold_writes_json_safe_state_to_ctx_extra() -> None:
     assert ctx.extra["compaction_until_msg_index"] > 0
     assert isinstance(result[0], UserMessage)
     assert provider.calls[0]["options"].signal is signal
+
+
+async def test_over_threshold_without_safe_boundary_returns_compressed_view() -> None:
+    provider = _FakeSummaryProvider()
+    middleware = _make_middleware(provider, max_tokens_before=1)
+    messages: list[Message] = [
+        _user("turn 1"),
+        _assistant("reply 1"),
+    ]
+    ctx = AgentContext(system_prompt="", messages=messages, extra={})
+
+    result = await middleware.transform_context(messages, ctx=ctx)
+
+    assert result == messages
+    assert provider.calls == []
 
 
 async def test_summarizer_failure_returns_current_view_without_writing_state() -> None:

--- a/tests/middleware/test_compaction.py
+++ b/tests/middleware/test_compaction.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any
+
+from cubepi.agent.types import AgentContext
+from cubepi.middleware.compaction import CompactionMiddleware, CompactionState
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    Model,
+    StreamOptions,
+    TextContent,
+    ToolDefinition,
+    UserMessage,
+)
+
+
+def _user(text: str) -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)])
+
+
+def _assistant(text: str) -> AssistantMessage:
+    return AssistantMessage(content=[TextContent(text=text)])
+
+
+class _FakeSummaryProvider:
+    def __init__(
+        self, *, reply: str = "summary text", raises: Exception | None = None
+    ) -> None:
+        self.reply = reply
+        self.raises = raises
+        self.calls: list[dict[str, Any]] = []
+
+    async def generate(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        thinking=None,
+        thinking_budgets=None,
+    ) -> AssistantMessage:
+        self.calls.append(
+            {
+                "model": model,
+                "messages": messages,
+                "system_prompt": system_prompt,
+                "tools": tools,
+                "options": options,
+                "max_output_tokens": max_output_tokens,
+                "temperature": temperature,
+                "thinking": thinking,
+                "thinking_budgets": thinking_budgets,
+            }
+        )
+        if self.raises is not None:
+            raise self.raises
+        return AssistantMessage(content=[TextContent(text=self.reply)])
+
+
+def _make_middleware(
+    provider: _FakeSummaryProvider,
+    *,
+    max_tokens_before: int = 1000,
+) -> CompactionMiddleware:
+    return CompactionMiddleware(
+        summary_provider=provider,
+        summary_model=Model(id="summary-model", provider="faux"),
+        max_tokens_before_compact=max_tokens_before,
+        keep_recent_messages=2,
+        max_summary_tokens=512,
+        min_compact_messages=2,
+    )
+
+
+async def test_under_threshold_returns_existing_compressed_view() -> None:
+    provider = _FakeSummaryProvider()
+    middleware = _make_middleware(provider, max_tokens_before=100_000)
+    messages: list[Message] = [
+        _user("old"),
+        _assistant("old reply"),
+        _user("recent"),
+        _assistant("recent reply"),
+    ]
+    ctx = AgentContext(
+        system_prompt="",
+        messages=messages,
+        extra={
+            "compaction": CompactionState(summary="old summary").model_dump(),
+            "compaction_until_msg_index": 2,
+        },
+    )
+
+    result = await middleware.transform_context(messages, ctx=ctx)
+
+    assert len(result) == 3
+    assert isinstance(result[0], UserMessage)
+    assert "old summary" in result[0].content[0].text
+    assert result[1:] == messages[2:]
+    assert provider.calls == []
+
+
+async def test_over_threshold_writes_json_safe_state_to_ctx_extra() -> None:
+    provider = _FakeSummaryProvider(reply="New summary")
+    middleware = _make_middleware(provider, max_tokens_before=1)
+    messages: list[Message] = [
+        _user("turn 1"),
+        _assistant("reply 1"),
+        _user("turn 2"),
+        _assistant("reply 2"),
+        _user("turn 3"),
+        _assistant("reply 3"),
+    ]
+    ctx = AgentContext(system_prompt="", messages=messages, extra={})
+
+    result = await middleware.transform_context(messages, ctx=ctx)
+
+    assert isinstance(ctx.extra["compaction"], dict)
+    state = CompactionState.model_validate(ctx.extra["compaction"])
+    assert state.summary == "New summary"
+    assert ctx.extra["compaction_until_msg_index"] > 0
+    assert isinstance(result[0], UserMessage)
+
+
+async def test_summarizer_failure_returns_current_view_without_writing_state() -> None:
+    provider = _FakeSummaryProvider(raises=RuntimeError("LLM unavailable"))
+    middleware = _make_middleware(provider, max_tokens_before=1)
+    messages: list[Message] = [
+        _user("turn 1"),
+        _assistant("reply 1"),
+        _user("turn 2"),
+        _assistant("reply 2"),
+        _user("turn 3"),
+        _assistant("reply 3"),
+    ]
+    ctx = AgentContext(system_prompt="", messages=messages, extra={})
+
+    result = await middleware.transform_context(messages, ctx=ctx)
+
+    assert result == messages
+    assert "compaction" not in ctx.extra

--- a/tests/middleware/test_compaction.py
+++ b/tests/middleware/test_compaction.py
@@ -143,3 +143,21 @@ async def test_summarizer_failure_returns_current_view_without_writing_state() -
 
     assert result == messages
     assert "compaction" not in ctx.extra
+
+
+async def test_stale_boundary_larger_than_history_is_ignored() -> None:
+    provider = _FakeSummaryProvider()
+    middleware = _make_middleware(provider, max_tokens_before=100_000)
+    messages: list[Message] = [_user("new question")]
+    ctx = AgentContext(
+        system_prompt="",
+        messages=messages,
+        extra={
+            "compaction": CompactionState(summary="old summary").model_dump(),
+            "compaction_until_msg_index": 10,
+        },
+    )
+
+    result = await middleware.transform_context(messages, ctx=ctx)
+
+    assert result == messages

--- a/tests/middleware/test_compaction.py
+++ b/tests/middleware/test_compaction.py
@@ -6,7 +6,7 @@ from typing import Any
 from cubepi.agent.types import AgentContext
 from cubepi.middleware.compaction import CompactionMiddleware, CompactionState
 from cubepi.middleware.compaction import _load_state
-from cubepi.middleware.compaction.state import message_refs
+from cubepi.middleware.compaction.state import message_ref, message_refs
 from cubepi.providers.base import (
     AssistantMessage,
     Message,
@@ -117,6 +117,17 @@ def test_load_state_accepts_state_and_ignores_unknown_values() -> None:
     assert _load_state("not-state") is None
 
 
+def test_message_ref_prefers_explicit_message_id() -> None:
+    class _MessageWithId:
+        id = "msg-123"
+
+        def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+            del kwargs
+            return {"content": "unused"}
+
+    assert message_ref(_MessageWithId()) == "id:msg-123"  # type: ignore[arg-type]
+
+
 async def test_over_threshold_writes_json_safe_state_to_ctx_extra() -> None:
     provider = _FakeSummaryProvider(reply="New summary")
     middleware = _make_middleware(provider, max_tokens_before=1)
@@ -225,6 +236,34 @@ async def test_stale_boundary_from_replaced_history_is_ignored() -> None:
     result = await middleware.transform_context(new_messages, ctx=ctx)
 
     assert result == new_messages
+    assert "compaction" not in ctx.extra
+    assert "compaction_until_msg_index" not in ctx.extra
+
+
+async def test_stale_boundary_with_mismatched_ref_count_is_ignored() -> None:
+    provider = _FakeSummaryProvider()
+    middleware = _make_middleware(provider, max_tokens_before=100_000)
+    messages: list[Message] = [
+        _user("turn 1"),
+        _assistant("reply 1"),
+        _user("turn 2"),
+        _assistant("reply 2"),
+    ]
+    ctx = AgentContext(
+        system_prompt="",
+        messages=messages,
+        extra={
+            "compaction": CompactionState(
+                summary="old summary",
+                summarized_message_refs=message_refs(messages[:1]),
+            ).model_dump(),
+            "compaction_until_msg_index": 2,
+        },
+    )
+
+    result = await middleware.transform_context(messages, ctx=ctx)
+
+    assert result == messages
     assert "compaction" not in ctx.extra
     assert "compaction_until_msg_index" not in ctx.extra
 

--- a/tests/middleware/test_compaction.py
+++ b/tests/middleware/test_compaction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from cubepi.agent.types import AgentContext
@@ -107,6 +108,7 @@ async def test_under_threshold_returns_existing_compressed_view() -> None:
 async def test_over_threshold_writes_json_safe_state_to_ctx_extra() -> None:
     provider = _FakeSummaryProvider(reply="New summary")
     middleware = _make_middleware(provider, max_tokens_before=1)
+    signal = asyncio.Event()
     messages: list[Message] = [
         _user("turn 1"),
         _assistant("reply 1"),
@@ -117,13 +119,14 @@ async def test_over_threshold_writes_json_safe_state_to_ctx_extra() -> None:
     ]
     ctx = AgentContext(system_prompt="", messages=messages, extra={})
 
-    result = await middleware.transform_context(messages, ctx=ctx)
+    result = await middleware.transform_context(messages, ctx=ctx, signal=signal)
 
     assert isinstance(ctx.extra["compaction"], dict)
     state = CompactionState.model_validate(ctx.extra["compaction"])
     assert state.summary == "New summary"
     assert ctx.extra["compaction_until_msg_index"] > 0
     assert isinstance(result[0], UserMessage)
+    assert provider.calls[0]["options"].signal is signal
 
 
 async def test_summarizer_failure_returns_current_view_without_writing_state() -> None:
@@ -161,3 +164,5 @@ async def test_stale_boundary_larger_than_history_is_ignored() -> None:
     result = await middleware.transform_context(messages, ctx=ctx)
 
     assert result == messages
+    assert "compaction" not in ctx.extra
+    assert "compaction_until_msg_index" not in ctx.extra

--- a/tests/middleware/test_init_exports.py
+++ b/tests/middleware/test_init_exports.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+import cubepi.middleware as middleware
+
+
+def test_lazy_exports_resolve_builtin_middleware() -> None:
+    assert middleware.CompactionMiddleware.__name__ == "CompactionMiddleware"
+    assert middleware.CompactionState.__name__ == "CompactionState"
+    assert middleware.SubagentMiddleware.__name__ == "SubagentMiddleware"
+    assert middleware.SubagentSpec.__name__ == "SubagentSpec"
+
+
+def test_unknown_lazy_export_raises_attribute_error() -> None:
+    with pytest.raises(AttributeError):
+        getattr(middleware, "MissingMiddleware")

--- a/tests/middleware/test_subagents.py
+++ b/tests/middleware/test_subagents.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from pydantic import BaseModel
+
+from cubepi import AgentTool, AgentToolResult, TextContent
+from cubepi.middleware.subagents import SubagentMiddleware, SubagentSpec
+from cubepi.providers.base import Model
+from cubepi.providers.faux import FauxProvider, faux_assistant_message
+
+
+def _make_middleware(
+    *,
+    provider: FauxProvider | None = None,
+    subagents: dict[str, SubagentSpec] | None = None,
+    **kwargs: Any,
+) -> SubagentMiddleware:
+    provider = provider or FauxProvider()
+    subagents = subagents or {
+        "general-purpose": SubagentSpec(
+            name="general-purpose",
+            description="general",
+            system_prompt="You are a subagent.",
+        )
+    }
+    return SubagentMiddleware(
+        subagents=subagents,
+        default_provider=provider,
+        default_model=Model(id="faux-1", provider="faux"),
+        **kwargs,
+    )
+
+
+def test_middleware_exposes_subagent_tool() -> None:
+    middleware = _make_middleware()
+
+    assert len(middleware.tools) == 1
+    assert middleware.tools[0].name == "subagent"
+    schema = middleware.tools[0].parameters.model_json_schema()
+    assert "prompt" in schema["properties"]
+    assert "subagent_type" in schema["properties"]
+
+
+def test_general_purpose_fallback_is_registered() -> None:
+    middleware = _make_middleware(
+        subagents={
+            "specialist": SubagentSpec(
+                name="specialist",
+                description="niche",
+                system_prompt="You are special.",
+            )
+        }
+    )
+
+    assert "general-purpose" in middleware.subagents
+    assert "specialist" in middleware.subagents
+
+
+def test_shared_tools_filter_is_configurable() -> None:
+    class _NoArgs(BaseModel):
+        pass
+
+    async def _noop(
+        tool_call_id: str,
+        args: _NoArgs,
+        *,
+        signal: Any = None,
+        on_update: Any = None,
+    ) -> AgentToolResult:
+        del tool_call_id, args, signal, on_update
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    safe = AgentTool(name="safe", description="safe", parameters=_NoArgs, execute=_noop)
+    subagent = AgentTool(
+        name="subagent", description="recursive", parameters=_NoArgs, execute=_noop
+    )
+    load_skill = AgentTool(
+        name="load_skill",
+        description="host-specific",
+        parameters=_NoArgs,
+        execute=_noop,
+    )
+
+    middleware = _make_middleware(
+        shared_tools=[safe, subagent, load_skill],
+        excluded_tool_names={"subagent", "load_skill"},
+    )
+
+    assert middleware.shared_tools == (safe,)
+
+
+async def test_subagent_tool_dispatches_to_child_agent() -> None:
+    provider = FauxProvider()
+    provider.set_responses([faux_assistant_message("subagent reply")])
+    middleware = _make_middleware(provider=provider)
+    [tool] = middleware.tools
+
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="general-purpose",
+    )
+    result = await tool.execute("tc-1", args, signal=None, on_update=None)
+
+    assert result.is_error is not True
+    assert result.content[0].text == "subagent reply"
+    assert isinstance(result.details, dict)
+    assert "subagent_events" in result.details
+
+
+async def test_unknown_subagent_type_falls_back_to_general_purpose() -> None:
+    provider = FauxProvider()
+    provider.set_responses([faux_assistant_message("fallback reply")])
+    middleware = _make_middleware(provider=provider)
+    [tool] = middleware.tools
+
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="missing",
+    )
+    result = await tool.execute("tc-2", args, signal=None, on_update=None)
+
+    assert result.is_error is not True
+    assert result.content[0].text == "fallback reply"
+
+
+async def test_event_mapper_and_handler_receive_child_events() -> None:
+    provider = FauxProvider()
+    provider.set_responses([faux_assistant_message("mapped reply")])
+    handled: list[tuple[str, dict[str, Any]]] = []
+
+    def mapper(event: Any) -> list[dict[str, Any]]:
+        return [{"type": event.type}]
+
+    async def handler(agent_id: str, payload: dict[str, Any]) -> None:
+        handled.append((agent_id, payload))
+
+    middleware = _make_middleware(
+        provider=provider,
+        event_mapper=mapper,
+        event_handler=handler,
+    )
+    [tool] = middleware.tools
+
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="general-purpose",
+    )
+    result = await tool.execute("tc-3", args, signal=None, on_update=None)
+
+    assert handled
+    assert all(agent_id == "subagent:tc-3" for agent_id, _ in handled)
+    assert result.details["subagent_events"] == [payload for _, payload in handled]
+
+
+async def test_inner_agent_failure_returns_tool_error() -> None:
+    class _FailingProvider(FauxProvider):
+        async def stream(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            raise RuntimeError("inner boom")
+
+    middleware = _make_middleware(provider=_FailingProvider())
+    [tool] = middleware.tools
+
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="general-purpose",
+    )
+    result = await tool.execute("tc-4", args, signal=None, on_update=None)
+
+    assert result.is_error is True
+    assert "inner boom" in result.content[0].text
+
+
+async def test_tracer_detaches_after_success_and_cancel() -> None:
+    tracer = _FakeTracer(awaitable_detach=True)
+    provider = FauxProvider()
+    provider.set_responses([faux_assistant_message("ok")])
+    middleware = _make_middleware(provider=provider, tracer=tracer)
+    [tool] = middleware.tools
+
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="general-purpose",
+    )
+    result = await tool.execute("tc-5", args, signal=None, on_update=None)
+
+    assert result.is_error is not True
+    assert len(tracer.attached) == 1
+    assert tracer.detached == 1
+    assert tracer.awaited is True
+
+
+async def test_cancelled_subagent_run_propagates_and_detaches_tracer() -> None:
+    class _CancelledProvider(FauxProvider):
+        async def stream(self, *args: Any, **kwargs: Any) -> Any:
+            del args, kwargs
+            raise asyncio.CancelledError()
+
+    tracer = _FakeTracer()
+    middleware = _make_middleware(provider=_CancelledProvider(), tracer=tracer)
+    [tool] = middleware.tools
+
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="general-purpose",
+    )
+    try:
+        await tool.execute("tc-6", args, signal=None, on_update=None)
+    except asyncio.CancelledError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("CancelledError was swallowed")
+
+    assert len(tracer.attached) == 1
+    assert tracer.detached == 1
+
+
+class _FakeTracer:
+    def __init__(self, *, awaitable_detach: bool = False) -> None:
+        self.awaitable_detach = awaitable_detach
+        self.attached: list[Any] = []
+        self.detached = 0
+        self.awaited = False
+
+    def attach(self, agent: Any) -> Any:
+        self.attached.append(agent)
+
+        def detach() -> Any:
+            self.detached += 1
+            if not self.awaitable_detach:
+                return None
+
+            async def flush() -> None:
+                await asyncio.sleep(0)
+                self.awaited = True
+
+            return flush()
+
+        return detach

--- a/tests/middleware/test_subagents.py
+++ b/tests/middleware/test_subagents.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from cubepi import AgentTool, AgentToolResult, TextContent
 from cubepi.middleware.subagents import SubagentMiddleware, SubagentSpec
 from cubepi.providers.base import Model
-from cubepi.providers.faux import FauxProvider, faux_assistant_message
+from cubepi.providers.faux import FauxProvider, faux_assistant_message, faux_tool_call
 
 
 def _make_middleware(
@@ -129,6 +129,55 @@ async def test_unknown_subagent_type_falls_back_to_general_purpose() -> None:
 
     assert result.is_error is not True
     assert result.content[0].text == "fallback reply"
+
+
+async def test_subagent_tool_returns_only_child_final_answer() -> None:
+    class _EchoParams(BaseModel):
+        value: str
+
+    async def _echo(
+        tool_call_id: str,
+        args: _EchoParams,
+        *,
+        signal: Any = None,
+        on_update: Any = None,
+    ) -> AgentToolResult:
+        del tool_call_id, signal, on_update
+        return AgentToolResult(content=[TextContent(text=f"echoed {args.value}")])
+
+    echo_tool = AgentTool(
+        name="echo",
+        description="echo",
+        parameters=_EchoParams,
+        execute=_echo,
+    )
+    provider = FauxProvider()
+    provider.set_responses(
+        [
+            faux_assistant_message(
+                [
+                    TextContent(text="I'll check."),
+                    faux_tool_call("echo", {"value": "x"}, id="echo-1"),
+                ],
+                stop_reason="tool_use",
+            ),
+            faux_assistant_message("final answer"),
+        ]
+    )
+    middleware = _make_middleware(provider=provider, shared_tools=[echo_tool])
+    [tool] = middleware.tools
+
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please use a tool",
+        subagent_type="general-purpose",
+    )
+    result = await tool.execute("tc-final", args, signal=None, on_update=None)
+
+    assert result.is_error is not True
+    assert result.content[0].text == "final answer"
 
 
 async def test_event_mapper_and_handler_receive_child_events() -> None:

--- a/tests/middleware/test_subagents.py
+++ b/tests/middleware/test_subagents.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from cubepi import AgentTool, AgentToolResult, TextContent
+from cubepi import Agent, AgentTool, AgentToolResult, TextContent, UserMessage
 from cubepi.middleware.subagents import SubagentMiddleware, SubagentSpec
 from cubepi.providers.base import AssistantMessage, MessageStream, Model, StreamEvent
 from cubepi.providers.faux import FauxProvider, faux_assistant_message, faux_tool_call
@@ -131,6 +131,29 @@ async def test_unknown_subagent_type_falls_back_to_general_purpose() -> None:
     assert result.content[0].text == "fallback reply"
 
 
+async def test_subagent_tool_returns_error_when_dispatch_raises() -> None:
+    middleware = _make_middleware()
+    [tool] = middleware.tools
+
+    async def fail_run(*args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise RuntimeError("dispatch boom")
+
+    middleware._run_subagent = fail_run  # type: ignore[method-assign]
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="general-purpose",
+    )
+
+    result = await tool.execute("tc-dispatch-error", args, signal=None, on_update=None)
+
+    assert result.is_error is True
+    assert "dispatch boom" in result.content[0].text
+
+
 async def test_subagent_tool_returns_only_child_final_answer() -> None:
     class _EchoParams(BaseModel):
         value: str
@@ -245,6 +268,36 @@ async def test_string_event_mapper_payload_is_treated_as_one_payload() -> None:
     assert result.details["subagent_events"] == ["started"]
 
 
+def test_child_error_handles_empty_non_assistant_and_error_assistant_states() -> None:
+    child = Agent(
+        provider=FauxProvider(),
+        model=Model(id="faux-1", provider="faux"),
+    )
+
+    assert SubagentMiddleware._child_error(child) is None
+
+    child.state.messages = [UserMessage(content=[TextContent(text="user only")])]
+    assert SubagentMiddleware._child_error(child) is None
+
+    child.state.messages = [
+        AssistantMessage(content=[], error_message="assistant failed")
+    ]
+    assert SubagentMiddleware._child_error(child) == "assistant failed"
+
+    child.state.messages = [AssistantMessage(content=[], stop_reason="error")]
+    assert SubagentMiddleware._child_error(child) == "subagent failed"
+
+
+def test_final_assistant_text_returns_empty_without_assistant_message() -> None:
+    child = Agent(
+        provider=FauxProvider(),
+        model=Model(id="faux-1", provider="faux"),
+    )
+    child.state.messages = [UserMessage(content=[TextContent(text="user only")])]
+
+    assert SubagentMiddleware._final_assistant_text(child) == ""
+
+
 async def test_inner_agent_failure_returns_tool_error() -> None:
     class _FailingProvider(FauxProvider):
         async def stream(self, *args: Any, **kwargs: Any) -> Any:
@@ -356,6 +409,69 @@ async def test_parent_signal_aborts_running_child_agent() -> None:
 
     assert result.is_error is True
     assert "aborted" in result.content[0].text
+
+
+async def test_abort_forwarder_waits_for_child_streaming_before_abort() -> None:
+    class _State:
+        is_streaming = False
+
+    class _Child:
+        state = _State()
+        aborted = False
+
+        def abort(self) -> None:
+            self.aborted = True
+
+    child = _Child()
+    signal = asyncio.Event()
+    middleware = _make_middleware()
+    task = middleware._start_abort_forwarder(child, signal)  # type: ignore[arg-type]
+    assert task is not None
+
+    signal.set()
+    await asyncio.sleep(0)
+    assert child.aborted is False
+
+    child.state.is_streaming = True
+    await asyncio.wait_for(task, timeout=1)
+    assert child.aborted is True
+
+
+async def test_stop_abort_forwarder_cancels_active_task() -> None:
+    middleware = _make_middleware()
+
+    async def never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(never())
+
+    await middleware._stop_abort_forwarder(task)
+
+    assert task.cancelled()
+
+
+def test_tracer_attach_failure_is_ignored() -> None:
+    class _BadTracer:
+        def attach(self, agent: Any) -> Any:
+            del agent
+            raise RuntimeError("attach failed")
+
+    middleware = _make_middleware(tracer=_BadTracer())
+    child = Agent(
+        provider=FauxProvider(),
+        model=Model(id="faux-1", provider="faux"),
+    )
+
+    assert middleware._attach_tracer(child) is None
+
+
+async def test_tracer_detach_failure_is_ignored() -> None:
+    middleware = _make_middleware()
+
+    def detach() -> None:
+        raise RuntimeError("detach failed")
+
+    await middleware._detach_tracer(detach)
 
 
 class _FakeTracer:

--- a/tests/middleware/test_subagents.py
+++ b/tests/middleware/test_subagents.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from cubepi import AgentTool, AgentToolResult, TextContent
 from cubepi.middleware.subagents import SubagentMiddleware, SubagentSpec
-from cubepi.providers.base import Model
+from cubepi.providers.base import AssistantMessage, MessageStream, Model, StreamEvent
 from cubepi.providers.faux import FauxProvider, faux_assistant_message, faux_tool_call
 
 
@@ -212,6 +212,39 @@ async def test_event_mapper_and_handler_receive_child_events() -> None:
     assert result.details["subagent_events"] == [payload for _, payload in handled]
 
 
+async def test_string_event_mapper_payload_is_treated_as_one_payload() -> None:
+    provider = FauxProvider()
+    provider.set_responses([faux_assistant_message("mapped reply")])
+    handled: list[tuple[str, str]] = []
+
+    def mapper(event: Any) -> str | None:
+        if event.type == "agent_start":
+            return "started"
+        return None
+
+    def handler(agent_id: str, payload: str) -> None:
+        handled.append((agent_id, payload))
+
+    middleware = _make_middleware(
+        provider=provider,
+        event_mapper=mapper,
+        event_handler=handler,
+    )
+    [tool] = middleware.tools
+
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="general-purpose",
+    )
+    result = await tool.execute("tc-string", args, signal=None, on_update=None)
+
+    assert handled == [("subagent:tc-string", "started")]
+    assert result.details["subagent_events"] == ["started"]
+
+
 async def test_inner_agent_failure_returns_tool_error() -> None:
     class _FailingProvider(FauxProvider):
         async def stream(self, *args: Any, **kwargs: Any) -> Any:
@@ -282,6 +315,47 @@ async def test_cancelled_subagent_run_propagates_and_detaches_tracer() -> None:
 
     assert len(tracer.attached) == 1
     assert tracer.detached == 1
+
+
+async def test_parent_signal_aborts_running_child_agent() -> None:
+    class _SlowProvider(FauxProvider):
+        async def stream(self, *args: Any, **kwargs: Any) -> MessageStream:
+            del args
+            options = kwargs["options"]
+            stream = MessageStream()
+
+            async def produce() -> None:
+                await options.signal.wait()
+                stream.push(StreamEvent(type="error", error_message="aborted"))
+                stream.set_result(
+                    AssistantMessage(
+                        content=[],
+                        stop_reason="aborted",
+                        error_message="aborted",
+                    )
+                )
+
+            stream.attach_task(asyncio.create_task(produce()))
+            return stream
+
+    signal = asyncio.Event()
+    middleware = _make_middleware(provider=_SlowProvider())
+    [tool] = middleware.tools
+    args = tool.parameters(
+        name="worker",
+        role="researcher",
+        task="answer",
+        prompt="please reply",
+        subagent_type="general-purpose",
+    )
+
+    task = asyncio.create_task(tool.execute("tc-abort", args, signal=signal))
+    await asyncio.sleep(0.05)
+    signal.set()
+    result = await asyncio.wait_for(task, timeout=2)
+
+    assert result.is_error is True
+    assert "aborted" in result.content[0].text
 
 
 class _FakeTracer:

--- a/tests/middleware/test_transform_system_prompt.py
+++ b/tests/middleware/test_transform_system_prompt.py
@@ -3,17 +3,20 @@
 import pytest
 
 from cubepi import Agent, Model
+from cubepi.agent.types import AgentContext
 from cubepi.middleware.base import Middleware, compose_middleware
 from cubepi.providers.faux import FauxProvider, faux_assistant_message
 
 
 class _AppendA(Middleware):
-    async def transform_system_prompt(self, sp, *, signal=None):
+    async def transform_system_prompt(self, sp, *, ctx, signal=None):
+        del ctx, signal
         return sp + "\n[A]"
 
 
 class _AppendB(Middleware):
-    async def transform_system_prompt(self, sp, *, signal=None):
+    async def transform_system_prompt(self, sp, *, ctx, signal=None):
+        del ctx, signal
         return sp + "\n[B]"
 
 
@@ -21,7 +24,7 @@ class _AppendB(Middleware):
 async def test_single_middleware_appends() -> None:
     hooks = compose_middleware([_AppendA()])
     fn = hooks["transform_system_prompt"]
-    out = await fn("base")
+    out = await fn("base", ctx=AgentContext(system_prompt="", messages=[]))
     assert out == "base\n[A]"
 
 
@@ -30,7 +33,7 @@ async def test_chain_order_preserved() -> None:
     """A then B → A first, then B sees A's output."""
     hooks = compose_middleware([_AppendA(), _AppendB()])
     fn = hooks["transform_system_prompt"]
-    out = await fn("base")
+    out = await fn("base", ctx=AgentContext(system_prompt="", messages=[]))
     assert out == "base\n[A]\n[B]"
 
 
@@ -49,7 +52,9 @@ async def test_default_implementation_raises() -> None:
     """Default Middleware.transform_system_prompt raises NotImplementedError."""
     mw = Middleware()
     with pytest.raises(NotImplementedError):
-        await mw.transform_system_prompt("any")
+        await mw.transform_system_prompt(
+            "any", ctx=AgentContext(system_prompt="", messages=[])
+        )
 
 
 @pytest.mark.asyncio
@@ -58,7 +63,8 @@ async def test_agent_applies_transform_system_prompt() -> None:
     captured: list[str] = []
 
     class _Capturing(Middleware):
-        async def transform_system_prompt(self, sp: str, *, signal=None) -> str:
+        async def transform_system_prompt(self, sp: str, *, ctx, signal=None) -> str:
+            del ctx, signal
             # last middleware in chain captures what it saw
             captured.append(sp)
             return sp + "\n[C]"

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -4,16 +4,20 @@ import pytest
 
 from cubepi.providers.base import (
     AssistantMessage,
+    BaseProvider,
     ImageContent,
+    Message,
     MessageStream,
     Model,
     ModelCost,
     StreamEvent,
     TextContent,
+    ThinkingBudgets,
     ThinkingContent,
     ToolCall,
     ToolDefinition,
     ToolResultMessage,
+    StreamOptions,
     Usage,
     UserMessage,
     format_provider_error,
@@ -233,6 +237,47 @@ class TestMessageStreamTaskTracking:
             await ms.result()
 
 
+class TestBaseProviderGenerate:
+    async def test_generate_consumes_stream_and_returns_assistant_message(self):
+        provider = _RecordingProvider(
+            AssistantMessage(content=[TextContent(text="ok")])
+        )
+
+        result = await provider.generate(
+            Model(id="gpt-4o", provider="openai"),
+            [UserMessage(content=[TextContent(text="hi")])],
+            system_prompt="system",
+        )
+
+        assert result.content[0].text == "ok"
+        assert provider.call_count == 1
+
+    async def test_generate_applies_common_per_call_overrides(self):
+        provider = _RecordingProvider(AssistantMessage(content=[]))
+        base_model = Model(id="gpt-4o", provider="openai", max_tokens=128)
+        base_options = StreamOptions(thinking="low")
+        budgets = ThinkingBudgets(low=4096)
+
+        await provider.generate(
+            base_model,
+            [],
+            options=base_options,
+            max_output_tokens=512,
+            temperature=0.0,
+            thinking="high",
+            thinking_budgets=budgets,
+        )
+
+        assert provider.seen_model is not None
+        assert provider.seen_model.max_tokens == 512
+        assert provider.seen_model.temperature == 0.0
+        assert base_model.max_tokens == 128
+        assert provider.seen_options is not None
+        assert provider.seen_options.thinking == "high"
+        assert provider.seen_options.thinking_budgets is budgets
+        assert base_options.thinking == "low"
+
+
 class TestAssistantMessageMetadata:
     def test_default_metadata_fields(self):
         msg = AssistantMessage(content=[])
@@ -250,3 +295,30 @@ class TestAssistantMessageMetadata:
         assert msg.provider_id == "anthropic"
         assert msg.model_id == "claude-sonnet-4-20250514"
         assert msg.response_id == "msg_abc123"
+
+
+class _RecordingProvider(BaseProvider):
+    def __init__(self, result: AssistantMessage) -> None:
+        super().__init__()
+        self._result = result
+        self.call_count = 0
+        self.seen_model: Model | None = None
+        self.seen_options: StreamOptions | None = None
+
+    async def stream(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+    ) -> MessageStream:
+        del messages, system_prompt, tools
+        self.call_count += 1
+        self.seen_model = model
+        self.seen_options = options
+        stream = MessageStream()
+        stream.push(StreamEvent(type="done"))
+        stream.set_result(self._result)
+        return stream

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -8,7 +8,17 @@ import pytest
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
-from cubepi.providers.base import Model, TextContent, UserMessage
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    MessageStream,
+    Model,
+    StreamEvent,
+    StreamOptions,
+    TextContent,
+    ToolDefinition,
+    UserMessage,
+)
 from cubepi.providers.faux import FauxProvider, faux_assistant_message
 from cubepi.tracing import Tracer
 from cubepi.tracing.tracer import _OneShotSession
@@ -56,6 +66,26 @@ async def test_oneshot_session_type() -> None:
     async with tracer.oneshot(provider=provider, model=MODEL) as session:
         assert isinstance(session, _OneShotSession)
     await tracer.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_oneshot_session_uses_provider_generate() -> None:
+    provider = _GenerateOnlyProvider()
+    tracer, _ = _make_tracer()
+
+    async with tracer.oneshot(provider=provider, model=MODEL) as session:
+        text = await session.generate(
+            system="sys",
+            messages=[UserMessage(content=[TextContent(text="q")])],
+            max_output_tokens=123,
+        )
+
+    await tracer.shutdown()
+
+    assert text == "via generate"
+    assert provider.seen_max_output_tokens == 123
+    assert provider.seen_options is not None
+    assert provider.seen_options.signal is not None
 
 
 @pytest.mark.asyncio
@@ -233,18 +263,16 @@ async def test_oneshot_generate_error_event_raises_and_marks_root() -> None:
     the root invoke_agent span with ERROR status so `cubepi trace ls` shows
     the run as failed instead of as a successful invoke_agent."""
     from opentelemetry.trace import StatusCode
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, patch
 
     provider = FauxProvider()
     tracer, exporter = _make_tracer()
 
-    # Patch provider.stream to yield an error event
-    error_stream = MagicMock()
-
-    async def _gen():
-        yield MagicMock(type="error", error_message="boom", delta=None)
-
-    error_stream.__aiter__ = lambda self: _gen()
+    error_stream = MessageStream()
+    error_stream.push(StreamEvent(type="error", error_message="boom"))
+    error_stream.set_result(
+        AssistantMessage(content=[], stop_reason="error", error_message="boom")
+    )
     with patch.object(provider, "stream", new=AsyncMock(return_value=error_stream)):
         with pytest.raises(RuntimeError, match="boom"):
             async with tracer.oneshot(provider=provider, model=MODEL) as session:
@@ -406,8 +434,6 @@ async def test_oneshot_passes_signal_to_provider_and_sets_on_cancel() -> None:
     the consumer tears the producer task down too."""
     import asyncio
     from unittest.mock import AsyncMock, MagicMock, patch
-
-    from cubepi.providers.base import StreamOptions
 
     provider = FauxProvider()
     tracer, _ = _make_tracer()
@@ -661,3 +687,41 @@ async def test_oneshot_does_not_interfere_with_concurrent_agent() -> None:
     # Both runs should produce an invoke_agent span
     roots = [s for s in exporter.spans if s.name == "invoke_agent"]
     assert len(roots) == 2
+
+
+class _GenerateOnlyProvider(FauxProvider):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_max_output_tokens: int | None = None
+        self.seen_options: StreamOptions | None = None
+
+    async def generate(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        thinking=None,
+        thinking_budgets=None,
+    ) -> AssistantMessage:
+        del model, messages, system_prompt, tools, temperature, thinking
+        del thinking_budgets
+        self.seen_max_output_tokens = max_output_tokens
+        self.seen_options = options
+        return AssistantMessage(content=[TextContent(text="via generate")])
+
+    async def stream(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+    ) -> MessageStream:
+        del model, messages, system_prompt, tools, options
+        raise AssertionError("Tracer.oneshot must call provider.generate()")

--- a/website/docs/getting-started/core-concepts.md
+++ b/website/docs/getting-started/core-concepts.md
@@ -78,11 +78,27 @@ class Provider(Protocol):
         tools: list[ToolDefinition] | None = None,
         options: StreamOptions | None = None,
     ) -> MessageStream: ...
+
+    async def generate(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        thinking: ThinkingLevel | None = None,
+        thinking_budgets: ThinkingBudgets | None = None,
+    ) -> AssistantMessage: ...
 ```
 
-It returns a `MessageStream` — a single async iterator that yields
-`StreamEvent`s and exposes the final `AssistantMessage` via `await
-stream.result()`. Built-in providers:
+`stream()` returns a `MessageStream` — a single async iterator that
+yields `StreamEvent`s and exposes the final `AssistantMessage` via
+`await stream.result()`. `generate()` consumes one stream and returns
+the final message directly; `BaseProvider` implements it for any
+provider that implements `stream()`. Built-in providers:
 
 - `AnthropicProvider` — Claude (Messages API, with thinking, caching,
   tool use).
@@ -91,7 +107,8 @@ stream.result()`. Built-in providers:
   state).
 - `FauxProvider` — deterministic test double (no network).
 
-Write your own by implementing one method. See [Providers / Custom](../guides/providers/custom).
+Write your own by subclassing `BaseProvider` and implementing
+`stream()`. See [Providers / Custom](../guides/providers/custom).
 
 ## Stream and events
 

--- a/website/docs/guides/middleware/composition.md
+++ b/website/docs/guides/middleware/composition.md
@@ -166,7 +166,8 @@ overrides. You don't need to `pass`-implement every method.
 
 ```python
 class JustTransform(Middleware):
-    async def transform_context(self, messages, *, signal=None):
+    async def transform_context(self, messages, *, ctx, signal=None):
+        del ctx, signal
         return messages[-10:]
     # No other hooks. CubePi won't call them.
 ```

--- a/website/docs/guides/middleware/examples.md
+++ b/website/docs/guides/middleware/examples.md
@@ -152,7 +152,8 @@ class SlidingWindow(Middleware):
     def __init__(self, max_messages: int = 20) -> None:
         self.max_messages = max_messages
 
-    async def transform_context(self, messages, *, signal=None):
+    async def transform_context(self, messages, *, ctx, signal=None):
+        del ctx, signal
         if len(messages) <= self.max_messages:
             return messages
         return messages[-self.max_messages:]
@@ -166,10 +167,76 @@ what was dropped:
 
 ```python
 class SummaryInjector(Middleware):
-    async def transform_system_prompt(self, system_prompt, *, signal=None):
+    async def transform_system_prompt(self, system_prompt, *, ctx, signal=None):
+        del ctx, signal
         summary = "Earlier in this conversation we discussed: …"
         return f"{system_prompt}\n\nContext: {summary}".strip()
 ```
+
+## Built-in compaction
+
+`CompactionMiddleware` summarizes older turns into `ctx.extra` and
+passes the model a compressed view: one summary message plus recent
+messages. The full conversation history remains in `agent.state`.
+
+```python
+from cubepi.middleware import CompactionMiddleware
+from cubepi.providers import Model
+
+agent = Agent(
+    provider=main_provider,
+    model=main_model,
+    middleware=[
+        CompactionMiddleware(
+            summary_provider=cheap_provider,
+            summary_model=Model(id="claude-haiku-4-5", provider="anthropic"),
+            max_tokens_before_compact=80_000,
+            keep_recent_messages=8,
+        ),
+    ],
+)
+```
+
+The summary call uses `Provider.generate(...)` with
+`temperature=0.0`, `thinking="off"`, and `max_output_tokens` set from
+`max_summary_tokens`.
+
+## Built-in subagents
+
+`SubagentMiddleware` adds one `subagent` tool that runs a temporary
+child `Agent` with a self-contained prompt. CubePi captures child
+events and returns the child agent's final assistant text as the tool
+result.
+
+```python
+from cubepi.middleware import SubagentMiddleware, SubagentSpec
+
+subagents = {
+    "researcher": SubagentSpec(
+        name="researcher",
+        description="Researches a narrow question",
+        system_prompt="You are a concise research assistant.",
+    )
+}
+
+agent = Agent(
+    provider=provider,
+    model=model,
+    middleware=[
+        SubagentMiddleware(
+            subagents=subagents,
+            default_provider=provider,
+            default_model=model,
+            shared_tools=[web_search],
+        ),
+    ],
+)
+```
+
+Host applications can pass `event_mapper` and `event_handler` to map
+child `AgentEvent`s into their own UI stream or audit log. Billing,
+SSE payload shape, and product-specific tool filtering stay in the
+host application.
 
 ## Max turns / budget cap
 

--- a/website/docs/guides/middleware/hooks.md
+++ b/website/docs/guides/middleware/hooks.md
@@ -13,7 +13,7 @@ ones you need — CubePi only wires in the ones you override.
 from cubepi import Middleware
 
 class MyMiddleware(Middleware):
-    async def transform_context(self, messages, *, signal=None):
+    async def transform_context(self, messages, *, ctx, signal=None):
         ...
 ```
 
@@ -22,11 +22,19 @@ Pass instances to `Agent(middleware=[MyMiddleware(), …])`.
 ## `transform_context`
 
 ```python
-async def transform_context(self, messages: list[Message], *, signal=None) -> list[Message]:
+async def transform_context(
+    self,
+    messages: list[Message],
+    *,
+    ctx: AgentContext,
+    signal=None,
+) -> list[Message]:
     ...
 ```
 
-Fires **before each model call**, on the full message list. Use to:
+Fires **before each model call**, on the full message list. `ctx` is
+the current `AgentContext`; use `ctx.extra` for per-run or
+checkpointer-persisted middleware state. Use to:
 
 - Truncate or summarise to fit context windows.
 - Inject system reminders (better: use `transform_system_prompt`).
@@ -41,7 +49,12 @@ output.
 ## `convert_to_llm`
 
 ```python
-async def convert_to_llm(self, messages: list[Message]) -> list[Message]:
+async def convert_to_llm(
+    self,
+    messages: list[Message],
+    *,
+    ctx: AgentContext,
+) -> list[Message]:
     ...
 ```
 
@@ -59,7 +72,13 @@ multiple middlewares would conflict and you want a single owner.
 ## `transform_system_prompt`
 
 ```python
-async def transform_system_prompt(self, system_prompt: str, *, signal=None) -> str:
+async def transform_system_prompt(
+    self,
+    system_prompt: str,
+    *,
+    ctx: AgentContext,
+    signal=None,
+) -> str:
     ...
 ```
 

--- a/website/docs/guides/providers/custom.md
+++ b/website/docs/guides/providers/custom.md
@@ -44,6 +44,7 @@ import asyncio
 import time
 from cubepi.providers.base import (
     AssistantMessage,
+    BaseProvider,
     Message,
     MessageStream,
     Model,
@@ -55,8 +56,9 @@ from cubepi.providers.base import (
 )
 
 
-class MyProvider:
+class MyProvider(BaseProvider):
     def __init__(self, *, api_key: str) -> None:
+        super().__init__()
         self._api_key = api_key
 
     async def stream(

--- a/website/docs/guides/providers/custom.md
+++ b/website/docs/guides/providers/custom.md
@@ -5,7 +5,9 @@ description: "Write a custom provider for CubePi by implementing the Provider pr
 
 # Writing a Custom Provider
 
-A provider is any class with one method:
+A provider is any class matching the `Provider` protocol. In practice,
+subclass `BaseProvider` and implement `stream()`; `BaseProvider`
+supplies `generate()` for one-shot calls.
 
 ```python
 class Provider(Protocol):
@@ -20,8 +22,10 @@ class Provider(Protocol):
     ) -> MessageStream: ...
 ```
 
-That's the whole interface. Implement it and `Agent(provider=…)`
-accepts your class.
+That is the only method custom providers usually implement. The
+inherited `generate()` consumes `stream()` and returns the final
+`AssistantMessage`, with per-call overrides for `max_output_tokens`,
+`temperature`, `thinking`, and `thinking_budgets`.
 
 This page covers two scenarios:
 

--- a/website/docs/recipes/persistent-chat.md
+++ b/website/docs/recipes/persistent-chat.md
@@ -128,7 +128,8 @@ class SlidingWindow(Middleware):
     def __init__(self, n: int) -> None:
         self.n = n
 
-    async def transform_context(self, messages, *, signal=None):
+    async def transform_context(self, messages, *, ctx, signal=None):
+        del ctx, signal
         return messages[-self.n:] if len(messages) > self.n else messages
 
 


### PR DESCRIPTION
## Summary
- add ctx-aware pre-model middleware hooks: transform_context, transform_system_prompt, and convert_to_llm
- add Provider.generate() with max_output_tokens, temperature, thinking, and thinking_budgets overrides
- add cubepi CompactionMiddleware with JSON-safe state in AgentContext.extra
- add cubepi SubagentMiddleware for framework-level child Agent delegation with host event callbacks
- update tracing oneshot to use Provider.generate() and update current docs

## Notes
- This intentionally cuts over hook signatures without old-signature compatibility.
- Cubebox-specific SSE translation, billing cloning, config lookup, and product tool filtering stay in cubebox adapters.

## Verification
- uv run pytest tests/
- uv run ruff check cubepi/ tests/
- uv run ruff format --check cubepi/ tests/