### PR TITLE
build: add [project.urls] so PyPI links back to cubepi.ai

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,13 @@ dependencies = [
     "pydantic>=2.13.4",
 ]
 
+[project.urls]
+Homepage = "https://cubepi.ai"
+Documentation = "https://cubepi.ai/docs"
+Repository = "https://github.com/cubeplexai/cubepi"
+Changelog = "https://cubepi.ai/changelog"
+Issues = "https://github.com/cubeplexai/cubepi/issues"
+
 [project.optional-dependencies]
 sqlite = [
     "aiosqlite>=0.22.1",


### PR DESCRIPTION
## Summary

Adds a `[project.urls]` table to `pyproject.toml` so the PyPI project page links back to cubepi.ai and the repo.

Context: the package had no metadata URLs, so the (high-authority, frequently-crawled) PyPI page didn't link to the docs site — a missed backlink that matters for a new domain still establishing itself for its own brand term.

```toml
[project.urls]
Homepage = "https://cubepi.ai"
Documentation = "https://cubepi.ai/docs"
Repository = "https://github.com/cubeplexai/cubepi"
Changelog = "https://cubepi.ai/changelog"
Issues = "https://github.com/cubeplexai/cubepi/issues"
```

These render as sidebar links on PyPI. Takes effect on the next PyPI release.

## Verification

- `pyproject.toml` parses (tomllib) and the env still resolves (`uv`).
- Metadata-only change; no code or tests affected.

https://claude.ai/code/session_01UV4NAWz6qcBE35Nv1s1WRM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UV4NAWz6qcBE35Nv1s1WRM)_