### PR TITLE
SEO optimization for cubepi.ai

### DIFF
--- a/dev/seo-audit-2026-06-05.md
+++ b/dev/seo-audit-2026-06-05.md
@@ -1,0 +1,126 @@
+# cubepi.ai SEO 审计报告
+
+> 日期:2026-06-05 · 站点:Docusaurus 3.10.1(en + zh-Hans 双语)
+> 方法:阅读 `website/` 源码 + 本地 `pnpm build` 后检查真实产物(HTML `<head>`、sitemap、robots.txt)
+> 结论文中所有判断均以 build 产物为准,非仅凭配置推断。
+
+---
+
+## 0. 总评
+
+**基础 SEO 8/10,已超过多数同类开源项目文档站。** 头部元数据、双语 hreflang、
+canonical、版本去重、sitemap、结构化数据、分析埋点都已就位。剩余增量集中在
+**首页 H1、样板页清理、sitemap lastmod、结构化数据丰富度,以及对比落地页内容**。
+
+---
+
+## 1. 已验证「做对了」的部分(无需改动)
+
+| 项 | 验证结果 |
+|----|----------|
+| `url` / `baseUrl` / `organizationName` / `projectName` | 正确 |
+| `onBrokenLinks` / `onBrokenAnchors` / `onBrokenMarkdownLinks` | 均为 `throw`,防死链 |
+| canonical | 每页 `<link rel="canonical">` 正确生成 |
+| hreflang | 每页含 `en` / `zh-Hans` / `x-default` 三条 alternate(中英互指) |
+| Open Graph | `og:title/description/url/image/locale/locale:alternate` 齐全 |
+| Twitter Card | `twitter:card=summary_large_image` + image + site/creator |
+| description | **全部 42 篇文档**都有 frontmatter `description`;首页中英分别定制 |
+| keywords | 中英混合关键词(`langgraph alternative`、`langgraph 替代品`、`异步 Agent` 等) |
+| 版本去重 | 旧版本 0.3–0.6 与 `next` 均 `noIndex` + `sitemap.ignorePatterns`,只索引 0.7(根路径),避免重复内容 |
+| sitemap(英文) | `https://cubepi.ai/sitemap.xml` — 53 条 URL |
+| **sitemap(中文)** | `https://cubepi.ai/zh-Hans/sitemap.xml` — **存在,53 条 zh-Hans URL** |
+| robots.txt | 两份 sitemap 都已声明,`Allow: /` |
+| 双语翻译 | zh-Hans 完整翻译(154 个翻译文件,含各历史版本) |
+| 分析 | Google gtag(`G-NE2PDN0M91`,anonymizeIP)+ PostHog |
+| 性能基建 | 已启用 `@docusaurus/faster`;Hero 图带 `width/height`(无 CLS) |
+
+> 说明:此前怀疑 `robots.txt` 引用的 `/zh-Hans/sitemap.xml` 是死链 —— **build 证明它真实存在**,
+> Docusaurus 为每个 locale 各生成一份独立 sitemap。该项无需修改。
+
+---
+
+## 2. 待优化项(按优先级)
+
+### P0 — 应尽快修(低风险 / 高确定性)
+
+**2.1 首页 H1 关键词过弱**
+- 位置:`website/src/components/Home/Hero.tsx:29`
+- 现状:`<h1>CubePi</h1>` —— 只有品牌名一个词,价值主张全在 `<p>` 里。
+- 影响:H1 是最强的页面级关键词信号,目前完全没承载 "agent framework / langgraph alternative"。
+- 建议:H1 改为带描述的整句,视觉上可用 `<span>` 拆分让 "CubePi" 仍突出。例:
+  ```tsx
+  <h1>CubePi — a Pythonic, async-native agent framework</h1>
+  ```
+  中文页同理:`CubePi —— Pythonic 异步原生 Agent 框架`。
+
+**2.2 脚手架样板页 `/markdown-page` 被收录**
+- 位置:`website/src/pages/markdown-page.mdx`
+- 现状:内容是 Docusaurus 默认占位文("Markdown page example / You don't need React…"),
+  **已出现在 sitemap.xml 中**,会被索引,稀释站点质量信号。
+- 建议:直接删除该文件(同时它不在任何导航里,删除无副作用)。
+
+### P1 — 高价值
+
+**2.3 sitemap 缺 `lastmod`**
+- 现状:英文 sitemap 53 条 URL,`changefreq`/`priority` 有(默认 weekly/0.5),**`lastmod` 为 0 条**。
+- 建议:`website/docusaurus.config.ts` 的 sitemap 配置加 `lastmod: 'date'`,让搜索引擎感知更新时间:
+  ```ts
+  sitemap: {
+    lastmod: 'date',
+    changefreq: 'weekly',
+    priority: 0.5,
+    ignorePatterns: [ /* 不变 */ ],
+  },
+  ```
+
+**2.4 对比 / 替代品落地页(自然流量最大增量)**
+- 现状:仅 `docs/migration/from-langgraph.md` 一篇。
+- 机会:高购买意图查询 —— "langgraph alternative"、"pi-agent-core alternative"、
+  "langgraph vs …"、"异步 agent 框架"、"langgraph 替代品" —— 缺少**专门的可索引落地页**。
+  首页 `WhyTable` 内容很好,但独立页面排名效果远好于首页内的一个区块。
+- 建议:新建 `/compare/langgraph`、`/compare/pi-agent-core`(及对应 zh-Hans),
+  每页含对比表 + 迁移示例 + 内链回 quick-start。需要撰写中英双语内容,工作量最大。
+
+### P2 — 结构化数据
+
+**2.5 JSON-LD 过简且全站同一份**
+- 位置:`website/docusaurus.config.ts:79-94`(`headTags`)
+- 现状:`SoftwareApplication` schema 注入到**每一个页面**(包括文档页),且只有 6 个字段。
+- 建议:
+  - 拆分作用域:`SoftwareApplication` / `WebSite` / `Organization` 只放首页;文档页改用 `TechArticle`(或不注入)。
+  - 字段补充:`softwareVersion`、`offers: { "@type": "Offer", price: 0, priceCurrency: "USD" }`
+    (免费 → 有机会触发 rich result)、`author` / `publisher`(Organization)、`sameAs`(GitHub/X 链接)。
+  - 首页可加 `WebSite` + `SearchAction`(站内搜索框 sitelinks)。
+
+### P3 — 细节 / 锦上添花
+
+**2.6 `og:title` 重复品牌名**
+- 现状:首页 `og:title` = `CubePi — a Pythonic async-native agent framework | CubePi`(末尾多了 `| CubePi`)。
+- 原因:标题模板自动追加 `| CubePi`,而首页标题本身已含 CubePi。
+- 建议:首页可用更短/更干净的标题,或调整 `titleDelimiter`;影响很小,纯观感。
+
+**2.7 Hero 大图为 LCP 元素**
+- 位置:`website/src/components/Home/Hero.tsx:21`
+- 建议:给该 `<img>` 加 `fetchpriority="high"`;把 PNG 社交预览图额外导出 WebP/AVIF 版本用于页面展示
+  (分享卡片仍保留 PNG)。已有 `width/height`,CLS 无问题,仅优化 LCP。
+
+---
+
+## 3. 运营侧建议(非代码)
+
+- **Google Search Console / Bing Webmaster**:验证站点并提交 `sitemap.xml` 与 `zh-Hans/sitemap.xml`。
+- **百度站长平台(中文市场)**:单独提交 `https://cubepi.ai/zh-Hans/sitemap.xml`。
+  百度不解析 hreflang,但能抓取 Docusaurus 的静态 HTML,且仍读 meta keywords/description ——
+  现有中文关键词配置对百度有效,建议保留并持续扩充长尾中文词。
+- **外链 / 品牌信号**:GitHub README、PyPI 页、X(@cubeplexai)互链,补充 `Organization.sameAs`。
+
+---
+
+## 4. 一句话行动清单
+
+1. 改首页 H1(P0)
+2. 删 `markdown-page.mdx`(P0)
+3. sitemap 加 `lastmod: 'date'`(P1)
+4. 写 `/compare/*` 对比落地页(P1,内容工作量最大,自然流量增量最大)
+5. 丰富 + 拆分 JSON-LD(P2)
+6. 修 `og:title` 重复、Hero 图 `fetchpriority`(P3)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -43,6 +43,9 @@ const classicOptions: ClassicOptions = {
     customCss: './src/css/custom.css',
   },
   sitemap: {
+    lastmod: 'date',
+    changefreq: 'weekly',
+    priority: 0.5,
     ignorePatterns: [
       '/docs/next/**',
       '/docs/0.3/**',
@@ -76,19 +79,25 @@ const config: Config = {
     },
   },
 
+  // Site-wide structured data: an Organization is the only schema that is
+  // genuinely true on *every* page. The product-level SoftwareApplication
+  // schema is scoped to the homepage (see src/pages/index.tsx) so docs
+  // subpages aren't all mislabeled as the application itself.
   headTags: [
     {
       tagName: 'script',
       attributes: { type: 'application/ld+json' },
       innerHTML: JSON.stringify({
         '@context': 'https://schema.org',
-        '@type': 'SoftwareApplication',
+        '@type': 'Organization',
         name: 'CubePi',
-        description: 'A Pythonic, async-native alternative to langgraph and pi-agent-core. Plain async functions, append-only checkpointing, minimal dependencies.',
         url: 'https://cubepi.ai',
-        applicationCategory: 'DeveloperApplication',
-        operatingSystem: 'Linux, macOS, Windows',
-        programmingLanguage: 'Python',
+        logo: 'https://cubepi.ai/img/brand/cubepi-logo.png',
+        sameAs: [
+          'https://github.com/cubeplexai/cubepi',
+          'https://x.com/cubeplexai',
+          'https://pypi.org/project/cubepi/',
+        ],
       }),
     },
   ],
@@ -134,6 +143,15 @@ const config: Config = {
         { type: 'custom-versionAwareDocLink', section: 'docs', label: 'Docs', position: 'left' },
         { type: 'custom-versionAwareDocLink', section: 'api', label: 'API', position: 'left' },
         { type: 'custom-versionAwareDocLink', section: 'recipes', label: 'Recipes', position: 'left' },
+        {
+          type: 'dropdown',
+          label: 'Compare',
+          position: 'left',
+          items: [
+            { to: '/compare/langgraph', label: 'vs LangGraph' },
+            { to: '/compare/pi-agent-core', label: 'vs pi-agent-core' },
+          ],
+        },
         { to: '/changelog', label: 'Changelog', position: 'left' },
         { type: 'docsVersionDropdown', position: 'right' },
         { type: 'localeDropdown', position: 'right' },

--- a/website/src/components/Compare/ComparePage.module.css
+++ b/website/src/components/Compare/ComparePage.module.css
@@ -1,0 +1,26 @@
+.page { max-width: 880px; margin: 48px auto 80px; padding: 0 24px; }
+.h1 { font-family: 'Inter Tight', 'Inter', system-ui; font-size: 40px; line-height: 1.1; letter-spacing: -0.03em; font-weight: 600; color: var(--ink-12); margin: 0 0 20px; }
+.lead { font-size: 17px; line-height: 1.6; color: var(--ink-11); margin: 0 0 16px; max-width: 680px; }
+.h2 { font-family: 'Inter Tight'; font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; font-weight: 600; color: var(--ink-7); margin: 48px 0 16px; }
+
+.tableWrap { overflow-x: auto; border: 1px solid var(--ink-5); border-radius: 8px; background: var(--surface); }
+.table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.table th, .table td { padding: 12px 16px; border-bottom: 1px solid var(--ink-5); text-align: left; vertical-align: top; line-height: 1.55; }
+.table tr:last-child td { border-bottom: 0; }
+.table th { font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-7); background: var(--ink-3); }
+.label { font-weight: 500; color: var(--ink-12); width: 20%; }
+.us { color: var(--ink-12); }
+
+.codeSection { margin-top: 8px; }
+.codeGrid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.codeTitle { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; color: var(--ink-9); margin-bottom: 8px; letter-spacing: 0.04em; }
+@media (max-width: 800px) { .codeGrid { grid-template-columns: 1fr; } }
+
+.prose { }
+.body { font-size: 15px; line-height: 1.65; color: var(--ink-11); margin: 0 0 14px; max-width: 680px; }
+
+.ctaRow { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 48px; }
+.cta { display: inline-flex; align-items: center; height: 38px; padding: 0 16px; border: 1px solid var(--ink-12); border-radius: 5px; background: var(--ink-12); color: var(--surface); font-size: 14px; font-weight: 500; text-decoration: none; }
+.cta:hover { background: var(--ink-11); color: var(--surface); text-decoration: none; }
+.cta + .cta { background: transparent; color: var(--ink-12); border-color: var(--ink-5); }
+.cta + .cta:hover { background: var(--ink-3); color: var(--ink-12); }

--- a/website/src/components/Compare/ComparePage.tsx
+++ b/website/src/components/Compare/ComparePage.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import CodeBlock from '@theme/CodeBlock';
+import styles from './ComparePage.module.css';
+
+export interface CompareRow {
+  label: string;
+  them: string;
+  us: string;
+}
+
+export interface CompareSection {
+  h2: string;
+  /** Prose paragraphs; each string becomes a <p>. */
+  body: string[];
+}
+
+export interface CompareCode {
+  h2: string;
+  themTitle: string;
+  them: string;
+  usTitle: string;
+  us: string;
+}
+
+export interface CompareContent {
+  /** The competitor's display name, e.g. "LangGraph". */
+  them: string;
+  /** <title> — must NOT lead with "CubePi" (the brand is appended). */
+  title: string;
+  description: string;
+  keywords: string;
+  h1: string;
+  intro: string[];
+  rows: CompareRow[];
+  /** Optional side-by-side code sample. */
+  code?: CompareCode;
+  sections: CompareSection[];
+  cta: { text: string; href: string }[];
+  tableHeading: string;
+}
+
+export default function ComparePage({ content }: { content: CompareContent }): React.ReactElement {
+  return (
+    <Layout title={content.title} description={content.description}>
+      <Head>
+        <meta name="keywords" content={content.keywords} />
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'TechArticle',
+            headline: content.h1,
+            description: content.description,
+            author: { '@type': 'Organization', name: 'CubePi', url: 'https://cubepi.ai' },
+            publisher: { '@type': 'Organization', name: 'CubePi', url: 'https://cubepi.ai' },
+          })}
+        </script>
+      </Head>
+      <main className={styles.page}>
+        <h1 className={styles.h1}>{content.h1}</h1>
+        {content.intro.map((p, i) => (
+          <p key={i} className={styles.lead}>{p}</p>
+        ))}
+
+        <h2 className={styles.h2}>{content.tableHeading}</h2>
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th></th>
+                <th>{content.them}</th>
+                <th>CubePi</th>
+              </tr>
+            </thead>
+            <tbody>
+              {content.rows.map((r) => (
+                <tr key={r.label}>
+                  <td className={styles.label}>{r.label}</td>
+                  <td>{r.them}</td>
+                  <td className={styles.us}>{r.us}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {content.code && (
+          <section className={styles.codeSection}>
+            <h2 className={styles.h2}>{content.code.h2}</h2>
+            <div className={styles.codeGrid}>
+              <div>
+                <div className={styles.codeTitle}>{content.code.themTitle}</div>
+                <CodeBlock language="python">{content.code.them}</CodeBlock>
+              </div>
+              <div>
+                <div className={styles.codeTitle}>{content.code.usTitle}</div>
+                <CodeBlock language="python">{content.code.us}</CodeBlock>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {content.sections.map((s) => (
+          <section key={s.h2} className={styles.prose}>
+            <h2 className={styles.h2}>{s.h2}</h2>
+            {s.body.map((p, i) => (
+              <p key={i} className={styles.body}>{p}</p>
+            ))}
+          </section>
+        ))}
+
+        <div className={styles.ctaRow}>
+          {content.cta.map((c) => (
+            <Link key={c.href} className={styles.cta} to={c.href}>{c.text}</Link>
+          ))}
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/website/src/components/Home/Hero.module.css
+++ b/website/src/components/Home/Hero.module.css
@@ -1,8 +1,8 @@
 .hero { max-width: 880px; margin: 48px auto 64px; padding: 0 24px; text-align: left; }
 .banner { display: block; width: 100%; height: auto; border: 1px solid var(--ink-5); border-radius: 6px; margin-bottom: 40px; }
 .eyebrow { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 12px; color: var(--ink-7); letter-spacing: 0.06em; margin-bottom: 12px; }
-.h1 { font-family: 'Inter Tight', 'Inter', system-ui; font-size: 52px; line-height: 1.05; letter-spacing: -0.03em; font-weight: 600; color: var(--ink-12); margin: 0 0 12px; }
-.tagline { font-family: 'Inter Tight', 'Inter', system-ui; font-size: 22px; line-height: 1.35; letter-spacing: -0.01em; font-style: italic; font-weight: 400; color: var(--ink-11); margin: 0 0 20px; }
+.h1 { font-family: 'Inter Tight', 'Inter', system-ui; font-size: 52px; line-height: 1.05; letter-spacing: -0.03em; font-weight: 600; color: var(--ink-12); margin: 0 0 20px; }
+.h1sub { display: block; margin-top: 12px; font-family: 'Inter Tight', 'Inter', system-ui; font-size: 22px; line-height: 1.35; letter-spacing: -0.01em; font-style: italic; font-weight: 400; color: var(--ink-11); }
 .lead { font-size: 16px; line-height: 1.55; color: var(--ink-9); margin: 0 0 28px; max-width: 640px; }
 .lead code { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 14px; padding: 1px 5px; background: var(--ink-3); border-radius: 3px; color: var(--ink-11); }
 .actions { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
@@ -14,4 +14,4 @@
 .ctaGhost { background: transparent; }
 .kbd { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 10.5px; height: 18px; min-width: 18px; padding: 0 5px; display: inline-flex; align-items: center; border: 1px solid var(--ink-5); border-bottom-width: 2px; border-radius: 4px; background: var(--surface); color: var(--ink-9); opacity: 0.85; }
 .ctaPrimary .kbd { background: rgba(255,255,255,0.12); color: rgba(255,255,255,0.85); border-color: transparent; }
-@media (max-width: 640px) { .h1 { font-size: 36px; } .tagline { font-size: 18px; } .hero { margin-top: 24px; } }
+@media (max-width: 640px) { .h1 { font-size: 36px; } .h1sub { font-size: 18px; } .hero { margin-top: 24px; } }

--- a/website/src/components/Home/Hero.tsx
+++ b/website/src/components/Home/Hero.tsx
@@ -26,10 +26,16 @@ export default function Hero() {
         height={640}
       />
       <div className={styles.eyebrow}>cubepi · v{version}</div>
-      <h1 className={styles.h1}>CubePi</h1>
-      <p className={styles.tagline}>
-        {zh ? '一个 Pythonic 原生异步 Agent 框架。' : 'A Pythonic, async-native agent framework.'}
-      </p>
+      {/* Tagline lives inside the <h1> (as a styled subline) so the page's
+          single H1 carries the descriptive keyword phrase, not just the brand
+          name — while rendering identically to the previous brand + tagline
+          stack. */}
+      <h1 className={styles.h1}>
+        CubePi
+        <span className={styles.h1sub}>
+          {zh ? '一个 Pythonic 原生异步 Agent 框架。' : 'A Pythonic, async-native agent framework.'}
+        </span>
+      </h1>
       <p className={styles.lead}>
         {zh ? (
           <>

--- a/website/src/components/Home/Hero.tsx
+++ b/website/src/components/Home/Hero.tsx
@@ -24,6 +24,7 @@ export default function Hero() {
         alt="CubePi · A Pythonic, async-native agent framework"
         width={1280}
         height={640}
+        fetchPriority="high"
       />
       <div className={styles.eyebrow}>cubepi · v{version}</div>
       {/* Tagline lives inside the <h1> (as a styled subline) so the page's

--- a/website/src/components/Home/WhyTable.module.css
+++ b/website/src/components/Home/WhyTable.module.css
@@ -7,3 +7,4 @@
 .table th { font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-7); background: var(--ink-3); }
 .label { font-weight: 500; color: var(--ink-12); width: 22%; }
 .us { color: var(--ink-12); font-family: 'JetBrains Mono'; font-size: 12.5px; }
+.more { margin-top: 16px; font-size: 13px; color: var(--ink-9); }

--- a/website/src/components/Home/WhyTable.tsx
+++ b/website/src/components/Home/WhyTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Link from '@docusaurus/Link';
 import { useIsZhHans } from '@site/src/hooks/useIsZhHans';
 import styles from './WhyTable.module.css';
 
@@ -52,6 +53,15 @@ export default function WhyTable() {
           </tbody>
         </table>
       </div>
+      <p className={styles.more}>
+        <Link to="/compare/langgraph">
+          {zh ? '完整对比:CubePi vs LangGraph →' : 'Full comparison: CubePi vs LangGraph →'}
+        </Link>
+        {'  ·  '}
+        <Link to="/compare/pi-agent-core">
+          {zh ? 'CubePi vs pi-agent-core →' : 'CubePi vs pi-agent-core →'}
+        </Link>
+      </p>
     </section>
   );
 }

--- a/website/src/pages/compare/langgraph.tsx
+++ b/website/src/pages/compare/langgraph.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import ComparePage, { type CompareContent } from '@site/src/components/Compare/ComparePage';
+import { useIsZhHans } from '@site/src/hooks/useIsZhHans';
+
+const EN: CompareContent = {
+  them: 'LangGraph',
+  title: 'CubePi vs LangGraph — a leaner Python agent framework',
+  description:
+    'CubePi vs LangGraph: a side-by-side comparison of two Python agent frameworks. CubePi models the agent as a plain async while-loop with append-only checkpointing and 3 core dependencies, instead of a state graph of nodes, edges, and channels.',
+  keywords:
+    'CubePi vs LangGraph, LangGraph alternative, Python agent framework, async agent framework, LangGraph vs CubePi, state graph alternative, langgraph 替代品',
+  h1: 'CubePi vs LangGraph',
+  intro: [
+    'CubePi and LangGraph both build tool-using LLM agents in Python, but they start from opposite mental models. LangGraph asks you to express your agent as a state graph — nodes, edges, and typed channels you wire together. CubePi models the same agent as a plain async while-loop you can read top to bottom.',
+    'If you find yourself drawing graphs to express what is fundamentally a linear "call the model → run tools → repeat" loop, CubePi is the leaner alternative. Here is how the two compare.',
+  ],
+  tableHeading: 'Side-by-side',
+  rows: [
+    { label: 'Abstraction', them: 'State graph: nodes + edges + channels you wire manually', us: 'A plain async while-loop — run_agent_loop reads top to bottom' },
+    { label: 'Control flow', them: 'add_edge / add_conditional_edges reify the loop as a graph', us: 'The tool-call → re-prompt loop IS the runtime; you do not reify it' },
+    { label: 'Streaming', them: 'Callback-based with multiple stream_mode flags', us: 'async for event in stream — one pattern, eleven event types' },
+    { label: 'Checkpointing', them: 'Full snapshot per step; serializes the entire message list', us: 'Append-only — O(1) DB I/O regardless of conversation length' },
+    { label: 'Dependencies', them: 'langchain-core, langgraph-sdk, and transitive deps', us: '3 core deps: pydantic, anthropic, openai' },
+    { label: 'Tools', them: 'Tools are graph nodes (ToolNode) with manual wiring', us: 'Declare tools as functions; the framework routes and parallelizes' },
+    { label: 'Async', them: 'Split invoke / ainvoke surface', us: 'Async-first — every entry point is async' },
+    { label: 'Observability', them: 'LangSmith / Langfuse integration', us: 'Native OpenTelemetry — GenAI semconv, OTLP / JSONL out of the box' },
+  ],
+  code: {
+    h2: 'A tool-using agent',
+    themTitle: '# LangGraph',
+    them: `from langchain_anthropic import ChatAnthropic
+from langgraph.graph import StateGraph, END
+from langgraph.prebuilt import ToolNode
+from langchain_core.tools import tool
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get current weather for a city."""
+    return f"72F and sunny in {city}"
+
+
+llm = ChatAnthropic(model="claude-sonnet-4-5").bind_tools([get_weather])
+
+class State(TypedDict):
+    messages: list
+
+def call_model(state):
+    return {"messages": [llm.invoke(state["messages"])]}
+
+def should_continue(state):
+    return "tools" if state["messages"][-1].tool_calls else END
+
+graph = StateGraph(State)
+graph.add_node("llm", call_model)
+graph.add_node("tools", ToolNode([get_weather]))
+graph.add_edge("__start__", "llm")
+graph.add_conditional_edges("llm", should_continue)
+graph.add_edge("tools", "llm")
+app = graph.compile()
+`,
+    usTitle: '# CubePi',
+    us: `from pydantic import BaseModel
+from cubepi import Agent, AgentTool, AgentToolResult, TextContent
+from cubepi.providers.anthropic import AnthropicProvider
+
+
+class GetWeatherParams(BaseModel):
+    city: str
+
+
+async def get_weather(tool_call_id, params: GetWeatherParams, *, signal=None, on_update=None):
+    return AgentToolResult(content=[TextContent(text=f"72F and sunny in {params.city}")])
+
+
+agent = Agent(
+    model=AnthropicProvider(provider_id="anthropic", api_key="...").model("claude-sonnet-4-5"),
+    tools=[AgentTool(
+        name="get_weather",
+        description="Get current weather for a city.",
+        parameters=GetWeatherParams,
+        execute=get_weather,
+    )],
+)
+await agent.prompt("Weather in Tokyo?")
+`,
+  },
+  sections: [
+    {
+      h2: 'Why the loop instead of a graph',
+      body: [
+        'A LangGraph agent never branches at runtime the way a general graph suggests — the "graph" is almost always the same shape: call the model, and if it asked for tools, run them and call the model again. CubePi makes that shape the runtime. There is no StateGraph, no END sentinel, no should_continue function, no ToolNode registry, and no State TypedDict to keep in sync.',
+        'Flow control that does need to vary — stop early, summarize, gate a tool behind human approval — lives in typed middleware hooks instead of conditional edges, so it is imperative and testable in isolation.',
+      ],
+    },
+    {
+      h2: 'Persistence that does not grow with the conversation',
+      body: [
+        'LangGraph checkpointers snapshot the full state at every step, so write cost grows linearly with conversation length. CubePi checkpointing is append-only: each turn writes O(1) regardless of how long the thread is, and messages stay JSONB-queryable. The same MemorySaver / SqliteSaver / PostgresSaver idea maps onto MemoryCheckpointer / SQLiteCheckpointer / PostgresCheckpointer.',
+      ],
+    },
+    {
+      h2: 'When LangGraph is the better fit',
+      body: [
+        'LangGraph is the better choice if you genuinely need arbitrary multi-agent supervisor graphs, visual graph rendering, or time-travel/fork at arbitrary checkpoints today — CubePi keeps its flow linear by design and emits vendor-neutral OpenTelemetry rather than shipping its own trace UI. If your agent is fundamentally a loop, CubePi removes the graph machinery you were not really using.',
+      ],
+    },
+  ],
+  cta: [
+    { text: 'Migration guide: from LangGraph →', href: '/docs/migration/from-langgraph' },
+    { text: 'Quick Start →', href: '/docs/getting-started/quick-start' },
+  ],
+};
+
+const ZH: CompareContent = {
+  them: 'LangGraph',
+  title: 'CubePi vs LangGraph — 更精简的 Python Agent 框架',
+  description:
+    'CubePi 与 LangGraph 对比:两个 Python Agent 框架的并排比较。CubePi 用普通的 async while 循环建模 agent,配合追加式 checkpointing 和 3 个核心依赖,而非由节点、边、通道组成的状态图。',
+  keywords:
+    'CubePi vs LangGraph, LangGraph 替代品, Python Agent 框架, 异步 Agent 框架, 状态图替代方案, langgraph alternative',
+  h1: 'CubePi vs LangGraph',
+  intro: [
+    'CubePi 和 LangGraph 都用 Python 构建会调用工具的 LLM agent,但出发点完全相反。LangGraph 要求你把 agent 表达成一张状态图 —— 手动连接节点、边和类型化通道。CubePi 则把同样的 agent 建模为一个可以从上读到下的普通 async while 循环。',
+    '如果你发现自己在用画图的方式去表达本质上线性的「调用模型 → 执行工具 → 重复」循环,CubePi 就是更精简的替代方案。下面是两者的对比。',
+  ],
+  tableHeading: '并排对比',
+  rows: [
+    { label: '抽象模型', them: '状态图:手动连接节点 + 边 + 通道', us: '普通 async while 循环 —— run_agent_loop 从上读到下' },
+    { label: '控制流', them: 'add_edge / add_conditional_edges 把循环具象成图', us: '工具调用 → 再次提示 的循环本身就是运行时,无需具象化' },
+    { label: '流式输出', them: '基于回调,多个 stream_mode 标志', us: 'async for event in stream —— 统一模式,11 种事件类型' },
+    { label: '检查点', them: '每步全量快照,序列化整个消息列表', us: '追加式 —— 无论对话多长,每轮 O(1) DB I/O' },
+    { label: '依赖项', them: 'langchain-core、langgraph-sdk 及传递依赖', us: '3 个核心依赖:pydantic、anthropic、openai' },
+    { label: '工具', them: '工具是需要手动连线的图节点(ToolNode)', us: '声明为函数;框架自动路由并并行执行' },
+    { label: '异步', them: 'invoke / ainvoke 两套接口', us: '异步优先 —— 每个入口都是 async' },
+    { label: '可观测性', them: 'LangSmith / Langfuse 集成', us: '原生 OpenTelemetry —— GenAI semconv,开箱即用 OTLP / JSONL' },
+  ],
+  code: {
+    h2: '一个会调用工具的 agent',
+    themTitle: '# LangGraph',
+    them: `from langchain_anthropic import ChatAnthropic
+from langgraph.graph import StateGraph, END
+from langgraph.prebuilt import ToolNode
+from langchain_core.tools import tool
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get current weather for a city."""
+    return f"72F and sunny in {city}"
+
+
+llm = ChatAnthropic(model="claude-sonnet-4-5").bind_tools([get_weather])
+
+class State(TypedDict):
+    messages: list
+
+def call_model(state):
+    return {"messages": [llm.invoke(state["messages"])]}
+
+def should_continue(state):
+    return "tools" if state["messages"][-1].tool_calls else END
+
+graph = StateGraph(State)
+graph.add_node("llm", call_model)
+graph.add_node("tools", ToolNode([get_weather]))
+graph.add_edge("__start__", "llm")
+graph.add_conditional_edges("llm", should_continue)
+graph.add_edge("tools", "llm")
+app = graph.compile()
+`,
+    usTitle: '# CubePi',
+    us: `from pydantic import BaseModel
+from cubepi import Agent, AgentTool, AgentToolResult, TextContent
+from cubepi.providers.anthropic import AnthropicProvider
+
+
+class GetWeatherParams(BaseModel):
+    city: str
+
+
+async def get_weather(tool_call_id, params: GetWeatherParams, *, signal=None, on_update=None):
+    return AgentToolResult(content=[TextContent(text=f"72F and sunny in {params.city}")])
+
+
+agent = Agent(
+    model=AnthropicProvider(provider_id="anthropic", api_key="...").model("claude-sonnet-4-5"),
+    tools=[AgentTool(
+        name="get_weather",
+        description="Get current weather for a city.",
+        parameters=GetWeatherParams,
+        execute=get_weather,
+    )],
+)
+await agent.prompt("Weather in Tokyo?")
+`,
+  },
+  sections: [
+    {
+      h2: '为什么用循环而不是图',
+      body: [
+        'LangGraph 的 agent 在运行时其实从不像通用图那样随意分支 —— 那张「图」几乎永远是同一个形状:调用模型,如果它请求了工具就执行,然后再次调用模型。CubePi 直接把这个形状变成运行时。没有 StateGraph、没有 END 哨兵、没有 should_continue 函数、没有 ToolNode 注册表,也没有需要同步维护的 State TypedDict。',
+        '确实需要变化的流程控制 —— 提前停止、生成总结、把某个工具放到人工审批之后 —— 都放在类型化的 middleware hook 里,而非条件边,因此是命令式的,也能单独测试。',
+      ],
+    },
+    {
+      h2: '不随对话增长的持久化',
+      body: [
+        'LangGraph 的 checkpointer 在每一步都对完整状态做快照,写入成本随对话长度线性增长。CubePi 的 checkpointing 是追加式的:无论线程多长,每轮写入都是 O(1),且消息保持 JSONB 可查询。MemorySaver / SqliteSaver / PostgresSaver 的思路对应到 MemoryCheckpointer / SQLiteCheckpointer / PostgresCheckpointer。',
+      ],
+    },
+    {
+      h2: '什么时候 LangGraph 更合适',
+      body: [
+        '如果你现在确实需要任意的多 agent supervisor 图、可视化图渲染,或在任意检查点做时间旅行/分叉,那么 LangGraph 更合适 —— CubePi 在设计上保持流程线性,并输出厂商中立的 OpenTelemetry,而不是自带一套 trace UI。但如果你的 agent 本质上就是一个循环,CubePi 帮你去掉了那些你其实没真正用上的图机制。',
+      ],
+    },
+  ],
+  cta: [
+    { text: '迁移指南:从 LangGraph 迁移 →', href: '/docs/migration/from-langgraph' },
+    { text: '快速开始 →', href: '/docs/getting-started/quick-start' },
+  ],
+};
+
+export default function CompareLangGraph(): React.ReactElement {
+  const zh = useIsZhHans();
+  return <ComparePage content={zh ? ZH : EN} />;
+}

--- a/website/src/pages/compare/pi-agent-core.tsx
+++ b/website/src/pages/compare/pi-agent-core.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import ComparePage, { type CompareContent } from '@site/src/components/Compare/ComparePage';
+import { useIsZhHans } from '@site/src/hooks/useIsZhHans';
+
+const EN: CompareContent = {
+  them: 'pi-agent-core',
+  title: 'CubePi vs pi-agent-core — the Python-native sibling',
+  description:
+    'CubePi vs pi-agent-core: pi-agent-core is a TypeScript agent framework; CubePi is an independent Python reimplementation of the same linear agent-loop architecture, with Pydantic v2 models, asyncio-native primitives, and built-in append-only checkpointing.',
+  keywords:
+    'CubePi vs pi-agent-core, pi-agent-core alternative, pi-agent-core Python, Python agent framework, async agent framework, TypeScript to Python agent',
+  h1: 'CubePi vs pi-agent-core',
+  intro: [
+    'pi-agent-core is a TypeScript agent framework. CubePi is an independent Python reimplementation of the same architecture — the linear agent loop (agent.ts + agent-loop.ts maps onto CubePi’s agent.py + loop.py) — rebuilt around Pydantic v2, asyncio-native primitives, and built-in checkpointing.',
+    'So this is less a "which is better" question and more a "which ecosystem are you in" one. If your stack is TypeScript/Node, pi-agent-core fits natively. If your stack is Python, CubePi gives you the same mental model without dragging a JS runtime into your services.',
+  ],
+  tableHeading: 'Moving from TypeScript to Python',
+  rows: [
+    { label: 'Language / runtime', them: 'TypeScript on Node.js', us: 'Python 3.11+' },
+    { label: 'Concurrency', them: 'Promises / async-await', us: 'asyncio — async-first, every entry point is async' },
+    { label: 'Schemas & validation', them: 'TypeScript types (compile-time)', us: 'Pydantic v2 models — runtime-validated tool params' },
+    { label: 'Agent model', them: 'Linear agent loop (agent.ts + agent-loop.ts)', us: 'Same linear loop (agent.py + loop.py)' },
+    { label: 'Providers', them: 'Provider abstraction', us: 'Provider protocol — Anthropic & OpenAI built in' },
+  ],
+  sections: [
+    {
+      h2: 'Same architecture, Pythonic surface',
+      body: [
+        'CubePi deliberately keeps pi-agent-core’s core idea: an agent is a loop, not a graph. What changes is the surface. Tools are plain async functions whose parameters are Pydantic models, so arguments coming back from the model are validated at runtime, not just type-hinted. Streaming is a single async iterator. The result reads like idiomatic Python rather than a TypeScript API transliterated into Python.',
+      ],
+    },
+    {
+      h2: 'What CubePi adds on the Python side',
+      body: [
+        'Built-in checkpointing: an append-only persistence layer with memory, SQLite, and Postgres backends, where each turn is O(1) to write regardless of conversation length.',
+        'Native OpenTelemetry: a Tracer and Meter emit OTel spans with GenAI semantic-convention attributes out of the box, exportable to any OTLP backend (Jaeger, Tempo, Honeycomb, Langfuse, Datadog, …) — plus a cubepi trace CLI for local JSONL traces.',
+        'MCP loaders for HTTP and stdio transports, a streaming-realistic FauxProvider for deterministic tests, and a lean dependency footprint: pydantic, anthropic, and openai are the only core dependencies; everything else is an optional extra.',
+      ],
+    },
+    {
+      h2: 'Which should you choose',
+      body: [
+        'Choose pi-agent-core if your services are TypeScript/Node and you want to stay in that runtime. Choose CubePi if you are building in Python and want the same linear-loop agent model with first-class asyncio, Pydantic-validated tools, append-only persistence, and native OpenTelemetry — without running a JavaScript runtime alongside your Python.',
+      ],
+    },
+  ],
+  cta: [
+    { text: 'Quick Start →', href: '/docs/getting-started/quick-start' },
+    { text: 'Core Concepts →', href: '/docs/getting-started/core-concepts' },
+  ],
+};
+
+const ZH: CompareContent = {
+  them: 'pi-agent-core',
+  title: 'CubePi vs pi-agent-core — Python 原生的同源框架',
+  description:
+    'CubePi 与 pi-agent-core 对比:pi-agent-core 是一个 TypeScript Agent 框架;CubePi 是同一套线性 agent-loop 架构的 Python 独立重实现,采用 Pydantic v2 模型、asyncio 原生原语,以及内置的追加式 checkpointing。',
+  keywords:
+    'CubePi vs pi-agent-core, pi-agent-core 替代品, pi-agent-core Python, Python Agent 框架, 异步 Agent 框架',
+  h1: 'CubePi vs pi-agent-core',
+  intro: [
+    'pi-agent-core 是一个 TypeScript Agent 框架。CubePi 是同一套架构的 Python 独立重实现 —— 同样的线性 agent 循环(agent.ts + agent-loop.ts 对应 CubePi 的 agent.py + loop.py)—— 围绕 Pydantic v2、asyncio 原生原语和内置 checkpointing 重新构建。',
+    '所以这与其说是「谁更好」,不如说是「你在哪个生态」。如果你的技术栈是 TypeScript/Node,pi-agent-core 原生契合。如果你的技术栈是 Python,CubePi 给你同样的心智模型,而无需把 JS 运行时拖进你的服务里。',
+  ],
+  tableHeading: '从 TypeScript 迁移到 Python',
+  rows: [
+    { label: '语言 / 运行时', them: 'Node.js 上的 TypeScript', us: 'Python 3.11+' },
+    { label: '并发模型', them: 'Promise / async-await', us: 'asyncio —— 异步优先,每个入口都是 async' },
+    { label: '模式与校验', them: 'TypeScript 类型(编译期)', us: 'Pydantic v2 模型 —— 工具参数运行时校验' },
+    { label: 'Agent 模型', them: '线性 agent 循环(agent.ts + agent-loop.ts)', us: '同样的线性循环(agent.py + loop.py)' },
+    { label: 'Provider', them: 'Provider 抽象', us: 'Provider 协议 —— 内置 Anthropic 与 OpenAI' },
+  ],
+  sections: [
+    {
+      h2: '同一套架构,Pythonic 的表层',
+      body: [
+        'CubePi 刻意保留了 pi-agent-core 的核心理念:agent 是一个循环,而不是一张图。改变的是表层。工具是普通的 async 函数,其参数是 Pydantic 模型,因此模型返回的参数会在运行时被校验,而不只是类型提示。流式输出是单个 async 迭代器。最终代码读起来像地道的 Python,而非把 TypeScript API 直译成 Python。',
+      ],
+    },
+    {
+      h2: 'CubePi 在 Python 侧带来的增量',
+      body: [
+        '内置 checkpointing:追加式持久化层,提供 memory、SQLite、Postgres 后端,无论对话多长,每轮写入都是 O(1)。',
+        '原生 OpenTelemetry:Tracer 与 Meter 开箱即用地输出带 GenAI 语义约定属性的 OTel span,可导出到任意 OTLP 后端(Jaeger、Tempo、Honeycomb、Langfuse、Datadog……),并附带 cubepi trace CLI 用于本地 JSONL trace。',
+        'MCP 加载器(支持 HTTP 与 stdio 传输)、用于确定性测试的流式仿真 FauxProvider,以及精简的依赖足迹:核心依赖只有 pydantic、anthropic、openai,其余皆为可选 extra。',
+      ],
+    },
+    {
+      h2: '该怎么选',
+      body: [
+        '如果你的服务是 TypeScript/Node 并希望留在该运行时,选 pi-agent-core。如果你用 Python 构建,并想要同样的线性循环 agent 模型 —— 一等公民的 asyncio、Pydantic 校验的工具、追加式持久化、原生 OpenTelemetry —— 而不想在 Python 旁边再跑一个 JavaScript 运行时,选 CubePi。',
+      ],
+    },
+  ],
+  cta: [
+    { text: '快速开始 →', href: '/docs/getting-started/quick-start' },
+    { text: '核心概念 →', href: '/docs/getting-started/core-concepts' },
+  ],
+};
+
+export default function ComparePiAgentCore(): React.ReactElement {
+  const zh = useIsZhHans();
+  return <ComparePage content={zh ? ZH : EN} />;
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Hero from '@site/src/components/Home/Hero';
 import WhyTable from '@site/src/components/Home/WhyTable';
@@ -10,15 +12,47 @@ import { useIsZhHans } from '@site/src/hooks/useIsZhHans';
 
 export default function Home(): React.ReactElement {
   const zh = useIsZhHans();
+  const { siteConfig } = useDocusaurusContext();
+  const version =
+    (siteConfig.customFields?.PACKAGE_VERSION as string | undefined) ?? 'dev';
+
+  // Product-level structured data lives on the homepage only (the global
+  // headTags carry the site-wide Organization). Enriched with offers (free),
+  // the released version, and links the org `sameAs` points at, so Google can
+  // surface a richer software result.
+  const softwareJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'CubePi',
+    description:
+      'A Pythonic, async-native agent framework — a leaner alternative to langgraph and pi-agent-core. Plain async functions, append-only checkpointing, minimal dependencies.',
+    url: 'https://cubepi.ai',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Linux, macOS, Windows',
+    programmingLanguage: 'Python',
+    softwareVersion: version,
+    downloadUrl: 'https://pypi.org/project/cubepi/',
+    softwareHelp: 'https://cubepi.ai/docs/',
+    license: 'https://github.com/cubeplexai/cubepi/blob/main/LICENSE',
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    author: { '@type': 'Organization', name: 'CubePi', url: 'https://cubepi.ai' },
+  };
+
   return (
     <Layout
+      // The site title ("CubePi") is appended via the title delimiter, so the
+      // page title here must NOT lead with the brand or it double-brands the
+      // <title>/og:title (e.g. "CubePi — … | CubePi").
       title={zh
-        ? 'CubePi — Pythonic 异步原生 Agent 框架'
-        : 'CubePi — a Pythonic async-native agent framework'}
+        ? 'Pythonic 异步原生 Agent 框架'
+        : 'A Pythonic, async-native agent framework'}
       description={zh
         ? 'CubePi 是 langgraph 和 pi-agent-core 的 Pythonic 异步原生替代方案。普通 async 函数、追加式持久化、3 个核心依赖。'
         : 'CubePi is a Pythonic async-native agent framework — a leaner alternative to langgraph and pi-agent-core. Plain async functions, append-only checkpointing, 3 core dependencies.'}
     >
+      <Head>
+        <script type="application/ld+json">{JSON.stringify(softwareJsonLd)}</script>
+      </Head>
       <Hero />
       <WhyTable />
       <HelloAgent />

--- a/website/src/pages/markdown-page.mdx
+++ b/website/src/pages/markdown-page.mdx
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.


### PR DESCRIPTION
## Summary

SEO pass over the cubepi.ai docs site (Docusaurus). Starts from a build-verified audit (`dev/seo-audit-2026-06-05.md`) and implements the actionable items. Every change was verified against the actual `pnpm build` output (HTML `<head>`, sitemap), not just config.

The site's SEO foundation was already strong (canonical, hreflang en/zh-Hans/x-default, OG/Twitter, per-doc descriptions, version de-indexing). This PR closes the remaining gaps.

## Changes

**On-page**
- **Homepage H1** now carries the keyword phrase. The tagline was a separate `<p>`; it's folded into the single `<h1>` as a styled subline, so the page renders pixel-identically while the H1 reads "CubePi — a Pythonic, async-native agent framework."
- **Fixed double-branded `<title>`/`og:title`** ("… | CubePi") by dropping the leading brand from the homepage page title.
- **Removed the boilerplate `markdown-page.mdx`** scaffold page that was unlinked yet indexed and emitted to both sitemaps.

**New content (biggest organic upside)**
- **`/compare/langgraph`** and **`/compare/pi-agent-core`** — indexable comparison landing pages targeting high-intent queries ("LangGraph alternative", "pi-agent-core alternative", "CubePi vs …"). EN + zh-Hans via the existing `useIsZhHans` convention. Each has a comparison table, side-by-side code (LangGraph page), `TechArticle` JSON-LD, targeted title/description/keywords, and internal links.
  - Built as `src/pages` (not docs) so they index at canonical root URLs instead of landing in the `noIndex` "next" docs version.
  - The pi-agent-core comparison is grounded in `README.md` (pi-agent-core is TypeScript; CubePi is its Python reimplementation) — no invented API specifics; CubePi's additions are stated as CubePi capabilities rather than asserted gaps in the other framework.
- **Internal linking**: a "Compare" navbar dropdown and a full-comparison link under the homepage `WhyTable`.

**Technical SEO**
- **Structured data**: scoped the product `SoftwareApplication` schema to the homepage (enriched with `softwareVersion`, a free `offers`, and download/help links); kept only a site-wide `Organization` in global `headTags`, so docs subpages are no longer all mislabeled as the application itself.
- **Sitemap**: emit `lastmod` (plus explicit `changefreq`/`priority`).
- **LCP**: mark the hero image `fetchpriority="high"`.

## Verification

- `pnpm build` passes (incl. `onBrokenLinks: throw`), both locales.
- `pnpm typecheck` and `pnpm test` pass.
- Confirmed in build output: compare pages emit correct canonical + hreflang + TechArticle JSON-LD; sitemap includes both compare pages with `lastmod`; homepage `og:title` no longer double-brands; homepage carries enriched `SoftwareApplication` with `offers`; hero `fetchpriority="high"` present.

## Notes / out of scope
- Operational follow-ups (not code): submit `sitemap.xml` + `zh-Hans/sitemap.xml` to Google Search Console / Bing / Baidu webmaster tools.
- A WebP/AVIF variant of the hero social image was suggested in the audit but not done here to avoid churn; the `fetchpriority` hint is the low-risk part.

https://claude.ai/code/session_01UV4NAWz6qcBE35Nv1s1WRM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UV4NAWz6qcBE35Nv1s1WRM)_