### PR TITLE
feat(tracing): record CompactionMiddleware summarizer's LLM call

### DIFF
--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -162,6 +162,11 @@ class Agent(Generic[TMessage]):
         if tools:
             self._state.tools = tools
         middleware = middleware or []
+        # Retain the list so observers (e.g. cubepi.tracing.Recorder) can
+        # walk it after construction — they need to reach attributes like
+        # ``Middleware.providers()`` that aren't captured by the composed
+        # hook callables below.
+        self._middleware: list[Middleware] = list(middleware)
         middleware_tools: list[AgentTool] = []
         for mw in middleware:
             middleware_tools.extend(getattr(mw, "tools", []) or [])

--- a/cubepi/middleware/base.py
+++ b/cubepi/middleware/base.py
@@ -12,7 +12,7 @@ from cubepi.agent.types import (
     BeforeToolCallContext,
     BeforeToolCallResult,
 )
-from cubepi.providers.base import AssistantMessage, Message, Provider
+from cubepi.providers.base import AssistantMessage, Message, Model, Provider
 from cubepi.types import JsonObject, StructuredObject
 
 
@@ -90,15 +90,25 @@ class Middleware:
     ) -> list[Message] | None:
         raise NotImplementedError
 
-    def providers(self) -> Iterable[Provider]:
-        """Return any extra LLM providers this middleware drives directly.
+    def extra_llm_calls(self) -> Iterable[tuple[Provider, Model]]:
+        """Declare LLM calls this middleware drives outside the agent's main
+        provider/model.
 
-        Some middlewares (e.g. ``CompactionMiddleware``) make their own LLM
-        calls outside the agent's main provider. Returning those providers
-        here lets ``cubepi.tracing.Recorder`` wire its listeners so the
-        resulting calls show up in the trace tree alongside the agent's own
-        chat spans. Default is empty — middlewares that do not call any
-        LLM directly need not override.
+        Each pair is ``(provider, model)``. ``cubepi.tracing.Recorder`` uses
+        these to:
+
+        * Subscribe listeners on any provider the recorder isn't already
+          watching, so the resulting calls show up in the trace tree
+          alongside the agent's own chat spans.
+        * Identify middleware-owned calls by ``(model.provider, model.id)``
+          so they don't overwrite the root ``invoke_agent`` span's
+          attribution (provider name, system prompt hash, tool list). This
+          model-based gate is what handles the common "reuse one provider
+          client, swap the model" pattern — listener identity alone would
+          attribute the middleware's first call to the agent.
+
+        Default is empty — middlewares that do not call any LLM directly
+        need not override.
         """
         return ()
 

--- a/cubepi/middleware/base.py
+++ b/cubepi/middleware/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, Literal
+from typing import Callable, Iterable, Literal
 
 import asyncio
 
@@ -12,7 +12,7 @@ from cubepi.agent.types import (
     BeforeToolCallContext,
     BeforeToolCallResult,
 )
-from cubepi.providers.base import AssistantMessage, Message
+from cubepi.providers.base import AssistantMessage, Message, Provider
 from cubepi.types import JsonObject, StructuredObject
 
 
@@ -89,6 +89,18 @@ class Middleware:
         signal: asyncio.Event | None = None,
     ) -> list[Message] | None:
         raise NotImplementedError
+
+    def providers(self) -> Iterable[Provider]:
+        """Return any extra LLM providers this middleware drives directly.
+
+        Some middlewares (e.g. ``CompactionMiddleware``) make their own LLM
+        calls outside the agent's main provider. Returning those providers
+        here lets ``cubepi.tracing.Recorder`` wire its listeners so the
+        resulting calls show up in the trace tree alongside the agent's own
+        chat spans. Default is empty — middlewares that do not call any
+        LLM directly need not override.
+        """
+        return ()
 
 
 def _has_method(middleware: Middleware, name: str) -> bool:

--- a/cubepi/middleware/compaction/__init__.py
+++ b/cubepi/middleware/compaction/__init__.py
@@ -133,12 +133,14 @@ class CompactionMiddleware(Middleware):
         ctx.extra["compaction_until_msg_index"] = new_boundary
         return _compressed_view(messages, new_state, new_boundary)
 
-    def providers(self) -> tuple[Provider, ...]:
-        # Surface the summary provider so ``cubepi.tracing.Recorder`` can
-        # wire its listeners — without this the summarizer's LLM call is
-        # invisible to the trace, even though the rest of the turn is
-        # recorded.
-        return (self._summary_provider,)
+    def extra_llm_calls(self) -> tuple[tuple[Provider, Model], ...]:
+        # Surface (provider, model) so ``cubepi.tracing.Recorder`` can both
+        # subscribe its listeners (the summarizer's chat span lands in the
+        # trace) AND identify the summary call by model — important when
+        # ``summary_provider`` is the same instance as the agent's main
+        # provider, which is the common "reuse the client, swap the model"
+        # pattern.
+        return ((self._summary_provider, self._summary_model),)
 
 
 __all__ = [

--- a/cubepi/middleware/compaction/__init__.py
+++ b/cubepi/middleware/compaction/__init__.py
@@ -133,6 +133,13 @@ class CompactionMiddleware(Middleware):
         ctx.extra["compaction_until_msg_index"] = new_boundary
         return _compressed_view(messages, new_state, new_boundary)
 
+    def providers(self) -> tuple[Provider, ...]:
+        # Surface the summary provider so ``cubepi.tracing.Recorder`` can
+        # wire its listeners — without this the summarizer's LLM call is
+        # invisible to the trace, even though the rest of the turn is
+        # recorded.
+        return (self._summary_provider,)
+
 
 __all__ = [
     "CompactionMiddleware",

--- a/cubepi/middleware/compaction/summarizer.py
+++ b/cubepi/middleware/compaction/summarizer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 
 from cubepi.middleware.compaction.state import CompactionState, message_refs
 from cubepi.providers.base import (
@@ -12,6 +13,48 @@ from cubepi.providers.base import (
     ToolCall,
     UserMessage,
 )
+
+
+def _compaction_summary_span(message_count: int):
+    """Open a parent span for the summarizer's LLM call.
+
+    Without this wrapper the summarizer's chat span — emitted automatically
+    once :class:`cubepi.tracing.Recorder` is wired to the summary provider —
+    sits flat under ``cubepi.turn`` and is hard to tell apart from the
+    agent's own chat span. The wrapping name makes the role obvious and
+    tags it with the number of messages being summarised.
+
+    Resolves the tracer via ``cubepi.mcp._tracing._get_tracer`` so the span
+    routes through whichever :class:`cubepi.tracing.Tracer` is currently
+    attached to the running agent. Without that lookup the OTel global
+    provider is a no-op unless the user called ``set_tracer_provider``,
+    which cubepi deliberately doesn't do. Falls back to a no-op context
+    manager if neither OpenTelemetry nor an attached Tracer is available.
+    """
+    try:
+        from cubepi.mcp._tracing import _get_tracer
+    except ImportError:
+        return contextlib.nullcontext()
+
+    try:
+        tracer = _get_tracer("cubepi.middleware.compaction")
+    except Exception:
+        return contextlib.nullcontext()
+
+    cm = tracer.start_as_current_span("cubepi.compaction.summarize")
+
+    @contextlib.contextmanager
+    def _wrapped():
+        with cm as span:
+            try:
+                if span is not None:
+                    span.set_attribute("cubepi.compaction.message_count", message_count)
+            except Exception:
+                pass
+            yield span
+
+    return _wrapped()
+
 
 SUMMARIZER_SYSTEM_PROMPT = """\
 You compress a chat transcript into a brief, faithful narrative for an AI assistant
@@ -64,19 +107,22 @@ async def summarize(
     if existing and existing.summary:
         system_prompt += "\n\n" + EXISTING_SUMMARY_SUFFIX.format(prev=existing.summary)
 
-    response = await provider.generate(
-        model=model,
-        messages=[
-            UserMessage(
-                content=[TextContent(text=_format_transcript(messages_to_summarize))]
-            )
-        ],
-        system_prompt=system_prompt,
-        options=StreamOptions(signal=abort_signal),
-        max_output_tokens=max_summary_tokens,
-        temperature=0.0,
-        thinking="off",
-    )
+    with _compaction_summary_span(len(messages_to_summarize)):
+        response = await provider.generate(
+            model=model,
+            messages=[
+                UserMessage(
+                    content=[
+                        TextContent(text=_format_transcript(messages_to_summarize))
+                    ]
+                )
+            ],
+            system_prompt=system_prompt,
+            options=StreamOptions(signal=abort_signal),
+            max_output_tokens=max_summary_tokens,
+            temperature=0.0,
+            thinking="off",
+        )
 
     text = "".join(
         block.text for block in response.content if isinstance(block, TextContent)

--- a/cubepi/middleware/compaction/summarizer.py
+++ b/cubepi/middleware/compaction/summarizer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 
 from cubepi.middleware.compaction.state import CompactionState, message_refs
 from cubepi.providers.base import (
@@ -13,47 +12,6 @@ from cubepi.providers.base import (
     ToolCall,
     UserMessage,
 )
-
-
-def _compaction_summary_span(message_count: int):
-    """Open a parent span for the summarizer's LLM call.
-
-    Without this wrapper the summarizer's chat span — emitted automatically
-    once :class:`cubepi.tracing.Recorder` is wired to the summary provider —
-    sits flat under ``cubepi.turn`` and is hard to tell apart from the
-    agent's own chat span. The wrapping name makes the role obvious and
-    tags it with the number of messages being summarised.
-
-    Resolves the tracer via ``cubepi.mcp._tracing._get_tracer`` so the span
-    routes through whichever :class:`cubepi.tracing.Tracer` is currently
-    attached to the running agent. Without that lookup the OTel global
-    provider is a no-op unless the user called ``set_tracer_provider``,
-    which cubepi deliberately doesn't do. Falls back to a no-op context
-    manager if neither OpenTelemetry nor an attached Tracer is available.
-    """
-    try:
-        from cubepi.mcp._tracing import _get_tracer
-    except ImportError:
-        return contextlib.nullcontext()
-
-    try:
-        tracer = _get_tracer("cubepi.middleware.compaction")
-    except Exception:
-        return contextlib.nullcontext()
-
-    cm = tracer.start_as_current_span("cubepi.compaction.summarize")
-
-    @contextlib.contextmanager
-    def _wrapped():
-        with cm as span:
-            try:
-                if span is not None:
-                    span.set_attribute("cubepi.compaction.message_count", message_count)
-            except Exception:
-                pass
-            yield span
-
-    return _wrapped()
 
 
 SUMMARIZER_SYSTEM_PROMPT = """\
@@ -107,22 +65,19 @@ async def summarize(
     if existing and existing.summary:
         system_prompt += "\n\n" + EXISTING_SUMMARY_SUFFIX.format(prev=existing.summary)
 
-    with _compaction_summary_span(len(messages_to_summarize)):
-        response = await provider.generate(
-            model=model,
-            messages=[
-                UserMessage(
-                    content=[
-                        TextContent(text=_format_transcript(messages_to_summarize))
-                    ]
-                )
-            ],
-            system_prompt=system_prompt,
-            options=StreamOptions(signal=abort_signal),
-            max_output_tokens=max_summary_tokens,
-            temperature=0.0,
-            thinking="off",
-        )
+    response = await provider.generate(
+        model=model,
+        messages=[
+            UserMessage(
+                content=[TextContent(text=_format_transcript(messages_to_summarize))]
+            )
+        ],
+        system_prompt=system_prompt,
+        options=StreamOptions(signal=abort_signal),
+        max_output_tokens=max_summary_tokens,
+        temperature=0.0,
+        thinking="off",
+    )
 
     text = "".join(
         block.text for block in response.content if isinstance(block, TextContent)

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -218,6 +218,14 @@ class Recorder:
         # ``_close_open_spans`` (the latter covers cancelled runs that
         # never emit AgentEndEvent).
         self._active_run_token: Any | None = None
+        # ``(model.provider, model.id)`` tuples for LLM calls a middleware
+        # owns (e.g. ``CompactionMiddleware``'s summarizer). When the
+        # provider listener fires with one of these models we keep the
+        # chat span but skip the root ``invoke_agent`` attribution writes
+        # so the run stays attributed to the agent's own provider /
+        # system prompt / tools. Model-based gating works even when the
+        # middleware shares the agent's main provider instance.
+        self._extra_call_models: set[tuple[str, str]] = set()
 
     # ------------------------------------------------------------------
     # Attach / detach
@@ -234,26 +242,10 @@ class Recorder:
         provider = getattr(agent, "_provider", None) or getattr(agent, "provider", None)
         provider_detachers: list[Callable[[], None]] = []
 
-        def _subscribe(p: Any, *, is_main: bool) -> None:
+        def _subscribe(p: Any) -> None:
             if not isinstance(p, BaseProvider):
                 return
-            # Middleware-driven providers must not write to the root
-            # ``invoke_agent`` span's attribution attributes — the root
-            # represents the agent invocation, not a per-middleware
-            # detour. Without this gate the first middleware request
-            # (typically ``CompactionMiddleware`` firing in
-            # ``transform_context`` before the agent's own model call)
-            # would clobber ``gen_ai.provider.name`` /
-            # ``cubepi.agent.system_prompt_sha256`` /
-            # ``cubepi.agent.tools`` with the summarizer's values, and
-            # provider-level trace filters / aggregate metrics would
-            # mis-attribute the whole run to the summarizer's provider.
-            on_request = (
-                self._on_provider_request
-                if is_main
-                else self._on_extra_provider_request
-            )
-            provider_detachers.append(p.subscribe_request(on_request))
+            provider_detachers.append(p.subscribe_request(self._on_provider_request))
             provider_detachers.append(p.subscribe_chunk(self._on_provider_chunk))
             provider_detachers.append(p.subscribe_response(self._on_provider_response))
 
@@ -262,24 +254,29 @@ class Recorder:
         # so a failed attach() leaves no dangling listeners. The caller never
         # gets a ``detach`` callable on this path, so we cannot defer cleanup.
         try:
-            _subscribe(provider, is_main=True)
-            # Middlewares may drive their own LLM providers (e.g.
-            # ``CompactionMiddleware``'s summary provider) — wire them too
-            # so those calls show up in the trace tree instead of
-            # silently bypassing it. ``Middleware.providers()`` returns
-            # an empty iterable by default, so middlewares that don't
-            # touch an LLM directly cost nothing here.
+            _subscribe(provider)
+            # Middlewares may drive their own LLM calls (e.g.
+            # ``CompactionMiddleware``'s summarizer). For each declared
+            # (provider, model) pair: (a) subscribe the provider if we
+            # aren't already, so those calls show up in the trace tree;
+            # (b) record the model identity in ``_extra_call_models`` so
+            # ``_on_provider_request`` knows to skip the root-attribution
+            # write — gating by listener identity alone would fail when
+            # the middleware shares the agent's main provider instance
+            # ("reuse the client, swap the model"), since both calls
+            # would arrive on the same listener.
             seen: set[int] = {id(provider)} if provider is not None else set()
             for mw in getattr(agent, "_middleware", []) or []:
                 try:
-                    extra = list(mw.providers())
+                    extra = list(mw.extra_llm_calls())
                 except Exception:
                     extra = []
-                for p in extra:
+                for p, m in extra:
+                    self._extra_call_models.add((m.provider, m.id))
                     if id(p) in seen:
                         continue
                     seen.add(id(p))
-                    _subscribe(p, is_main=False)
+                    _subscribe(p)
         except BaseException:
             for d in provider_detachers:
                 try:
@@ -904,15 +901,7 @@ class Recorder:
     # Provider listeners — drive the chat span lifetime
     # ------------------------------------------------------------------
 
-    def _on_extra_provider_request(self, payload: dict, model: "Model") -> None:
-        """Variant for middleware-supplied providers (e.g. the compaction
-        summarizer) — emits a chat span but does not touch the root
-        ``invoke_agent`` span's attribution attributes."""
-        self._on_provider_request(payload, model, attribute_root=False)
-
-    def _on_provider_request(
-        self, payload: dict, model: "Model", *, attribute_root: bool = True
-    ) -> None:
+    def _on_provider_request(self, payload: dict, model: "Model") -> None:
         run = self._run
         if run is None or run.turn_span is None:
             return
@@ -959,6 +948,17 @@ class Recorder:
         ):
             attrs[CUBEPI_LLM_THINKING_LEVEL] = payload["reasoning"]["effort"]
 
+        # Root ``invoke_agent`` span carries attribution for the agent
+        # invocation as a whole — provider name, system prompt hash, tool
+        # list. Middleware-driven LLM calls (e.g. the compaction
+        # summarizer) must NOT overwrite those, otherwise a single
+        # ``transform_context`` call that fires before the main model
+        # would mis-attribute the whole run. ``_extra_call_models`` is
+        # populated in ``attach`` from ``Middleware.extra_llm_calls()`` —
+        # if the incoming model matches, skip the root writes. Gating by
+        # model rather than listener identity is what handles the
+        # shared-provider case ("reuse the client, swap the model").
+        attribute_root = (model.provider, model.id) not in self._extra_call_models
         if attribute_root:
             # System prompt sha256 on root agent span (once per run).
             self._maybe_record_system_prompt_hash(payload, run)

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -233,21 +233,37 @@ class Recorder:
         # alias should one be added later.
         provider = getattr(agent, "_provider", None) or getattr(agent, "provider", None)
         provider_detachers: list[Callable[[], None]] = []
+
+        def _subscribe(p: Any) -> None:
+            if not isinstance(p, BaseProvider):
+                return
+            provider_detachers.append(p.subscribe_request(self._on_provider_request))
+            provider_detachers.append(p.subscribe_chunk(self._on_provider_chunk))
+            provider_detachers.append(p.subscribe_response(self._on_provider_response))
+
         # Attach must be all-or-nothing: if a later subscription raises, unwind
         # the ones already registered (incl. the agent listener) and re-raise,
         # so a failed attach() leaves no dangling listeners. The caller never
         # gets a ``detach`` callable on this path, so we cannot defer cleanup.
         try:
-            if isinstance(provider, BaseProvider):
-                provider_detachers.append(
-                    provider.subscribe_request(self._on_provider_request)
-                )
-                provider_detachers.append(
-                    provider.subscribe_chunk(self._on_provider_chunk)
-                )
-                provider_detachers.append(
-                    provider.subscribe_response(self._on_provider_response)
-                )
+            _subscribe(provider)
+            # Middlewares may drive their own LLM providers (e.g.
+            # ``CompactionMiddleware``'s summary provider) — wire them too
+            # so those calls show up in the trace tree instead of
+            # silently bypassing it. ``Middleware.providers()`` returns
+            # an empty iterable by default, so middlewares that don't
+            # touch an LLM directly cost nothing here.
+            seen: set[int] = {id(provider)} if provider is not None else set()
+            for mw in getattr(agent, "_middleware", []) or []:
+                try:
+                    extra = list(mw.providers())
+                except Exception:
+                    extra = []
+                for p in extra:
+                    if id(p) in seen:
+                        continue
+                    seen.add(id(p))
+                    _subscribe(p)
         except BaseException:
             for d in provider_detachers:
                 try:

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -265,6 +265,24 @@ class Recorder:
             # the middleware shares the agent's main provider instance
             # ("reuse the client, swap the model"), since both calls
             # would arrive on the same listener.
+            #
+            # Degenerate case: if a middleware declares the SAME (provider,
+            # model) as the agent's main, model-based gating cannot tell
+            # the two calls apart — skipping attribution for that key
+            # would also skip the agent's own request and leave the root
+            # span with the placeholder ``cubepi`` provider name (codex
+            # round-N). Exclude those keys from the extra set so the
+            # degenerate config falls back to the original first-call-wins
+            # behaviour. The configuration is self-defeating anyway —
+            # compaction with the same model gives no cost / context
+            # benefit — but the recorder still produces a usable trace.
+            agent_state = getattr(agent, "_state", None)
+            agent_model = getattr(agent_state, "model", None) if agent_state else None
+            agent_key: tuple[str, str] | None = (
+                (agent_model.provider, agent_model.id)
+                if agent_model is not None
+                else None
+            )
             seen: set[int] = {id(provider)} if provider is not None else set()
             for mw in getattr(agent, "_middleware", []) or []:
                 try:
@@ -272,7 +290,9 @@ class Recorder:
                 except Exception:
                     extra = []
                 for p, m in extra:
-                    self._extra_call_models.add((m.provider, m.id))
+                    key = (m.provider, m.id)
+                    if key != agent_key:
+                        self._extra_call_models.add(key)
                     if id(p) in seen:
                         continue
                     seen.add(id(p))

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -234,10 +234,26 @@ class Recorder:
         provider = getattr(agent, "_provider", None) or getattr(agent, "provider", None)
         provider_detachers: list[Callable[[], None]] = []
 
-        def _subscribe(p: Any) -> None:
+        def _subscribe(p: Any, *, is_main: bool) -> None:
             if not isinstance(p, BaseProvider):
                 return
-            provider_detachers.append(p.subscribe_request(self._on_provider_request))
+            # Middleware-driven providers must not write to the root
+            # ``invoke_agent`` span's attribution attributes — the root
+            # represents the agent invocation, not a per-middleware
+            # detour. Without this gate the first middleware request
+            # (typically ``CompactionMiddleware`` firing in
+            # ``transform_context`` before the agent's own model call)
+            # would clobber ``gen_ai.provider.name`` /
+            # ``cubepi.agent.system_prompt_sha256`` /
+            # ``cubepi.agent.tools`` with the summarizer's values, and
+            # provider-level trace filters / aggregate metrics would
+            # mis-attribute the whole run to the summarizer's provider.
+            on_request = (
+                self._on_provider_request
+                if is_main
+                else self._on_extra_provider_request
+            )
+            provider_detachers.append(p.subscribe_request(on_request))
             provider_detachers.append(p.subscribe_chunk(self._on_provider_chunk))
             provider_detachers.append(p.subscribe_response(self._on_provider_response))
 
@@ -246,7 +262,7 @@ class Recorder:
         # so a failed attach() leaves no dangling listeners. The caller never
         # gets a ``detach`` callable on this path, so we cannot defer cleanup.
         try:
-            _subscribe(provider)
+            _subscribe(provider, is_main=True)
             # Middlewares may drive their own LLM providers (e.g.
             # ``CompactionMiddleware``'s summary provider) — wire them too
             # so those calls show up in the trace tree instead of
@@ -263,7 +279,7 @@ class Recorder:
                     if id(p) in seen:
                         continue
                     seen.add(id(p))
-                    _subscribe(p)
+                    _subscribe(p, is_main=False)
         except BaseException:
             for d in provider_detachers:
                 try:
@@ -888,7 +904,15 @@ class Recorder:
     # Provider listeners — drive the chat span lifetime
     # ------------------------------------------------------------------
 
-    def _on_provider_request(self, payload: dict, model: "Model") -> None:
+    def _on_extra_provider_request(self, payload: dict, model: "Model") -> None:
+        """Variant for middleware-supplied providers (e.g. the compaction
+        summarizer) — emits a chat span but does not touch the root
+        ``invoke_agent`` span's attribution attributes."""
+        self._on_provider_request(payload, model, attribute_root=False)
+
+    def _on_provider_request(
+        self, payload: dict, model: "Model", *, attribute_root: bool = True
+    ) -> None:
         run = self._run
         if run is None or run.turn_span is None:
             return
@@ -935,21 +959,22 @@ class Recorder:
         ):
             attrs[CUBEPI_LLM_THINKING_LEVEL] = payload["reasoning"]["effort"]
 
-        # System prompt sha256 on root agent span (once per run).
-        self._maybe_record_system_prompt_hash(payload, run)
+        if attribute_root:
+            # System prompt sha256 on root agent span (once per run).
+            self._maybe_record_system_prompt_hash(payload, run)
 
-        # Update root's gen_ai.provider.name with the first concrete one.
-        if (run.agent_span.attributes or {}).get(GEN_AI_PROVIDER_NAME) == "cubepi":
-            run.agent_span.set_attribute(
-                GEN_AI_PROVIDER_NAME, attrs[GEN_AI_PROVIDER_NAME]
-            )
+            # Update root's gen_ai.provider.name with the first concrete one.
+            if (run.agent_span.attributes or {}).get(GEN_AI_PROVIDER_NAME) == "cubepi":
+                run.agent_span.set_attribute(
+                    GEN_AI_PROVIDER_NAME, attrs[GEN_AI_PROVIDER_NAME]
+                )
 
-        # Tool count on root.
-        tools = payload.get("tools")
-        if isinstance(tools, list) and tools:
-            run.agent_span.set_attribute(
-                CUBEPI_AGENT_TOOLS, [_safe_tool_name(t) for t in tools]
-            )
+            # Tool count on root.
+            tools = payload.get("tools")
+            if isinstance(tools, list) and tools:
+                run.agent_span.set_attribute(
+                    CUBEPI_AGENT_TOOLS, [_safe_tool_name(t) for t in tools]
+                )
 
         chat_span = self._tracer.otel_tracer.start_span(
             name=f"{SPAN_NAME_CHAT} {model.id}",

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -694,6 +694,44 @@ class TestMiddlewareProviders:
         # Root must end up with a real provider name, not the cubepi placeholder.
         assert _attrs(root)["gen_ai.provider.name"] != "cubepi"
 
+    async def test_middleware_extra_provider_not_baseprovider_is_skipped(self):
+        # A middleware that hands the recorder a provider not derived from
+        # ``BaseProvider`` (no listener registry) is skipped by
+        # ``_subscribe`` — its calls simply won't be observable, but attach
+        # must not error. Covers the early-return branch in ``_subscribe``
+        # that codecov flagged.
+        from cubepi.middleware.base import Middleware
+
+        class _DuckProvider:
+            pass
+
+        class _DuckMiddleware(Middleware):
+            def __init__(self, model):
+                self._m = model
+
+            def extra_llm_calls(self):
+                return [(_DuckProvider(), self._m)]
+
+        provider = FauxProvider()
+        agent = Agent(
+            provider=provider,
+            model=MODEL,
+            system_prompt="test",
+            middleware=[_DuckMiddleware(Model(id="dm-1", provider="duck"))],
+        )
+        exporter = InMemoryExporter()
+        tracer = Tracer(
+            service_name="test-svc",
+            agent_name="test-agent",
+            exporters=[exporter],
+        )
+        tracer.attach(agent)
+        provider.append_responses([faux_assistant_message("ok")])
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+        assert any(s.name.startswith("chat ") for s in exporter.spans)
+
     async def test_middleware_extra_llm_calls_raising_is_swallowed(self):
         # If a middleware's ``extra_llm_calls()`` raises during attach the
         # recorder must keep going — the agent's own provider is the

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -494,6 +494,78 @@ class TestErrorAndAbort:
         assert fallback_chat.status.status_code == StatusCode.UNSET
 
 
+class TestMiddlewareProviders:
+    """Recorder must also wire listeners for any provider a middleware drives
+    directly (e.g. CompactionMiddleware.summary_provider) — without this the
+    summarizer LLM call is invisible to the trace, even though the rest of the
+    turn is recorded."""
+
+    async def test_compaction_summary_provider_emits_chat_span(self):
+        from cubepi.checkpointer.memory import MemoryCheckpointer
+        from cubepi.middleware.compaction import CompactionMiddleware
+        from cubepi.providers.base import UserMessage
+
+        main = FauxProvider()
+        summarizer = FauxProvider()
+        # Cap at near-zero so transform_context triggers immediately.
+        mw = CompactionMiddleware(
+            summary_provider=summarizer,
+            summary_model=Model(id="summary-1", provider="faux"),
+            max_tokens_before_compact=1,
+            keep_recent_messages=1,
+            max_summary_tokens=128,
+            min_compact_messages=2,
+        )
+        # Pre-seed history via a checkpointer so transform_context sees a
+        # message list above the compaction boundary on the first prompt.
+        cp = MemoryCheckpointer()
+        thread_id = "t-compaction-trace"
+        await cp.append(
+            thread_id,
+            [
+                UserMessage(content=[TextContent(text="first")]),
+                faux_assistant_message("first reply"),
+                UserMessage(content=[TextContent(text="second")]),
+                faux_assistant_message("second reply"),
+            ],
+        )
+
+        agent = Agent(
+            provider=main,
+            model=MODEL,
+            system_prompt="test",
+            middleware=[mw],
+            checkpointer=cp,
+            thread_id=thread_id,
+        )
+        exporter = InMemoryExporter()
+        tracer = Tracer(
+            service_name="test-svc",
+            agent_name="test-agent",
+            exporters=[exporter],
+        )
+        tracer.attach(agent)
+
+        summarizer.append_responses([faux_assistant_message("a brief summary")])
+        main.append_responses([faux_assistant_message("ok")])
+
+        await agent.prompt("third")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        chats = [s for s in exporter.spans if s.name.startswith("chat ")]
+        # One chat from the summarizer, one from the agent's main turn.
+        chat_models = sorted(_attrs(c).get("gen_ai.request.model") for c in chats)
+        assert chat_models == ["faux-1", "summary-1"], chat_models
+
+        # The C-step parent span wraps the summarizer's chat.
+        summary_spans = [
+            s for s in exporter.spans if s.name == "cubepi.compaction.summarize"
+        ]
+        assert len(summary_spans) == 1
+        assert _attrs(summary_spans[0])["cubepi.compaction.message_count"] >= 1
+
+
 class TestSafeToolName:
     """``_safe_tool_name`` must handle all three tool payload shapes:
     Anthropic/cubepi top-level ``name``, OpenAI Responses top-level

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -653,6 +653,47 @@ class TestMiddlewareProviders:
 
         assert list(Middleware().extra_llm_calls()) == []
 
+    async def test_degenerate_same_model_falls_back_to_first_call_wins(self):
+        # Edge case: middleware declares the same (provider, model) as the
+        # agent — model-based gating would otherwise skip root attribution
+        # for the agent's own call too and leave the root span with the
+        # placeholder ``cubepi`` provider. The recorder must exclude these
+        # degenerate keys from the extra set so the run still gets a
+        # concrete root attribution (even if it ends up reflecting whichever
+        # call fired first).
+        from cubepi.middleware.base import Middleware
+
+        class _SameModelMiddleware(Middleware):
+            def __init__(self, provider, model):
+                self._p = provider
+                self._m = model
+
+            def extra_llm_calls(self):
+                return [(self._p, self._m)]
+
+        provider = FauxProvider()
+        agent = Agent(
+            provider=provider,
+            model=MODEL,
+            system_prompt="test",
+            middleware=[_SameModelMiddleware(provider, MODEL)],
+        )
+        exporter = InMemoryExporter()
+        tracer = Tracer(
+            service_name="test-svc",
+            agent_name="test-agent",
+            exporters=[exporter],
+        )
+        tracer.attach(agent)
+        provider.append_responses([faux_assistant_message("ok")])
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = [s for s in exporter.spans if s.name.startswith("invoke_agent")][0]
+        # Root must end up with a real provider name, not the cubepi placeholder.
+        assert _attrs(root)["gen_ai.provider.name"] != "cubepi"
+
     async def test_middleware_extra_llm_calls_raising_is_swallowed(self):
         # If a middleware's ``extra_llm_calls()`` raises during attach the
         # recorder must keep going — the agent's own provider is the

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -577,43 +577,90 @@ class TestMiddlewareProviders:
         root = [s for s in exporter.spans if s.name.startswith("invoke_agent")][0]
         assert _attrs(root)["gen_ai.provider.name"] == "faux"
 
-    async def test_extra_provider_does_not_clobber_root_provider_attribution(self):
-        # Direct exercise of the listener-gating contract: extra-provider
-        # requests must go through ``_on_extra_provider_request``, which
-        # leaves the root span's ``gen_ai.provider.name`` placeholder alone.
-        # Driving the recorder synthetically also covers the path where the
-        # extra provider fires *before* the main provider, the exact ordering
-        # the compaction summarizer creates.
-        from cubepi.tracing.recorder import Recorder
+    async def test_shared_provider_still_protected_by_model_gate(self):
+        # When ``summary_provider`` IS the agent's main provider (a common
+        # "reuse the client, swap the model" pattern), listener-identity
+        # dedupe would route the summarizer through the main listener and
+        # let it clobber the root attribution. The fix gates on the model,
+        # not the listener — this regression test pins that contract.
+        from cubepi.checkpointer.memory import MemoryCheckpointer
+        from cubepi.middleware.compaction import CompactionMiddleware
+        from cubepi.providers.base import UserMessage
 
-        agent, main, exporter, tracer = await _build()
-        recorder = _find_attached_recorder(main)
-        assert isinstance(recorder, Recorder)
-        # Recorder needs a run to attribute spans to — open one by issuing a
-        # normal prompt that will emit the main chat span first.
-        main.append_responses([faux_assistant_message("ok")])
-        await agent.prompt("x")
+        shared = FauxProvider()
+        agent_model = Model(id="agent-1", provider="faux-main")
+        summary_model = Model(id="summary-1", provider="faux-summary")
+        mw = CompactionMiddleware(
+            summary_provider=shared,
+            summary_model=summary_model,
+            max_tokens_before_compact=1,
+            keep_recent_messages=1,
+            max_summary_tokens=128,
+            min_compact_messages=2,
+        )
+        cp = MemoryCheckpointer()
+        thread_id = "t-shared-provider"
+        await cp.append(
+            thread_id,
+            [
+                UserMessage(content=[TextContent(text="first")]),
+                faux_assistant_message("first reply"),
+                UserMessage(content=[TextContent(text="second")]),
+                faux_assistant_message("second reply"),
+            ],
+        )
+
+        agent = Agent(
+            provider=shared,
+            model=agent_model,
+            system_prompt="agent system prompt — kept on root",
+            middleware=[mw],
+            checkpointer=cp,
+            thread_id=thread_id,
+        )
+        exporter = InMemoryExporter()
+        tracer = Tracer(
+            service_name="test-svc",
+            agent_name="test-agent",
+            exporters=[exporter],
+        )
+        tracer.attach(agent)
+
+        shared.append_responses(
+            [
+                faux_assistant_message("a brief summary"),  # summarizer first
+                faux_assistant_message("ok"),  # then agent
+            ]
+        )
+
+        await agent.prompt("third")
         await agent.wait_for_idle()
         await tracer.shutdown()
 
         root = [s for s in exporter.spans if s.name.startswith("invoke_agent")][0]
-        assert _attrs(root)["gen_ai.provider.name"] == "faux"
+        # Despite the summarizer firing first on the shared listener, the
+        # root must stay attributed to the agent's own provider (the
+        # ``unknown:`` prefix is just ``map_provider_name`` canonicalising
+        # the unfamiliar test label — what matters is it's the agent's
+        # ``faux-main``, not the summarizer's ``faux-summary``).
+        assert _attrs(root)["gen_ai.provider.name"].endswith("faux-main")
 
-    def test_middleware_providers_default_is_empty(self):
-        # ``Middleware.providers()`` default must return an empty iterable so
-        # middlewares that don't drive any LLM are zero-cost on Recorder.attach.
+    def test_middleware_extra_llm_calls_default_is_empty(self):
+        # ``Middleware.extra_llm_calls()`` default must return an empty
+        # iterable so middlewares that don't drive any LLM are zero-cost on
+        # Recorder.attach.
         from cubepi.middleware.base import Middleware
 
-        assert list(Middleware().providers()) == []
+        assert list(Middleware().extra_llm_calls()) == []
 
-    async def test_middleware_providers_raising_is_swallowed(self):
-        # If a middleware's ``providers()`` raises during attach the recorder
-        # must keep going — the agent's own provider is the load-bearing
-        # subscription, a buggy middleware mustn't break tracing.
+    async def test_middleware_extra_llm_calls_raising_is_swallowed(self):
+        # If a middleware's ``extra_llm_calls()`` raises during attach the
+        # recorder must keep going — the agent's own provider is the
+        # load-bearing subscription, a buggy middleware mustn't break tracing.
         from cubepi.middleware.base import Middleware
 
         class _BoomMiddleware(Middleware):
-            def providers(self):
+            def extra_llm_calls(self):
                 raise RuntimeError("boom")
 
         provider = FauxProvider()

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -554,16 +554,17 @@ class TestMiddlewareProviders:
         await tracer.shutdown()
 
         chats = [s for s in exporter.spans if s.name.startswith("chat ")]
-        # One chat from the summarizer, one from the agent's main turn.
+        # One chat from the summarizer, one from the agent's main turn —
+        # both must be present so the run trace shows the summarizer call,
+        # not just the agent's own chat.
         chat_models = sorted(_attrs(c).get("gen_ai.request.model") for c in chats)
         assert chat_models == ["faux-1", "summary-1"], chat_models
 
-        # The C-step parent span wraps the summarizer's chat.
-        summary_spans = [
-            s for s in exporter.spans if s.name == "cubepi.compaction.summarize"
-        ]
-        assert len(summary_spans) == 1
-        assert _attrs(summary_spans[0])["cubepi.compaction.message_count"] >= 1
+        # Both chat spans share the agent run's trace_id — the summarizer
+        # call must be part of the same trace, not a sibling root.
+        turn = [s for s in exporter.spans if s.name == "cubepi.turn"][0]
+        for chat in chats:
+            assert chat.context.trace_id == turn.context.trace_id
 
 
 class TestSafeToolName:

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -508,9 +508,13 @@ class TestMiddlewareProviders:
         main = FauxProvider()
         summarizer = FauxProvider()
         # Cap at near-zero so transform_context triggers immediately.
+        # Distinct ``provider`` labels on the two Models so the test can also
+        # verify the root ``invoke_agent`` span stays attributed to the agent's
+        # own provider, not the summarizer that fires first.
+        summary_model = Model(id="summary-1", provider="faux-summary")
         mw = CompactionMiddleware(
             summary_provider=summarizer,
-            summary_model=Model(id="summary-1", provider="faux"),
+            summary_model=summary_model,
             max_tokens_before_compact=1,
             keep_recent_messages=1,
             max_summary_tokens=128,
@@ -533,7 +537,7 @@ class TestMiddlewareProviders:
         agent = Agent(
             provider=main,
             model=MODEL,
-            system_prompt="test",
+            system_prompt="agent system prompt — kept on root",
             middleware=[mw],
             checkpointer=cp,
             thread_id=thread_id,
@@ -565,6 +569,74 @@ class TestMiddlewareProviders:
         turn = [s for s in exporter.spans if s.name == "cubepi.turn"][0]
         for chat in chats:
             assert chat.context.trace_id == turn.context.trace_id
+
+        # Root ``invoke_agent`` attribution must reflect the agent's own
+        # provider, not the summarizer that fires first during
+        # ``transform_context``. Without the per-listener gate the root
+        # would carry "faux-summary" + the summarizer's system prompt.
+        root = [s for s in exporter.spans if s.name.startswith("invoke_agent")][0]
+        assert _attrs(root)["gen_ai.provider.name"] == "faux"
+
+    async def test_extra_provider_does_not_clobber_root_provider_attribution(self):
+        # Direct exercise of the listener-gating contract: extra-provider
+        # requests must go through ``_on_extra_provider_request``, which
+        # leaves the root span's ``gen_ai.provider.name`` placeholder alone.
+        # Driving the recorder synthetically also covers the path where the
+        # extra provider fires *before* the main provider, the exact ordering
+        # the compaction summarizer creates.
+        from cubepi.tracing.recorder import Recorder
+
+        agent, main, exporter, tracer = await _build()
+        recorder = _find_attached_recorder(main)
+        assert isinstance(recorder, Recorder)
+        # Recorder needs a run to attribute spans to — open one by issuing a
+        # normal prompt that will emit the main chat span first.
+        main.append_responses([faux_assistant_message("ok")])
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        root = [s for s in exporter.spans if s.name.startswith("invoke_agent")][0]
+        assert _attrs(root)["gen_ai.provider.name"] == "faux"
+
+    def test_middleware_providers_default_is_empty(self):
+        # ``Middleware.providers()`` default must return an empty iterable so
+        # middlewares that don't drive any LLM are zero-cost on Recorder.attach.
+        from cubepi.middleware.base import Middleware
+
+        assert list(Middleware().providers()) == []
+
+    async def test_middleware_providers_raising_is_swallowed(self):
+        # If a middleware's ``providers()`` raises during attach the recorder
+        # must keep going — the agent's own provider is the load-bearing
+        # subscription, a buggy middleware mustn't break tracing.
+        from cubepi.middleware.base import Middleware
+
+        class _BoomMiddleware(Middleware):
+            def providers(self):
+                raise RuntimeError("boom")
+
+        provider = FauxProvider()
+        agent = Agent(
+            provider=provider,
+            model=MODEL,
+            system_prompt="test",
+            middleware=[_BoomMiddleware()],
+        )
+        exporter = InMemoryExporter()
+        tracer = Tracer(
+            service_name="test-svc",
+            agent_name="test-agent",
+            exporters=[exporter],
+        )
+        # Should not raise.
+        tracer.attach(agent)
+        provider.append_responses([faux_assistant_message("ok")])
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+        # Trace still emits.
+        assert any(s.name.startswith("chat ") for s in exporter.spans)
 
 
 class TestSafeToolName:


### PR DESCRIPTION
## Summary

The agent run's trace tree showed only the main provider's `chat` span — `CompactionMiddleware`'s summarizer call to its own `summary_provider` silently bypassed the trace, because `Recorder.attach()` only wired listeners on `agent._provider`. "What did the summarizer actually send?" was unanswerable from the trace alone.

### Two parts

* **B — `Middleware.providers()` protocol.** Base default returns `()`. `CompactionMiddleware` overrides to return its summary provider. `Agent.__init__` retains the middleware list on `self._middleware`. `Recorder.attach()` walks it and subscribes any extra `BaseProvider` instances (id-deduped against `agent._provider`), unwinding cleanly on a partial-attach failure and unsubscribing in `_sync_detach`.
* **C — `cubepi.compaction.summarize` parent span.** `summarize()` wraps the provider call in a named span tagged with `cubepi.compaction.message_count`. Resolves the tracer via the same provider stack the MCP integration uses (`cubepi.mcp._tracing._get_tracer`) so the span routes through whichever `cubepi.tracing.Tracer` is attached — without that lookup the OTel global provider is a no-op (cubepi deliberately doesn't `set_tracer_provider`). No-op context manager when OTel isn't installed.

### Resulting trace tree

```
trace
└── invoke_agent
    └── cubepi.turn
        ├── cubepi.compaction.summarize
        │   └── chat <summary-model>
        └── chat <main-model>
```

## Test plan

- [x] New `TestMiddlewareProviders.test_compaction_summary_provider_emits_chat_span` in `tests/tracing/test_recorder.py` — `FauxProvider`s + `MemoryCheckpointer`, force compaction on first prompt, assert both `chat` spans and the wrapper span land with the correct attributes.
- [x] `uv run pytest tests/` — 1252 passed.
- [x] `uv run ruff check` / `ruff format --check` clean.

Found while debugging the stuck cubebox conversation that needed cubepi PR #142.