### PR TITLE
feat(errors): typed ProviderError taxonomy + classify_and_raise, SDK wrapping in openai/anthropic

### DIFF
--- a/cubepi/__init__.py
+++ b/cubepi/__init__.py
@@ -35,6 +35,14 @@ from cubepi.providers import (
     UserMessage,
     adjust_max_tokens_for_thinking,
 )
+from cubepi.errors import (
+    ContextLengthExceeded,
+    ProviderAuthFailed,
+    ProviderBadRequest,
+    ProviderError,
+    ProviderUnavailable,
+    RateLimited,
+)
 from cubepi.providers.capability import (
     CapabilityDescriptor,
     ReasoningLevelSpec,
@@ -50,11 +58,17 @@ __all__ = [
     "AssistantMessage",
     "BaseProvider",
     "CapabilityDescriptor",
+    "ContextLengthExceeded",
     "Message",
     "MessageStream",
     "Middleware",
     "Model",
     "Provider",
+    "ProviderAuthFailed",
+    "ProviderBadRequest",
+    "ProviderError",
+    "ProviderUnavailable",
+    "RateLimited",
     "ReasoningLevelSpec",
     "StreamEvent",
     "StreamOptions",

--- a/cubepi/errors.py
+++ b/cubepi/errors.py
@@ -253,6 +253,15 @@ def classify_and_raise(
             msg, provider=provider, model=model_id, status_code=status
         ) from exc
 
+    # SDK-specific connection/timeout errors (openai.APIConnectionError,
+    # anthropic.APITimeoutError) don't inherit from Python's built-in
+    # ConnectionError/TimeoutError, so the isinstance above misses them.
+    cls_name = type(exc).__name__
+    if "ConnectionError" in cls_name or "Timeout" in cls_name:
+        raise ProviderUnavailable(
+            msg, provider=provider, model=model_id, status_code=status
+        ) from exc
+
     if status is not None and 500 <= status < 600:
         raise ProviderUnavailable(
             msg, provider=provider, model=model_id, status_code=status

--- a/cubepi/errors.py
+++ b/cubepi/errors.py
@@ -1,0 +1,278 @@
+"""Typed provider errors.
+
+cubepi providers catch raw SDK exceptions and re-raise as one of these
+subclasses, so downstream callers can ``except cubepi.errors.X`` instead
+of pattern-matching on SDK-specific strings or status codes.
+
+Adding a new subclass: add it at the bottom of the file (never reorder)
+and re-export from ``cubepi/__init__.py`` and ``__all__``.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import NoReturn
+
+from cubepi.providers.base import Message, Model
+
+
+class ProviderError(Exception):
+    """Base class for typed cubepi provider errors.
+
+    Always carries provider / model context. ``raw_exception`` is the
+    original SDK exception (kept on ``__cause__`` via ``raise … from``).
+    """
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        self.provider = provider
+        self.model = model
+        self.status_code = status_code
+        super().__init__(message or self.__class__.__name__)
+
+
+class ContextLengthExceeded(ProviderError):
+    """The request exceeded the model's context window.
+
+    ``tokens_in`` is an estimate (chars/4) of the prompt size at the time
+    of the failure; ``context_window`` is the model's advertised window.
+    Both may be None if the provider couldn't measure them.
+    """
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        status_code: int | None = None,
+        tokens_in: int | None = None,
+        context_window: int | None = None,
+    ) -> None:
+        self.tokens_in = tokens_in
+        self.context_window = context_window
+        super().__init__(
+            message, provider=provider, model=model, status_code=status_code
+        )
+
+
+class RateLimited(ProviderError):
+    """Provider rate-limit / quota error.
+
+    ``retry_after`` is the recommended retry delay in seconds, parsed from
+    the SDK response when available.
+    """
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        status_code: int | None = None,
+        retry_after: float | None = None,
+    ) -> None:
+        self.retry_after = retry_after
+        super().__init__(
+            message, provider=provider, model=model, status_code=status_code
+        )
+
+
+class ProviderAuthFailed(ProviderError):
+    """API-key invalid, account suspended, or 401/403 with no quota wording."""
+
+
+class ProviderUnavailable(ProviderError):
+    """5xx, timeout, or connection failure."""
+
+
+class ProviderBadRequest(ProviderError):
+    """Other 4xx provider error (model_not_found, schema rejection, etc.)."""
+
+
+# ---------------------------------------------------------------------------
+# Heuristics: turn a raw SDK exception into one of the typed errors above.
+# ---------------------------------------------------------------------------
+
+_CONTEXT_LENGTH_PATTERNS = (
+    re.compile(r"maximum context length", re.IGNORECASE),
+    re.compile(r"context.{0,10}length.{0,20}exceed", re.IGNORECASE),
+    re.compile(r"too many tokens", re.IGNORECASE),
+    re.compile(r"prompt is too long", re.IGNORECASE),
+    re.compile(r"reduce.{0,10}messages", re.IGNORECASE),
+)
+
+_RATE_LIMIT_PATTERNS = (
+    re.compile(r"rate ?limit", re.IGNORECASE),
+    re.compile(r"quota (?:exceed|exhaust|limit|reach)", re.IGNORECASE),
+    re.compile(r"too many requests", re.IGNORECASE),
+)
+
+
+def _status_of(exc: BaseException) -> int | None:
+    """Best-effort status code extraction from an SDK exception."""
+
+    code = getattr(exc, "status_code", None)
+    if isinstance(code, int):
+        return code
+    resp = getattr(exc, "response", None)
+    if resp is not None:
+        rc = getattr(resp, "status_code", None)
+        if isinstance(rc, int):
+            return rc
+    return None
+
+
+def _estimate_input_tokens(messages: list[Message] | None) -> int | None:
+    """Rough chars/4 estimate over message text, used only for diagnostics.
+
+    Returns None when ``messages`` is empty or missing.
+    """
+
+    if not messages:
+        return None
+    total = 0
+    for msg in messages:
+        content = getattr(msg, "content", None)
+        if isinstance(content, list):
+            for block in content:
+                text = getattr(block, "text", None)
+                if isinstance(text, str):
+                    total += len(text)
+                else:
+                    text = getattr(block, "content", None)
+                    if isinstance(text, str):
+                        total += len(text)
+        elif isinstance(content, str):
+            total += len(content)
+    if total == 0:
+        return None
+    return max(1, math.ceil(total / 4))
+
+
+def _retry_after_from(exc: BaseException) -> float | None:
+    """Pull retry-after seconds from an SDK exception's response headers."""
+
+    resp = getattr(exc, "response", None)
+    headers = getattr(resp, "headers", None) if resp is not None else None
+    if not headers:
+        return None
+    val = headers.get("retry-after") or headers.get("Retry-After")
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def classify_and_raise(
+    exc: BaseException,
+    *,
+    model: Model,
+    messages: list[Message] | None = None,
+) -> NoReturn:
+    """Inspect a raw SDK exception and raise the typed cubepi error.
+
+    Heuristics (first match wins):
+      1. Explicit context-length wording → ContextLengthExceeded.
+      2. status==400 + estimated tokens_in within 5% of model.context_window
+         → ContextLengthExceeded (covers Volcano ARK's opaque
+         ``InvalidParameter`` 400).
+      3. status==429 OR quota/rate-limit wording → RateLimited.
+      4. status==401 / 403 → ProviderAuthFailed.
+      5. TimeoutError / ConnectionError / 5xx → ProviderUnavailable.
+      6. Any other 4xx → ProviderBadRequest.
+      7. Else: re-raise the original (caller should let it propagate).
+
+    ``raise classify_and_raise(...) from exc`` is the idiomatic call site.
+    """
+
+    # Already typed — re-raise unchanged so callers that catch ProviderError
+    # don't get double-wrapped.
+    if isinstance(exc, ProviderError):
+        raise exc
+
+    msg = str(exc) or getattr(exc, "message", "")
+    status = _status_of(exc)
+    provider = model.provider
+    model_id = model.id
+
+    tokens_in = _estimate_input_tokens(messages)
+    context_window = model.context_window if model.context_window else None
+
+    for pat in _CONTEXT_LENGTH_PATTERNS:
+        if pat.search(msg):
+            raise ContextLengthExceeded(
+                msg,
+                provider=provider,
+                model=model_id,
+                status_code=status,
+                tokens_in=tokens_in,
+                context_window=context_window,
+            ) from exc
+
+    if (
+        status == 400
+        and tokens_in is not None
+        and context_window is not None
+        and tokens_in >= int(context_window * 0.95)
+    ):
+        raise ContextLengthExceeded(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            tokens_in=tokens_in,
+            context_window=context_window,
+        ) from exc
+
+    if status == 429 or any(pat.search(msg) for pat in _RATE_LIMIT_PATTERNS):
+        raise RateLimited(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            retry_after=_retry_after_from(exc),
+        ) from exc
+
+    if status in (401, 403):
+        raise ProviderAuthFailed(
+            msg, provider=provider, model=model_id, status_code=status
+        ) from exc
+
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        raise ProviderUnavailable(
+            msg, provider=provider, model=model_id, status_code=status
+        ) from exc
+
+    if status is not None and 500 <= status < 600:
+        raise ProviderUnavailable(
+            msg, provider=provider, model=model_id, status_code=status
+        ) from exc
+
+    if status is not None and 400 <= status < 500:
+        raise ProviderBadRequest(
+            msg, provider=provider, model=model_id, status_code=status
+        ) from exc
+
+    # Unknown → let original propagate. Callers might still need to handle it.
+    raise exc
+
+
+__all__ = [
+    "ProviderError",
+    "ContextLengthExceeded",
+    "RateLimited",
+    "ProviderAuthFailed",
+    "ProviderUnavailable",
+    "ProviderBadRequest",
+    "classify_and_raise",
+]

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -313,8 +313,7 @@ class AnthropicProvider(BaseProvider):
                     # _convert_response, _assemble_response).
                     if type(_sdk_exc).__module__.startswith("anthropic"):
                         classify_and_raise(_sdk_exc, model=model, messages=messages)
-                    else:
-                        raise
+                    raise
 
             except BaseException as e:
                 exc = e

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -308,12 +308,7 @@ class AnthropicProvider(BaseProvider):
                 except Exception as _sdk_exc:
                     from cubepi.errors import classify_and_raise
 
-                    # Guard: only classify Anthropic SDK errors, not local
-                    # callback/processing exceptions (on_response, _handle_event,
-                    # _convert_response, _assemble_response).
-                    if type(_sdk_exc).__module__.startswith("anthropic"):
-                        classify_and_raise(_sdk_exc, model=model, messages=messages)
-                    raise
+                    classify_and_raise(_sdk_exc, model=model, messages=messages)
 
             except BaseException as e:
                 exc = e

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -308,7 +308,13 @@ class AnthropicProvider(BaseProvider):
                 except Exception as _sdk_exc:
                     from cubepi.errors import classify_and_raise
 
-                    classify_and_raise(_sdk_exc, model=model, messages=messages)
+                    # Guard: only classify Anthropic SDK errors, not local
+                    # callback/processing exceptions (on_response, _handle_event,
+                    # _convert_response, _assemble_response).
+                    if type(_sdk_exc).__module__.startswith("anthropic"):
+                        classify_and_raise(_sdk_exc, model=model, messages=messages)
+                    else:
+                        raise
 
             except BaseException as e:
                 exc = e

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -244,66 +244,71 @@ class AnthropicProvider(BaseProvider):
                 kwargs = await invoke_on_payload(opts.on_payload, kwargs, model)
                 await _fire_request_listeners(self._request_listeners, kwargs, model)
 
-                async with self._client.messages.stream(**kwargs) as stream:
-                    # Invoke on_response with HTTP metadata if available
-                    http_response = getattr(stream, "response", None)
-                    if http_response is not None:
-                        await invoke_on_response(
-                            opts.on_response,
-                            ProviderResponse(
-                                status=http_response.status_code,
-                                headers=dict(http_response.headers),
+                try:
+                    async with self._client.messages.stream(**kwargs) as stream:
+                        # Invoke on_response with HTTP metadata if available
+                        http_response = getattr(stream, "response", None)
+                        if http_response is not None:
+                            await invoke_on_response(
+                                opts.on_response,
+                                ProviderResponse(
+                                    status=http_response.status_code,
+                                    headers=dict(http_response.headers),
+                                ),
+                                model,
+                            )
+
+                        partial = AssistantMessage(
+                            content=[],
+                            usage=Usage(),
+                            timestamp=time.time(),
+                            provider_id=model.provider,
+                            model_id=model.id,
+                        )
+                        await self._emit(
+                            ms,
+                            StreamEvent(
+                                type="start", partial=partial.model_copy(deep=True)
                             ),
                             model,
                         )
 
-                    partial = AssistantMessage(
-                        content=[],
-                        usage=Usage(),
-                        timestamp=time.time(),
-                        provider_id=model.provider,
-                        model_id=model.id,
-                    )
-                    await self._emit(
-                        ms,
-                        StreamEvent(
-                            type="start", partial=partial.model_copy(deep=True)
-                        ),
-                        model,
-                    )
+                        # Accumulate streamed tool-call args JSON per content index
+                        # so toolcall_end can carry parsed arguments (the Anthropic
+                        # stream only delivers them as incremental partial_json).
+                        tool_args_buffers: dict[int, str] = {}
+                        async for event in stream:
+                            if opts.signal and opts.signal.is_set():
+                                aborted = partial.model_copy(
+                                    update={
+                                        "stop_reason": "aborted",
+                                        "error_message": "Request was aborted",
+                                    }
+                                )
+                                await self._emit(
+                                    ms,
+                                    StreamEvent(
+                                        type="error",
+                                        error_message="Request was aborted",
+                                    ),
+                                    model,
+                                )
+                                ms.set_result(aborted)
+                                return
 
-                    # Accumulate streamed tool-call args JSON per content index
-                    # so toolcall_end can carry parsed arguments (the Anthropic
-                    # stream only delivers them as incremental partial_json).
-                    tool_args_buffers: dict[int, str] = {}
-                    async for event in stream:
-                        if opts.signal and opts.signal.is_set():
-                            aborted = partial.model_copy(
-                                update={
-                                    "stop_reason": "aborted",
-                                    "error_message": "Request was aborted",
-                                }
+                            await self._handle_event(
+                                event, partial, ms, model, tool_args_buffers
                             )
-                            await self._emit(
-                                ms,
-                                StreamEvent(
-                                    type="error",
-                                    error_message="Request was aborted",
-                                ),
-                                model,
-                            )
-                            ms.set_result(aborted)
-                            return
 
-                        await self._handle_event(
-                            event, partial, ms, model, tool_args_buffers
-                        )
+                        final_msg = await stream.get_final_message()
+                        result = self._convert_response(final_msg, model)
+                        body = self._assemble_response(final_msg)
+                        await self._emit(ms, StreamEvent(type="done"), model)
+                        ms.set_result(result)
+                except Exception as _sdk_exc:
+                    from cubepi.errors import classify_and_raise
 
-                    final_msg = await stream.get_final_message()
-                    result = self._convert_response(final_msg, model)
-                    body = self._assemble_response(final_msg)
-                    await self._emit(ms, StreamEvent(type="done"), model)
-                    ms.set_result(result)
+                    classify_and_raise(_sdk_exc, model=model, messages=messages)
 
             except BaseException as e:
                 exc = e

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -162,7 +162,12 @@ class OpenAIProvider(BaseProvider):
                 # accidentally mutate the dict that's about to be sent.
                 await _fire_request_listeners(self._request_listeners, kwargs, model)
 
-                response = await self._client.chat.completions.create(**kwargs)
+                try:
+                    response = await self._client.chat.completions.create(**kwargs)
+                except Exception as _sdk_exc:
+                    from cubepi.errors import classify_and_raise
+
+                    classify_and_raise(_sdk_exc, model=model, messages=messages)
 
                 # Invoke on_response with HTTP metadata if available
                 http_response = getattr(response, "response", None)

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -510,17 +510,15 @@ class OpenAIProvider(BaseProvider):
             except BaseException as e:
                 exc = e
                 # Classify SDK stream-level errors that the narrow create()
-                # try/except didn't catch. Only classify exceptions from the
-                # openai SDK module — local callback/processing exceptions
-                # (on_payload, on_response, assembly) must not be re-tagged.
+                # try/except didn't catch — async-for-chunk iteration errors
+                # (mid-stream connection drops, timeouts) arrive here raw.
                 if isinstance(e, Exception):
                     from cubepi.errors import classify_and_raise
 
-                    if type(e).__module__.startswith("openai"):
-                        try:
-                            classify_and_raise(e, model=model, messages=messages)
-                        except Exception as _classified:
-                            exc = _classified
+                    try:
+                        classify_and_raise(e, model=model, messages=messages)
+                    except Exception as _classified:
+                        exc = _classified
                 err_text = self._error_message(exc, model)
                 error_msg = AssistantMessage(
                     content=[],

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -509,7 +509,17 @@ class OpenAIProvider(BaseProvider):
 
             except BaseException as e:
                 exc = e
-                err_text = self._error_message(e, model)
+                # Classify SDK stream-level errors that the narrow create()
+                # try/except didn't catch — async-for-chunk iteration errors
+                # (mid-stream connection drops, timeouts) arrive here raw.
+                if isinstance(e, Exception):
+                    from cubepi.errors import classify_and_raise
+
+                    try:
+                        classify_and_raise(e, model=model, messages=messages)
+                    except Exception as _classified:
+                        exc = _classified
+                err_text = self._error_message(exc, model)
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -510,15 +510,17 @@ class OpenAIProvider(BaseProvider):
             except BaseException as e:
                 exc = e
                 # Classify SDK stream-level errors that the narrow create()
-                # try/except didn't catch — async-for-chunk iteration errors
-                # (mid-stream connection drops, timeouts) arrive here raw.
+                # try/except didn't catch. Only classify exceptions from the
+                # openai SDK module — local callback/processing exceptions
+                # (on_payload, on_response, assembly) must not be re-tagged.
                 if isinstance(e, Exception):
                     from cubepi.errors import classify_and_raise
 
-                    try:
-                        classify_and_raise(e, model=model, messages=messages)
-                    except Exception as _classified:
-                        exc = _classified
+                    if type(e).__module__.startswith("openai"):
+                        try:
+                            classify_and_raise(e, model=model, messages=messages)
+                        except Exception as _classified:
+                            exc = _classified
                 err_text = self._error_message(exc, model)
                 error_msg = AssistantMessage(
                     content=[],

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -580,7 +580,17 @@ class OpenAIResponsesProvider(BaseProvider):
 
             except BaseException as e:
                 exc = e
-                err_text = self._error_message(e, model)
+                # Classify SDK stream-level errors that the narrow create()
+                # try/except didn't catch — async-for-event iteration errors
+                # arrive here raw.
+                if isinstance(e, Exception):
+                    from cubepi.errors import classify_and_raise
+
+                    try:
+                        classify_and_raise(e, model=model, messages=messages)
+                    except Exception as _classified:
+                        exc = _classified
+                err_text = self._error_message(exc, model)
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -581,15 +581,17 @@ class OpenAIResponsesProvider(BaseProvider):
             except BaseException as e:
                 exc = e
                 # Classify SDK stream-level errors that the narrow create()
-                # try/except didn't catch — async-for-event iteration errors
-                # arrive here raw.
+                # try/except didn't catch. Only classify exceptions from the
+                # openai SDK module — local callback/processing exceptions
+                # must not be re-tagged.
                 if isinstance(e, Exception):
                     from cubepi.errors import classify_and_raise
 
-                    try:
-                        classify_and_raise(e, model=model, messages=messages)
-                    except Exception as _classified:
-                        exc = _classified
+                    if type(e).__module__.startswith("openai"):
+                        try:
+                            classify_and_raise(e, model=model, messages=messages)
+                        except Exception as _classified:
+                            exc = _classified
                 err_text = self._error_message(exc, model)
                 error_msg = AssistantMessage(
                     content=[],

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -581,17 +581,15 @@ class OpenAIResponsesProvider(BaseProvider):
             except BaseException as e:
                 exc = e
                 # Classify SDK stream-level errors that the narrow create()
-                # try/except didn't catch. Only classify exceptions from the
-                # openai SDK module — local callback/processing exceptions
-                # must not be re-tagged.
+                # try/except didn't catch — async-for-event iteration errors
+                # arrive here raw.
                 if isinstance(e, Exception):
                     from cubepi.errors import classify_and_raise
 
-                    if type(e).__module__.startswith("openai"):
-                        try:
-                            classify_and_raise(e, model=model, messages=messages)
-                        except Exception as _classified:
-                            exc = _classified
+                    try:
+                        classify_and_raise(e, model=model, messages=messages)
+                    except Exception as _classified:
+                        exc = _classified
                 err_text = self._error_message(exc, model)
                 error_msg = AssistantMessage(
                     content=[],

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -183,7 +183,12 @@ class OpenAIResponsesProvider(BaseProvider):
 
                 await _fire_request_listeners(self._request_listeners, kwargs, model)
 
-                response = await self._client.responses.create(**kwargs)
+                try:
+                    response = await self._client.responses.create(**kwargs)
+                except Exception as _sdk_exc:
+                    from cubepi.errors import classify_and_raise
+
+                    classify_and_raise(_sdk_exc, model=model, messages=messages)
 
                 # Invoke on_response with HTTP metadata if available
                 http_response = getattr(response, "response", None)

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -1364,3 +1364,88 @@ class TestAnthropicBaseUrl:
             mock_anthropic.return_value = MagicMock()
             AnthropicProvider(api_key="x")
             assert "base_url" not in mock_anthropic.call_args.kwargs
+
+
+# ---------------------------------------------------------------------------
+# Typed error wrapping — provider integration
+# ---------------------------------------------------------------------------
+
+
+class _FakeAnthropicExc(Exception):
+    """Minimal fake Anthropic SDK exception with configurable status_code."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+
+
+class TestAnthropicTypedErrorWrapping:
+    """Verify that raw SDK exceptions are re-raised as typed ProviderError subclasses.
+
+    The provider wraps the entire async with stream block. When the SDK raises,
+    classify_and_raise converts it to a typed ProviderError. The outer
+    BaseException handler converts it to an error AssistantMessage and passes
+    the typed exception to response listeners.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_429_delivers_rate_limited_to_listener(self) -> None:
+        from cubepi.errors import RateLimited
+
+        exc = _FakeAnthropicExc("Rate limit exceeded", status_code=429)
+        provider = _make_provider("none")
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock()
+        mock_client.messages.stream = MagicMock(side_effect=exc)
+        provider._client = mock_client
+
+        captured_exc: list[BaseException | None] = []
+
+        def on_response(body, model, e):  # type: ignore[misc]
+            captured_exc.append(e)
+
+        provider.subscribe_response(on_response)
+
+        ms = await provider.stream(
+            _anthropic_model(), [UserMessage(content=[TextContent(text="hi")])]
+        )
+        async for _ in ms:
+            pass
+        result = await ms.result()
+
+        assert result.stop_reason == "error"
+        assert len(captured_exc) == 1
+        assert isinstance(captured_exc[0], RateLimited)
+
+    @pytest.mark.asyncio
+    async def test_context_length_message_delivers_context_length_exceeded(
+        self,
+    ) -> None:
+        from cubepi.errors import ContextLengthExceeded
+
+        exc = _FakeAnthropicExc(
+            "This model's maximum context length is 200000 tokens.", status_code=400
+        )
+        provider = _make_provider("none")
+        mock_client = MagicMock()
+        mock_client.messages = MagicMock()
+        mock_client.messages.stream = MagicMock(side_effect=exc)
+        provider._client = mock_client
+
+        captured_exc: list[BaseException | None] = []
+
+        def on_response(body, model, e):  # type: ignore[misc]
+            captured_exc.append(e)
+
+        provider.subscribe_response(on_response)
+
+        ms = await provider.stream(
+            _anthropic_model(), [UserMessage(content=[TextContent(text="hi")])]
+        )
+        async for _ in ms:
+            pass
+        await ms.result()
+
+        assert len(captured_exc) == 1
+        assert isinstance(captured_exc[0], ContextLengthExceeded)

--- a/tests/providers/test_anthropic.py
+++ b/tests/providers/test_anthropic.py
@@ -1374,6 +1374,8 @@ class TestAnthropicBaseUrl:
 class _FakeAnthropicExc(Exception):
     """Minimal fake Anthropic SDK exception with configurable status_code."""
 
+    __module__ = "anthropic"  # so the __module__ guard in classify_and_raise allows it
+
     def __init__(self, message: str, *, status_code: int | None = None) -> None:
         super().__init__(message)
         if status_code is not None:

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -945,6 +945,8 @@ class TestOpenAIStreamMultipleToolCalls:
 class _FakeSdkExc(Exception):
     """Minimal fake SDK exception with configurable status_code."""
 
+    __module__ = "openai"  # so the __module__ guard in classify_and_raise allows it
+
     def __init__(self, message: str, *, status_code: int | None = None) -> None:
         super().__init__(message)
         if status_code is not None:

--- a/tests/providers/test_openai.py
+++ b/tests/providers/test_openai.py
@@ -935,3 +935,91 @@ class TestOpenAIStreamMultipleToolCalls:
             assert tool_calls[0].arguments == {"q": "a"}
             assert tool_calls[1].name == "fetch"
             assert tool_calls[1].arguments == {"url": "b"}
+
+
+# ---------------------------------------------------------------------------
+# Typed error wrapping — provider integration
+# ---------------------------------------------------------------------------
+
+
+class _FakeSdkExc(Exception):
+    """Minimal fake SDK exception with configurable status_code."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+
+
+class TestOpenAITypedErrorWrapping:
+    """Verify that raw SDK exceptions are re-raised as typed ProviderError subclasses.
+
+    The provider catches raw SDK exceptions, classifies them via classify_and_raise,
+    and then the outer BaseException handler converts them to error AssistantMessages.
+    The typed exception is available via the response listener's ``exc`` argument.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_429_delivers_rate_limited_to_listener(self) -> None:
+        from cubepi.errors import RateLimited
+
+        exc = _FakeSdkExc("Rate limit exceeded", status_code=429)
+        mock_client = MagicMock()
+        mock_client.chat = MagicMock()
+        mock_client.chat.completions = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=exc)
+
+        provider = OpenAIProvider(api_key="test-key")
+        provider._client = mock_client
+
+        captured_exc: list[BaseException | None] = []
+
+        def on_response(body, model, e):  # type: ignore[misc]
+            captured_exc.append(e)
+
+        provider.subscribe_response(on_response)
+
+        ms = await provider.stream(
+            _model(), [UserMessage(content=[TextContent(text="hi")])]
+        )
+        async for _ in ms:
+            pass
+        result = await ms.result()
+
+        assert result.stop_reason == "error"
+        assert len(captured_exc) == 1
+        assert isinstance(captured_exc[0], RateLimited)
+
+    @pytest.mark.asyncio
+    async def test_context_length_message_delivers_context_length_exceeded(
+        self,
+    ) -> None:
+        from cubepi.errors import ContextLengthExceeded
+
+        exc = _FakeSdkExc(
+            "This model's maximum context length is 128000 tokens.", status_code=400
+        )
+        mock_client = MagicMock()
+        mock_client.chat = MagicMock()
+        mock_client.chat.completions = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(side_effect=exc)
+
+        provider = OpenAIProvider(api_key="test-key")
+        provider._client = mock_client
+
+        captured_exc: list[BaseException | None] = []
+
+        def on_response(body, model, e):  # type: ignore[misc]
+            captured_exc.append(e)
+
+        provider.subscribe_response(on_response)
+
+        ms = await provider.stream(
+            _model(), [UserMessage(content=[TextContent(text="hi")])]
+        )
+        async for _ in ms:
+            pass
+        await ms.result()
+
+        assert len(captured_exc) == 1
+        assert isinstance(captured_exc[0], ContextLengthExceeded)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -345,3 +345,19 @@ class TestRetryAfterFrom:
             "rate limited", status_code=429, headers={"retry-after": "not-a-number"}
         )
         assert _retry_after_from(exc) is None
+
+
+class TestSDKConnectionErrors:
+    """SDK-specific connection/timeout exceptions masquerading as ProviderUnavailable."""
+
+    def test_sdk_connection_error_name_match(self) -> None:
+        """openai.APIConnectionError has 'ConnectionError' in class name."""
+        exc = type("APIConnectionError", (Exception,), {})("cannot connect")
+        with pytest.raises(ProviderUnavailable):
+            classify_and_raise(exc, model=_model())
+
+    def test_sdk_timeout_name_match(self) -> None:
+        """anthropic.APITimeoutError has 'Timeout' in class name."""
+        exc = type("APITimeoutError", (Exception,), {})("timed out")
+        with pytest.raises(ProviderUnavailable):
+            classify_and_raise(exc, model=_model())

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,255 @@
+"""Tests for cubepi.errors — classifier heuristics and typed error taxonomy."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cubepi.errors import (
+    ContextLengthExceeded,
+    ProviderAuthFailed,
+    ProviderBadRequest,
+    ProviderError,
+    ProviderUnavailable,
+    RateLimited,
+    classify_and_raise,
+)
+from cubepi.providers.base import Model, TextContent, UserMessage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _model(
+    provider: str = "openai",
+    model_id: str = "gpt-4o",
+    context_window: int = 128_000,
+) -> Model:
+    return Model(id=model_id, provider=provider, context_window=context_window)
+
+
+def _messages(text: str = "hello") -> list:
+    return [UserMessage(content=[TextContent(text=text)])]
+
+
+class _FakeExc(Exception):
+    """Fake SDK exception with configurable status_code, message, and headers."""
+
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        status_code: int | None = None,
+        headers: dict | None = None,
+    ) -> None:
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+        if headers is not None:
+            self.response = SimpleNamespace(
+                status_code=status_code,
+                headers=headers,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Classifier tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyContextLengthExceeded:
+    def test_explicit_context_length_message(self) -> None:
+        exc = _FakeExc("This model's maximum context length is 4096 tokens.")
+        with pytest.raises(ContextLengthExceeded) as ei:
+            classify_and_raise(exc, model=_model())
+        assert ei.value.__cause__ is exc
+
+    def test_exceed_pattern(self) -> None:
+        exc = _FakeExc("context length exceeded: reduce your input")
+        with pytest.raises(ContextLengthExceeded):
+            classify_and_raise(exc, model=_model())
+
+    def test_too_many_tokens_pattern(self) -> None:
+        exc = _FakeExc("too many tokens in input")
+        with pytest.raises(ContextLengthExceeded):
+            classify_and_raise(exc, model=_model())
+
+    def test_prompt_is_too_long_pattern(self) -> None:
+        exc = _FakeExc("prompt is too long")
+        with pytest.raises(ContextLengthExceeded):
+            classify_and_raise(exc, model=_model())
+
+    def test_reduce_messages_pattern(self) -> None:
+        exc = _FakeExc("Please reduce the messages sent in your request.")
+        with pytest.raises(ContextLengthExceeded):
+            classify_and_raise(exc, model=_model())
+
+    def test_carries_provider_and_model_fields(self) -> None:
+        exc = _FakeExc("maximum context length exceeded", status_code=400)
+        with pytest.raises(ContextLengthExceeded) as ei:
+            classify_and_raise(exc, model=_model(provider="openai", model_id="gpt-4o"))
+        err = ei.value
+        assert err.provider == "openai"
+        assert err.model == "gpt-4o"
+        assert err.status_code == 400
+
+    def test_volcano_invalid_parameter_400_with_oversize_tokens(self) -> None:
+        """Volcano ARK sends opaque 400 InvalidParameter when over-context."""
+        # Build a message whose chars/4 estimate is >= 95% of context_window (100k).
+        # context_window=100_000; 95% threshold = 95_000 tokens = 380_000 chars.
+        big_text = "x" * 400_000
+        msgs = [UserMessage(content=[TextContent(text=big_text)])]
+        exc = _FakeExc("InvalidParameter", status_code=400)
+        with pytest.raises(ContextLengthExceeded) as ei:
+            classify_and_raise(exc, model=_model(context_window=100_000), messages=msgs)
+        assert ei.value.tokens_in is not None
+        assert ei.value.context_window == 100_000
+
+    def test_400_below_95_percent_threshold_not_context_length(self) -> None:
+        """400 with small messages should NOT be classified as ContextLengthExceeded."""
+        msgs = _messages("short prompt")
+        exc = _FakeExc("InvalidParameter", status_code=400)
+        with pytest.raises(ProviderBadRequest):
+            classify_and_raise(exc, model=_model(context_window=100_000), messages=msgs)
+
+
+class TestClassifyRateLimited:
+    def test_429_raises_rate_limited(self) -> None:
+        exc = _FakeExc("Too Many Requests", status_code=429)
+        with pytest.raises(RateLimited) as ei:
+            classify_and_raise(exc, model=_model())
+        assert ei.value.status_code == 429
+
+    def test_retry_after_parsed_from_headers(self) -> None:
+        exc = _FakeExc(
+            "rate limit exceeded",
+            status_code=429,
+            headers={"retry-after": "42"},
+        )
+        with pytest.raises(RateLimited) as ei:
+            classify_and_raise(exc, model=_model())
+        assert ei.value.retry_after == 42.0
+
+    def test_quota_wording_triggers_rate_limited(self) -> None:
+        # Pattern: "quota (?:exceed|exhaust|limit|reach)" — matches "quota exceeded"
+        exc = _FakeExc("quota exceeded for your account", status_code=200)
+        with pytest.raises(RateLimited):
+            classify_and_raise(exc, model=_model())
+
+    def test_403_with_quota_wording_raises_rate_limited(self) -> None:
+        """Anthropic-style 403 with 'quota limit' text → RateLimited, not AuthFailed."""
+        exc = _FakeExc(
+            "Your account has reached its quota limit. Please upgrade.",
+            status_code=403,
+        )
+        with pytest.raises(RateLimited):
+            classify_and_raise(exc, model=_model())
+
+
+class TestClassifyProviderAuthFailed:
+    def test_401_raises_provider_auth_failed(self) -> None:
+        exc = _FakeExc("Unauthorized", status_code=401)
+        with pytest.raises(ProviderAuthFailed) as ei:
+            classify_and_raise(exc, model=_model())
+        assert ei.value.status_code == 401
+
+    def test_403_without_quota_wording_raises_provider_auth_failed(self) -> None:
+        exc = _FakeExc("Forbidden", status_code=403)
+        with pytest.raises(ProviderAuthFailed):
+            classify_and_raise(exc, model=_model())
+
+    def test_carries_provider_context(self) -> None:
+        exc = _FakeExc("Invalid API key", status_code=401)
+        with pytest.raises(ProviderAuthFailed) as ei:
+            classify_and_raise(
+                exc, model=_model(provider="anthropic", model_id="claude-3-5-sonnet")
+            )
+        assert ei.value.provider == "anthropic"
+
+
+class TestClassifyProviderUnavailable:
+    def test_5xx_raises_provider_unavailable(self) -> None:
+        exc = _FakeExc("Internal Server Error", status_code=500)
+        with pytest.raises(ProviderUnavailable) as ei:
+            classify_and_raise(exc, model=_model())
+        assert ei.value.status_code == 500
+
+    def test_503_raises_provider_unavailable(self) -> None:
+        exc = _FakeExc("Service Unavailable", status_code=503)
+        with pytest.raises(ProviderUnavailable):
+            classify_and_raise(exc, model=_model())
+
+    def test_timeout_error_raises_provider_unavailable(self) -> None:
+        exc = TimeoutError("request timed out")
+        with pytest.raises(ProviderUnavailable):
+            classify_and_raise(exc, model=_model())
+
+    def test_connection_error_raises_provider_unavailable(self) -> None:
+        exc = ConnectionError("failed to connect")
+        with pytest.raises(ProviderUnavailable):
+            classify_and_raise(exc, model=_model())
+
+
+class TestClassifyProviderBadRequest:
+    def test_generic_400_raises_provider_bad_request(self) -> None:
+        exc = _FakeExc("Bad Request", status_code=400)
+        with pytest.raises(ProviderBadRequest) as ei:
+            classify_and_raise(exc, model=_model())
+        assert ei.value.status_code == 400
+
+    def test_404_raises_provider_bad_request(self) -> None:
+        exc = _FakeExc("model not found", status_code=404)
+        with pytest.raises(ProviderBadRequest):
+            classify_and_raise(exc, model=_model())
+
+
+class TestClassifyUnknown:
+    def test_unknown_exception_re_raised_as_is(self) -> None:
+        """A plain RuntimeError with no status code propagates unchanged."""
+        exc = RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom") as ei:
+            classify_and_raise(exc, model=_model())
+        assert ei.value is exc
+
+    def test_already_typed_error_re_raised_unchanged(self) -> None:
+        """A ProviderError passed in is re-raised without double-wrapping."""
+        original = ContextLengthExceeded(
+            "already typed", provider="openai", model="gpt-4o"
+        )
+        with pytest.raises(ContextLengthExceeded) as ei:
+            classify_and_raise(original, model=_model())
+        assert ei.value is original
+
+
+class TestProviderErrorInheritance:
+    def test_all_subclasses_are_provider_error(self) -> None:
+        for cls in (
+            ContextLengthExceeded,
+            RateLimited,
+            ProviderAuthFailed,
+            ProviderUnavailable,
+            ProviderBadRequest,
+        ):
+            err = cls("msg", provider="p", model="m")
+            assert isinstance(err, ProviderError)
+            assert isinstance(err, Exception)
+
+    def test_context_length_carries_token_fields(self) -> None:
+        err = ContextLengthExceeded(
+            "too long",
+            provider="openai",
+            model="gpt-4o",
+            tokens_in=5000,
+            context_window=4096,
+        )
+        assert err.tokens_in == 5000
+        assert err.context_window == 4096
+
+    def test_rate_limited_carries_retry_after(self) -> None:
+        err = RateLimited(
+            "slow down", provider="openai", model="gpt-4o", retry_after=30.0
+        )
+        assert err.retry_after == 30.0

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -13,6 +13,9 @@ from cubepi.errors import (
     ProviderError,
     ProviderUnavailable,
     RateLimited,
+    _estimate_input_tokens,
+    _retry_after_from,
+    _status_of,
     classify_and_raise,
 )
 from cubepi.providers.base import Model, TextContent, UserMessage
@@ -36,7 +39,12 @@ def _messages(text: str = "hello") -> list:
 
 
 class _FakeExc(Exception):
-    """Fake SDK exception with configurable status_code, message, and headers."""
+    """Fake SDK exception with configurable status_code, message, and headers.
+
+    ``status_code`` sets both the direct attr AND ``.response.status_code`` so
+    existing classifier tests work. Pass ``response_status_code`` instead to
+    put the code only on ``.response`` (for testing the fallback path).
+    """
 
     def __init__(
         self,
@@ -44,14 +52,18 @@ class _FakeExc(Exception):
         *,
         status_code: int | None = None,
         headers: dict | None = None,
+        response_status_code: int | None = None,
     ) -> None:
         super().__init__(message)
         if status_code is not None:
             self.status_code = status_code
-        if headers is not None:
+        response_code = (
+            response_status_code if response_status_code is not None else status_code
+        )
+        if response_code is not None or headers is not None:
             self.response = SimpleNamespace(
-                status_code=status_code,
-                headers=headers,
+                status_code=response_code,
+                headers=headers or {},
             )
 
 
@@ -253,3 +265,83 @@ class TestProviderErrorInheritance:
             "slow down", provider="openai", model="gpt-4o", retry_after=30.0
         )
         assert err.retry_after == 30.0
+
+
+# ---------------------------------------------------------------------------
+# Coverage fillers — internal helpers exercised directly.
+# ---------------------------------------------------------------------------
+
+
+class TestStatusOf:
+    def test_direct_status_code(self) -> None:
+        exc = _FakeExc("msg", status_code=400)
+        assert _status_of(exc) == 400
+
+    def test_response_fallback(self) -> None:
+        """exc has no .status_code but .response.status_code — fallback path."""
+        exc = _FakeExc("msg", response_status_code=503)
+        assert getattr(exc, "status_code", None) is None
+        assert _status_of(exc) == 503
+
+    def test_no_status(self) -> None:
+        exc = RuntimeError("no status anywhere")
+        assert _status_of(exc) is None
+
+
+class TestEstimateInputTokens:
+    def test_none_returns_none(self) -> None:
+        assert _estimate_input_tokens(None) is None
+
+    def test_empty_returns_none(self) -> None:
+        assert _estimate_input_tokens([]) is None
+
+    def test_user_message_with_text_content(self) -> None:
+        msgs = _messages("hello world")
+        est = _estimate_input_tokens(msgs)
+        assert est >= 2
+
+    def test_block_with_content_not_text_attr(self) -> None:
+        """Block that has .content instead of .text — non-TextContent blocks."""
+        block = SimpleNamespace(text=None, content="tool result text")
+        msg = type("_Msg", (), {"content": [block]})()
+        est = _estimate_input_tokens([msg])
+        assert est is not None and est >= 3
+
+    def test_string_content(self) -> None:
+        """Message with list[str] content blocks is NOT expected but is handled."""
+
+        # Actually test the elif isinstance(content, str) branch via a mock.
+        class _StrMsg:
+            content = "plain string content for token estimation"
+
+        est = _estimate_input_tokens([_StrMsg])  # type: ignore[list-item]
+        assert est is not None and est >= 7
+
+    def test_zero_total_returns_none(self) -> None:
+        """Empty strings produce zero total."""
+        msgs = [UserMessage(content=[TextContent(text="")])]
+        assert _estimate_input_tokens(msgs) is None
+
+
+class TestRetryAfterFrom:
+    def test_lowercase_retry_after_header(self) -> None:
+        exc = _FakeExc("rate limited", status_code=429, headers={"retry-after": "60"})
+        assert _retry_after_from(exc) == 60.0
+
+    def test_title_case_retry_after_header(self) -> None:
+        exc = _FakeExc("rate limited", status_code=429, headers={"Retry-After": "30"})
+        assert _retry_after_from(exc) == 30.0
+
+    def test_no_headers_returns_none(self) -> None:
+        exc = _FakeExc("rate limited", status_code=429)
+        assert _retry_after_from(exc) is None
+
+    def test_no_retry_after_key_returns_none(self) -> None:
+        exc = _FakeExc("rate limited", status_code=429, headers={"x-other": "1"})
+        assert _retry_after_from(exc) is None
+
+    def test_non_numeric_value_returns_none(self) -> None:
+        exc = _FakeExc(
+            "rate limited", status_code=429, headers={"retry-after": "not-a-number"}
+        )
+        assert _retry_after_from(exc) is None


### PR DESCRIPTION
## Summary
- New `cubepi.errors` module: `ProviderError` base + 5 subclasses (`ContextLengthExceeded`, `RateLimited`, `ProviderAuthFailed`, `ProviderUnavailable`, `ProviderBadRequest`). Each carries `.provider` / `.model` / `.status_code`. Subclasses carry extra diagnostics (`tokens_in` / `context_window` / `retry_after`).
- `classify_and_raise(exc, *, model, messages)` inspects raw SDK exceptions and re-raises as typed cubepi errors. Heuristics cover Volcano ARK's opaque `InvalidParameter` → `ContextLengthExceeded` (tokensin >= 95% of context_window), Anthropic's 403-for-quota → `RateLimited`, etc.
- All three provider adapters (`openai.py`, `openai_responses.py`, `anthropic.py`) wrap their SDK call sites. Any raw SDK exception bubbles up as a typed cubepi error instead.
- 26 classifier tests + 53 openai provider tests + 36 anthropic provider tests. Full suite 1180 passed.
## Why
Downstream consumers (cubebox, examples, future apps) currently inspect raw SDK exception strings and status codes to guess what went wrong. This is fragile (ARK returns opaque `InvalidParameter` for over-context) and duplicated in every consumer. Typed errors let callers `except cubepi.errors.ContextLengthExceeded` and get `tokens_in` / `context_window` diagnostics for free.
@codex