### PR TITLE
feat(agent): conversation fork — Agent.fork() + Agent.fork_once()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only when declared. Tools may return a `str`, a `Content`, a `list` of
   content, or a full `AgentToolResult`. The longhand `AgentTool(...)` remains
   fully supported.
+- **Conversation fork** — fork a thread at a completed-run boundary, or run
+  a one-shot ephemeral continuation against a snapshot:
+  - `Agent.fork(src, new, *, after_run_id, metadata=None)` — physical-copy
+    fork at a completed-run boundary.
+  - `Agent.fork_once(src, message, *, after_run_id) -> ForkOnceResult` —
+    single-turn ephemeral continuation, no checkpointer writes.
+  - `Agent.prompt(message, *, run_id=None) -> str` now accept-or-generates
+    the `run_id` and returns it.
+  - `Agent.state.active_run_id` exposes the in-flight `run_id`.
+  - `Agent(messages=...)` constructor arg for ephemeral pre-seeded history.
+  - `Checkpointer.snapshot`, `fork`, `claim_run`, `mark_run_complete`,
+    `load_pending` Protocol methods.
+  - `cubepi_runs` table per backend (Postgres / MySQL schema v3 → v4).
+  - `Message.run_id: str | None` field on all three Message variants.
+  - `HitlBinding` attribute on `AgentTool` / `Middleware`; `ask_user_tool`
+    and `ApprovalPolicyMiddleware` populate it.
 
 ### Fixed
 
@@ -23,6 +39,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   body that returned `AgentToolResult(is_error=True)` without raising was
   surfaced to the model as a successful result; the flag is now honored on the
   execution path (affects both `@tool` and longhand `AgentTool` tools).
+
+### Breaking
+
+- `Agent.prompt()` return type changed from `None` to `str`. Callers ignoring
+  the return value keep working.
+- `Checkpointer` Protocol gained 5 new methods. Third-party v3-only
+  checkpointers continue to work for vanilla `prompt()` via degraded mode;
+  fork APIs raise `CheckpointerError` on such backends.
+
+### Migration
+
+- Postgres / MySQL: run the new alembic helper (see backend guides).
+- SQLite: auto-migration at connect time.
+- Legacy `run_id=NULL` messages remain readable; threads with only such
+  messages are not forkable.
 
 ## [0.7.0] - 2026-06-05
 

--- a/cubepi/agent/_outcome.py
+++ b/cubepi/agent/_outcome.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from typing import Literal
+
+RunOutcome = Literal["complete", "suspended", "incomplete", "abandoned"]

--- a/cubepi/agent/_tool_cycle.py
+++ b/cubepi/agent/_tool_cycle.py
@@ -1,0 +1,77 @@
+"""Pre-completion tool-cycle invariant — spec §3.6.2.
+
+For each AssistantMessage with ToolCall blocks {c1..cK}, the K-message
+window immediately following MUST be all ToolResultMessages whose
+tool_call_id MULTISET equals {c1..cK} — no extras, no missing, no
+duplicates beyond what the assistant emitted, and no other
+AssistantMessage or UserMessage may appear in that window.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    ToolCall,
+    ToolResultMessage,
+)
+
+
+class ToolCycleViolation(ValueError):
+    def __init__(
+        self,
+        *,
+        kind: str,
+        assistant_index: int,
+        expected: Counter,
+        got: Counter,
+    ) -> None:
+        super().__init__(
+            f"tool-cycle violation [{kind}] at assistant index "
+            f"{assistant_index}: expected {dict(expected)}, "
+            f"got {dict(got)}"
+        )
+        self.kind = kind
+        self.assistant_index = assistant_index
+        self.expected = expected
+        self.got = got
+
+
+def check_tool_cycle(messages: list[Message]) -> None:
+    for i, m in enumerate(messages):
+        if not isinstance(m, AssistantMessage):
+            continue
+        call_ids = [c.id for c in m.content if isinstance(c, ToolCall)]
+        if not call_ids:
+            continue
+        expected = Counter(call_ids)
+        k = len(call_ids)
+        window = messages[i + 1 : i + 1 + k]
+        if len(window) < k:
+            raise ToolCycleViolation(
+                kind="incomplete-window",
+                assistant_index=i,
+                expected=expected,
+                got=Counter(),
+            )
+        for w in window:
+            if not isinstance(w, ToolResultMessage):
+                raise ToolCycleViolation(
+                    kind="non-tool-result-in-window",
+                    assistant_index=i,
+                    expected=expected,
+                    got=Counter(),
+                )
+        got = Counter(
+            w.tool_call_id for w in window if isinstance(w, ToolResultMessage)
+        )
+        # Multiset equality — catches duplicates the spec rejects.
+        if got != expected:
+            raise ToolCycleViolation(
+                kind="multiset-mismatch",
+                assistant_index=i,
+                expected=expected,
+                got=got,
+            )

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -311,6 +311,30 @@ class Agent(Generic[TMessage]):
                 "Agent is already processing a prompt. "
                 "Use steer() or follow_up() to queue messages."
             )
+        bound: set[str] = set()
+        for elem in (*self._state.tools, *self._middleware):
+            binding = getattr(elem, "hitl", None)
+            if binding is None or not binding.checkpointed:
+                continue
+            if binding.run_id is None:
+                raise ValueError(
+                    f"Checkpointed HITL element {elem!r} has no run_id bound; "
+                    "construct CheckpointedChannel(run_id=...) before passing "
+                    "it to ask_user_tool/HITL middleware"
+                )
+            bound.add(binding.run_id)
+        if bound:
+            if run_id is None:
+                raise ValueError(
+                    f"Agent has checkpointed HITL elements bound to "
+                    f"run_ids {sorted(bound)!r}; prompt(run_id=...) "
+                    "must be explicitly supplied (generate-mode rejected)"
+                )
+            if any(b != run_id for b in bound):
+                raise ValueError(
+                    f"prompt(run_id={run_id!r}) does not match "
+                    f"HITL-bound run_ids {sorted(bound)!r}"
+                )
         effective_run_id = run_id or uuid.uuid4().hex
         # Reject mismatched caller-supplied Message.run_id BEFORE any state
         # mutation so the supplied run_id remains reusable (Task 25 will add

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -426,6 +426,29 @@ class Agent(Generic[TMessage]):
             self._state.active_run_id = None
             return effective_run_id
 
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        after_run_id: str,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        if self.checkpointer is None:
+            raise RuntimeError("fork requires a checkpointer")
+        if not self._run_aware:
+            from cubepi.checkpointer.exceptions import CheckpointerError
+
+            raise CheckpointerError(
+                "backend does not support fork; missing claim_run / mark_run_complete"
+            )
+        await self.checkpointer.fork(
+            src_thread_id,
+            new_thread_id,
+            after_run_id=after_run_id,
+            metadata=metadata,
+        )
+
     async def resume(self) -> None:
         # Same fail-fast pattern as prompt(): lock.locked() is the atomic gate.
         if self._run_lock.locked() or self._state.is_streaming:

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Callable, Generic, TypeVar
@@ -276,7 +277,12 @@ class Agent(Generic[TMessage]):
         self._steering_queue.clear()
         self._follow_up_queue.clear()
 
-    async def prompt(self, message: str | Message | list[Message]) -> None:
+    async def prompt(
+        self,
+        message: str | Message | list[Message],
+        *,
+        run_id: str | None = None,
+    ) -> str:
         # Fail-fast guard: if the run-lock is already held OR a stream is in
         # progress, raise immediately instead of queueing on the lock. This
         # makes two concurrent cold prompt() calls fail-fast deterministically
@@ -287,34 +293,43 @@ class Agent(Generic[TMessage]):
                 "Agent is already processing a prompt. "
                 "Use steer() or follow_up() to queue messages."
             )
-        async with self._run_lock:
-            # Re-check under the lock in case streaming flipped during acquire.
-            if self._state.is_streaming:  # pragma: no cover — defensive re-check
-                raise RuntimeError(
-                    "Agent is already processing a prompt. "
-                    "Use steer() or follow_up() to queue messages."
-                )
-
-            if isinstance(message, str):
-                messages: list[Message] = [
-                    UserMessage(
-                        content=[TextContent(text=message)], timestamp=time.time()
+        effective_run_id = run_id or uuid.uuid4().hex
+        self._state.active_run_id = effective_run_id
+        try:
+            async with self._run_lock:
+                # Re-check under the lock in case streaming flipped during acquire.
+                if self._state.is_streaming:  # pragma: no cover — defensive re-check
+                    raise RuntimeError(
+                        "Agent is already processing a prompt. "
+                        "Use steer() or follow_up() to queue messages."
                     )
-                ]
-            elif isinstance(message, list):
-                messages = message
-            else:
-                messages = [message]
 
-            # Restore history and extra from checkpointer if this is first prompt
-            if self.checkpointer and self.thread_id and not self._state._messages:
-                data = await self.checkpointer.load(self.thread_id)
-                if data:
-                    if data.messages:
-                        self._state._messages = list(data.messages)
-                    self._extra = dict(data.extra)
+                if isinstance(message, str):
+                    messages: list[Message] = [
+                        UserMessage(
+                            content=[TextContent(text=message)], timestamp=time.time()
+                        )
+                    ]
+                elif isinstance(message, list):
+                    messages = message
+                else:
+                    messages = [message]
 
-            await self._run_prompt(messages)
+                # Restore history and extra from checkpointer if this is first prompt
+                if self.checkpointer and self.thread_id and not self._state._messages:
+                    data = await self.checkpointer.load(self.thread_id)
+                    if data:
+                        if data.messages:
+                            self._state._messages = list(data.messages)
+                        self._extra = dict(data.extra)
+
+                await self._run_prompt(messages)
+        except BaseException:
+            # Spec §3.7: leave active_run_id SET on failure.
+            raise
+        else:
+            self._state.active_run_id = None
+            return effective_run_id
 
     async def resume(self) -> None:
         # Same fail-fast pattern as prompt(): lock.locked() is the atomic gate.

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Callable, Generic, TypeVar
 
 from cubepi.agent._outcome import RunOutcome
+from cubepi.agent._tool_cycle import ToolCycleViolation, check_tool_cycle
 from cubepi.agent.loop import (
     run_agent_loop,
     run_agent_loop_continue,
@@ -294,6 +295,12 @@ class Agent(Generic[TMessage]):
         return _sink
 
     async def _dispatch_outcome(self, outcome: RunOutcome | None, run_id: str) -> None:
+        if outcome == "complete":
+            run_messages = [m for m in self._state.messages if m.run_id == run_id]
+            try:
+                check_tool_cycle(run_messages)
+            except ToolCycleViolation:
+                outcome = "incomplete"
         if outcome != "complete":
             return
         if not (self._run_aware and self.thread_id):

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -376,14 +376,9 @@ class Agent(Generic[TMessage]):
                 )
         effective_run_id = run_id or uuid.uuid4().hex
         # Reject mismatched caller-supplied Message.run_id BEFORE any state
-        # mutation so the supplied run_id remains reusable (Task 25 will add
-        # claim_run, which must not be called for a rejected prompt).
+        # mutation so the supplied run_id remains reusable (claim_run must
+        # not be called for a rejected prompt).
         self._validate_input_run_ids(message, effective_run_id)
-        if self._run_aware and self.thread_id is not None:
-            assert self.checkpointer is not None  # narrowed by _run_aware
-            await self.checkpointer.claim_run(self.thread_id, effective_run_id)
-        self._state.active_run_id = effective_run_id
-        self._state.last_outcome = None
         try:
             async with self._run_lock:
                 # Re-check under the lock in case streaming flipped during acquire.
@@ -392,6 +387,16 @@ class Agent(Generic[TMessage]):
                         "Agent is already processing a prompt. "
                         "Use steer() or follow_up() to queue messages."
                     )
+                # Claim the run UNDER the lock: this serializes concurrent cold
+                # prompt() calls against the checkpointer. With the fail-fast
+                # `.locked()` guard above, the second concurrent caller raises
+                # immediately instead of awaiting claim_run + queueing on the
+                # lock.
+                if self._run_aware and self.thread_id is not None:
+                    assert self.checkpointer is not None  # narrowed by _run_aware
+                    await self.checkpointer.claim_run(self.thread_id, effective_run_id)
+                self._state.active_run_id = effective_run_id
+                self._state.last_outcome = None
 
                 if isinstance(message, str):
                     messages: list[Message] = [
@@ -485,13 +490,30 @@ class Agent(Generic[TMessage]):
         snapshot = await self.checkpointer.snapshot(
             src_thread_id, after_run_id=after_run_id
         )
-        # Build transient agent
+        # Build transient agent. Forward the parent's resolved execution
+        # options + middleware-composed hooks so the probe behaves like the
+        # parent would (tool_execution, thinking, transform/response hooks,
+        # on_payload/on_response, queue modes). Passing the resolved hooks
+        # as explicit args means we pass middleware=[] to avoid composing
+        # middleware twice — the parent's composed result already lives on
+        # self.transform_context etc.
         child: Agent = Agent(
             model=self._model,
             system_prompt=self._state.system_prompt,
             tools=list(self._state.tools),
-            middleware=list(self._middleware),
+            thinking=self._state.thinking,
             convert_to_llm=self.convert_to_llm,
+            transform_context=self.transform_context,
+            transform_system_prompt=self.transform_system_prompt,
+            after_model_response=self.after_model_response,
+            before_tool_call=self.before_tool_call,
+            after_tool_call=self.after_tool_call,
+            should_stop_after_turn=self.should_stop_after_turn,
+            on_run_end=self.on_run_end,
+            on_payload=self.on_payload,
+            on_response=self.on_response,
+            tool_execution=self.tool_execution,
+            middleware=[],
             messages=snapshot,
         )
         pre_len = len(child.state.messages)

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Callable, Generic, TypeVar
 
@@ -153,13 +154,25 @@ class Agent(Generic[TMessage]):
         thread_id: str | None = None,
         middleware: list[Middleware] | None = None,
         channel: HitlChannel | None = None,
+        messages: Sequence[Message] | None = None,
     ) -> None:
         self._provider: Provider = model.provider
+        self._model = model
         self._state = AgentState(
             system_prompt=system_prompt,
             model=model.spec,
             thinking=thinking,
         )
+        if messages is not None:
+            if thread_id is not None and checkpointer is not None:
+                raise ValueError(
+                    "Agent(messages=...) cannot be combined with "
+                    "thread_id + checkpointer (pre-seed conflicts with lazy "
+                    "load). Construct an ephemeral Agent without those for "
+                    "fork_once-style usage."
+                )
+            seeded = [m.model_copy(deep=True) for m in messages]
+            self._state.messages = list(seeded)
         if tools:
             self._state.tools = tools
         middleware = middleware or []

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -98,6 +98,7 @@ class AgentState:
     is_streaming: bool = False
     streaming_message: Message | None = None
     error_message: str | None = None
+    active_run_id: str | None = None
     _tools: list[AgentTool] = field(default_factory=list)
     _messages: list[Message] = field(default_factory=list)
     _pending_tool_calls: set[str] = field(default_factory=set)

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -517,10 +517,26 @@ class Agent(Generic[TMessage]):
         )
 
     def _fork_once_span(self, *, src_thread_id: str, after_run_id: str):
-        """Replaced by a real OTel span in Task 34. Placeholder no-op."""
-        from contextlib import nullcontext
+        """Emit a `cubepi.agent.fork_once` OTel span around the probe run.
 
-        return nullcontext()
+        The opentelemetry dependency is part of the optional `tracing` extra;
+        when it isn't installed we fall back to a no-op nullcontext so the
+        agent still works.
+        """
+        try:
+            from opentelemetry import trace
+        except ImportError:
+            from contextlib import nullcontext
+
+            return nullcontext()
+        tracer = trace.get_tracer("cubepi.agent")
+        return tracer.start_as_current_span(
+            "cubepi.agent.fork_once",
+            attributes={
+                "cubepi.fork.src_thread_id": src_thread_id,
+                "cubepi.fork.after_run_id": after_run_id,
+            },
+        )
 
     async def resume(self) -> None:
         # Same fail-fast pattern as prompt(): lock.locked() is the atomic gate.

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -210,6 +210,11 @@ class Agent(Generic[TMessage]):
         self.tool_execution = tool_execution
         self.checkpointer = checkpointer
         self.thread_id = thread_id
+        self._run_aware = (
+            self.checkpointer is not None
+            and hasattr(self.checkpointer, "claim_run")
+            and hasattr(self.checkpointer, "mark_run_complete")
+        )
         self._channel = channel
         # _bind_emit is a _BaseChannel internal, not part of the HitlChannel
         # protocol. Third-party channels that only implement the public
@@ -340,6 +345,9 @@ class Agent(Generic[TMessage]):
         # mutation so the supplied run_id remains reusable (Task 25 will add
         # claim_run, which must not be called for a rejected prompt).
         self._validate_input_run_ids(message, effective_run_id)
+        if self._run_aware and self.thread_id is not None:
+            assert self.checkpointer is not None  # narrowed by _run_aware
+            await self.checkpointer.claim_run(self.thread_id, effective_run_id)
         self._state.active_run_id = effective_run_id
         try:
             async with self._run_lock:

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -25,6 +25,7 @@ from cubepi.agent.types import (
     AgentEndEvent,
     AgentEvent,
     AgentTool,
+    ForkOnceResult,
     MessageEndEvent,
     MessageStartEvent,
     TurnEndEvent,
@@ -448,6 +449,78 @@ class Agent(Generic[TMessage]):
             after_run_id=after_run_id,
             metadata=metadata,
         )
+
+    async def fork_once(
+        self,
+        src_thread_id: str,
+        message: str | Message | list[Message],
+        *,
+        after_run_id: str,
+    ) -> ForkOnceResult:
+        if self.checkpointer is None:
+            raise RuntimeError("fork_once requires a checkpointer")
+        # Degraded-mode guard
+        if not self._run_aware or not hasattr(self.checkpointer, "snapshot"):
+            from cubepi.checkpointer.exceptions import CheckpointerError
+
+            raise CheckpointerError(
+                "backend does not support fork_once; missing snapshot / "
+                "claim_run / mark_run_complete"
+            )
+        # HITL pre-flight
+        hitl_offenders = [
+            elem
+            for elem in (*self._state.tools, *self._middleware)
+            if getattr(elem, "hitl", None) is not None
+        ]
+        if hitl_offenders:
+            names = ", ".join(
+                getattr(e, "name", type(e).__name__) for e in hitl_offenders
+            )
+            raise RuntimeError(
+                f"fork_once() does not support HITL. Found HITL-bearing "
+                f"tools/middleware: {names}. Construct a different Agent "
+                "without these for ephemeral probes."
+            )
+        snapshot = await self.checkpointer.snapshot(
+            src_thread_id, after_run_id=after_run_id
+        )
+        # Build transient agent
+        child: Agent = Agent(
+            model=self._model,
+            system_prompt=self._state.system_prompt,
+            tools=list(self._state.tools),
+            middleware=list(self._middleware),
+            convert_to_llm=self.convert_to_llm,
+            messages=snapshot,
+        )
+        pre_len = len(child.state.messages)
+        fresh_run_id = uuid.uuid4().hex
+        # Tracing placeholder — replaced by real OTel span in Task 34
+        with self._fork_once_span(
+            src_thread_id=src_thread_id, after_run_id=after_run_id
+        ):
+            await child.prompt(message, run_id=fresh_run_id)
+        new_messages = child.state.messages[pre_len:]
+        # Extract final assistant text and stop_reason
+        final_text = ""
+        stop_reason = "stop"
+        for m in reversed(new_messages):
+            if isinstance(m, AssistantMessage):
+                final_text = "".join(
+                    c.text for c in m.content if isinstance(c, TextContent)
+                )
+                stop_reason = m.stop_reason
+                break
+        return ForkOnceResult(
+            text=final_text, messages=new_messages, stop_reason=stop_reason
+        )
+
+    def _fork_once_span(self, *, src_thread_id: str, after_run_id: str):
+        """Replaced by a real OTel span in Task 34. Placeholder no-op."""
+        from contextlib import nullcontext
+
+        return nullcontext()
 
     async def resume(self) -> None:
         # Same fail-fast pattern as prompt(): lock.locked() is the atomic gate.

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -316,6 +316,56 @@ class Agent(Generic[TMessage]):
                 cause=exc,
             ) from exc
 
+    def _validate_hitl_bindings(self, run_id: str | None, *, caller: str) -> None:
+        """Reject HITL-bound tools/middleware that disagree with `run_id`.
+
+        Called from both `prompt(run_id=...)` and `respond()` (where the
+        run_id comes from the recovered pending row). This guarantees that
+        any checkpointed HITL channel/middleware on the Agent is bound to
+        the same run_id as the run that's about to drive the loop —
+        otherwise a second HITL pause would persist its pending row under
+        the wrong run_id and the next resume would stamp messages or try
+        to complete an unclaimed run.
+
+        Two callers, two None-semantics:
+        - `prompt(run_id=None)` with bindings → "generate-mode rejected":
+          the caller explicitly asked for an unbound run; the bindings
+          already carry one, so we must reject.
+        - `respond()` with `recovered_run_id=None` → legacy pending row
+          (pre-v4 save_pending_request, or forged). Skip the binding
+          check; the legacy fallback in respond() will skip dispatch
+          anyway, and the host's channel binding may correctly identify
+          the original run.
+        """
+        bound: set[str] = set()
+        for elem in (*self._state.tools, *self._middleware):
+            binding = getattr(elem, "hitl", None)
+            if binding is None or not binding.checkpointed:
+                continue
+            if binding.run_id is None:
+                raise ValueError(
+                    f"Checkpointed HITL element {elem!r} has no run_id bound; "
+                    "construct CheckpointedChannel(run_id=...) before passing "
+                    "it to ask_user_tool/HITL middleware"
+                )
+            bound.add(binding.run_id)
+        if not bound:
+            return
+        if run_id is None:
+            if caller == "respond":
+                # Legacy pending — no run_id to validate against.
+                return
+            raise ValueError(
+                f"Agent has checkpointed HITL elements bound to "
+                f"run_ids {sorted(bound)!r}; prompt(run_id=...) "
+                "must be explicitly supplied (generate-mode rejected)"
+            )
+        if any(b != run_id for b in bound):
+            raise ValueError(
+                f"{caller}() run_id={run_id!r} does not match "
+                f"HITL-bound run_ids {sorted(bound)!r}"
+            )
+
     def _validate_input_run_ids(
         self,
         message: str | Message | list[Message],
@@ -350,30 +400,7 @@ class Agent(Generic[TMessage]):
                 "Agent is already processing a prompt. "
                 "Use steer() or follow_up() to queue messages."
             )
-        bound: set[str] = set()
-        for elem in (*self._state.tools, *self._middleware):
-            binding = getattr(elem, "hitl", None)
-            if binding is None or not binding.checkpointed:
-                continue
-            if binding.run_id is None:
-                raise ValueError(
-                    f"Checkpointed HITL element {elem!r} has no run_id bound; "
-                    "construct CheckpointedChannel(run_id=...) before passing "
-                    "it to ask_user_tool/HITL middleware"
-                )
-            bound.add(binding.run_id)
-        if bound:
-            if run_id is None:
-                raise ValueError(
-                    f"Agent has checkpointed HITL elements bound to "
-                    f"run_ids {sorted(bound)!r}; prompt(run_id=...) "
-                    "must be explicitly supplied (generate-mode rejected)"
-                )
-            if any(b != run_id for b in bound):
-                raise ValueError(
-                    f"prompt(run_id={run_id!r}) does not match "
-                    f"HITL-bound run_ids {sorted(bound)!r}"
-                )
+        self._validate_hitl_bindings(run_id, caller="prompt")
         effective_run_id = run_id or uuid.uuid4().hex
         # Reject mismatched caller-supplied Message.run_id BEFORE any state
         # mutation so the supplied run_id remains reusable (claim_run must
@@ -728,6 +755,13 @@ class Agent(Generic[TMessage]):
                     f"answer for {question_id}, pending is {pending.question_id}"
                 )
 
+            # Validate HITL bindings on this Agent against the recovered
+            # run_id. Without this, a host that built CheckpointedChannel
+            # with a different run_id would persist a second pending row
+            # under the wrong run, then the next resume would stamp
+            # messages / try to complete an unclaimed run.
+            self._validate_hitl_bindings(recovered_run_id, caller="respond")
+
             # Thread the recovered run_id into agent state so the resume loop
             # stamps appended messages and _dispatch_outcome can mark the
             # run complete. respond() does NOT call claim_run — the original
@@ -848,6 +882,12 @@ class Agent(Generic[TMessage]):
                 tc_id for tc_id in tool_call_ids if tc_id not in already_resolved
             ]
 
+            # Stamp synthetic cleanup messages with the originating
+            # assistant's run_id so a later fork after an EARLIER completed
+            # run cannot copy aborted-run artifacts as "legacy" history
+            # (fork queries treat run_id IS NULL as always-copy).
+            owning_run_id = last.run_id
+
             # Synthesize deny tool_result for each unresolved tool_call.
             for tc_id in unresolved:
                 tc = next(
@@ -860,6 +900,7 @@ class Agent(Generic[TMessage]):
                     details={"hitl": {"decision": "aborted", "reason": reason}},
                     is_error=True,
                     timestamp=time.time(),
+                    run_id=owning_run_id,
                 )
                 self._state._messages.append(synthetic)
                 await self.checkpointer.append(self.thread_id, [synthetic])
@@ -872,6 +913,7 @@ class Agent(Generic[TMessage]):
                     stop_reason="aborted",
                     usage=Usage(),
                     timestamp=time.time(),
+                    run_id=owning_run_id,
                 )
                 self._state._messages.append(term)
                 await self.checkpointer.append(self.thread_id, [term])
@@ -980,6 +1022,12 @@ class Agent(Generic[TMessage]):
                 for m in self._state._messages[last_idx + 1 :]
                 if isinstance(m, ToolResultMessage)
             }
+            # Stamp synthetic results with the originating assistant's
+            # run_id so a fork after an earlier completed run cannot copy
+            # them as "legacy" history (fork treats run_id IS NULL as
+            # always-copy; an uncompleted run's tool_results would be
+            # orphaned in the forked transcript).
+            owning_run_id = last_assistant.run_id
             synthetic: list[Message] = []
             for block in last_assistant.content:
                 if not isinstance(block, ToolCall) or block.id in answered:
@@ -993,6 +1041,7 @@ class Agent(Generic[TMessage]):
                         ],
                         is_error=True,
                         timestamp=time.time(),
+                        run_id=owning_run_id,
                     )
                 )
 

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -357,7 +357,7 @@ class Agent(Generic[TMessage]):
                 return
             raise ValueError(
                 f"Agent has checkpointed HITL elements bound to "
-                f"run_ids {sorted(bound)!r}; prompt(run_id=...) "
+                f"run_ids {sorted(bound)!r}; {caller}(run_id=...) "
                 "must be explicitly supplied (generate-mode rejected)"
             )
         if any(b != run_id for b in bound):
@@ -587,37 +587,65 @@ class Agent(Generic[TMessage]):
             },
         )
 
-    async def resume(self) -> None:
+    async def resume(self, *, run_id: str | None = None) -> str:
         # Same fail-fast pattern as prompt(): lock.locked() is the atomic gate.
         if self._run_lock.locked() or self._state.is_streaming:
             raise RuntimeError(
                 "Agent is already processing. Wait for completion before continuing."
             )
-        async with self._run_lock:
-            if self._state.is_streaming:  # pragma: no cover — defensive re-check
-                raise RuntimeError(
-                    "Agent is already processing. Wait for completion before continuing."
-                )
+        self._validate_hitl_bindings(run_id, caller="resume")
+        effective_run_id = run_id or uuid.uuid4().hex
+        try:
+            async with self._run_lock:
+                if self._state.is_streaming:  # pragma: no cover — defensive re-check
+                    raise RuntimeError(
+                        "Agent is already processing. "
+                        "Wait for completion before continuing."
+                    )
 
-            if not self._state._messages:
-                raise RuntimeError("No messages to continue from")
+                if not self._state._messages:
+                    raise RuntimeError("No messages to continue from")
 
-            last = self._state._messages[-1]
-            if isinstance(last, AssistantMessage):
-                # Check for queued messages
-                steering = self._steering_queue.drain()
-                if steering:
-                    await self._run_prompt(steering)
-                    return
+                last = self._state._messages[-1]
+                # Validate preconditions BEFORE claim_run so a precondition
+                # failure does not leave a claimed run dangling on the
+                # checkpointer.
+                if isinstance(last, AssistantMessage) and not (
+                    self._steering_queue.has_items()
+                    or self._follow_up_queue.has_items()
+                ):
+                    raise RuntimeError("Cannot continue from message role: assistant")
 
-                follow_ups = self._follow_up_queue.drain()
-                if follow_ups:
-                    await self._run_prompt(follow_ups)
-                    return
+                # Claim + stamp under the lock (same invariants as prompt()):
+                # without this, messages emitted by the resumed turn would
+                # land with run_id=None and fork queries (which treat NULL
+                # as legacy / always-copy) would happily copy them into a
+                # later fork even if this resumed work is still in flight or
+                # later abandoned.
+                if self._run_aware and self.thread_id is not None:
+                    assert self.checkpointer is not None  # narrowed by _run_aware
+                    await self.checkpointer.claim_run(self.thread_id, effective_run_id)
+                self._state.active_run_id = effective_run_id
+                self._state.last_outcome = None
 
-                raise RuntimeError("Cannot continue from message role: assistant")
-
-            await self._run_continuation()
+                if isinstance(last, AssistantMessage):
+                    steering = self._steering_queue.drain()
+                    if steering:
+                        await self._run_prompt(steering)
+                    else:
+                        follow_ups = self._follow_up_queue.drain()
+                        await self._run_prompt(follow_ups)
+                else:
+                    await self._run_continuation()
+        except BaseException:
+            # Spec §3.7 parity: leave active_run_id SET on failure so callers
+            # can observe which run failed.
+            raise
+        else:
+            outcome: RunOutcome = self._state.last_outcome or "abandoned"
+            await self._dispatch_outcome(outcome, effective_run_id)
+            self._state.active_run_id = None
+            return effective_run_id
 
     def _build_stream_options(self, signal: asyncio.Event) -> StreamOptions:
         return StreamOptions(

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -7,12 +7,14 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Callable, Generic, TypeVar
 
+from cubepi.agent._outcome import RunOutcome
 from cubepi.agent.loop import (
     run_agent_loop,
     run_agent_loop_continue,
     run_agent_loop_resume,
 )
 from cubepi.checkpointer.base import Checkpointer
+from cubepi.checkpointer.exceptions import CompletionMarkerFailedError
 from cubepi.hitl import HitlError, HitlRequest
 from cubepi.hitl.channel import HitlChannel
 from cubepi.hitl.exceptions import HitlDetached
@@ -101,6 +103,7 @@ class AgentState:
     streaming_message: Message | None = None
     error_message: str | None = None
     active_run_id: str | None = None
+    last_outcome: RunOutcome | None = None
     _tools: list[AgentTool] = field(default_factory=list)
     _messages: list[Message] = field(default_factory=list)
     _pending_tool_calls: set[str] = field(default_factory=set)
@@ -282,6 +285,29 @@ class Agent(Generic[TMessage]):
         self._steering_queue.clear()
         self._follow_up_queue.clear()
 
+    def _outcome_sink(self) -> Callable[[str], None]:
+        def _sink(value: str) -> None:
+            # Cast through Any: loop callsites pass plain str literals from the
+            # RunOutcome alphabet ("complete" / "suspended" / "abandoned").
+            self._state.last_outcome = value  # type: ignore[assignment]
+
+        return _sink
+
+    async def _dispatch_outcome(self, outcome: RunOutcome | None, run_id: str) -> None:
+        if outcome != "complete":
+            return
+        if not (self._run_aware and self.thread_id):
+            return
+        assert self.checkpointer is not None  # narrowed by _run_aware
+        try:
+            await self.checkpointer.mark_run_complete(self.thread_id, run_id)
+        except Exception as exc:
+            raise CompletionMarkerFailedError(
+                thread_id=self.thread_id,
+                run_id=run_id,
+                cause=exc,
+            ) from exc
+
     def _validate_input_run_ids(
         self,
         message: str | Message | list[Message],
@@ -349,6 +375,7 @@ class Agent(Generic[TMessage]):
             assert self.checkpointer is not None  # narrowed by _run_aware
             await self.checkpointer.claim_run(self.thread_id, effective_run_id)
         self._state.active_run_id = effective_run_id
+        self._state.last_outcome = None
         try:
             async with self._run_lock:
                 # Re-check under the lock in case streaming flipped during acquire.
@@ -384,6 +411,11 @@ class Agent(Generic[TMessage]):
             # Spec §3.7: leave active_run_id SET on failure.
             raise
         else:
+            outcome: RunOutcome = self._state.last_outcome or "abandoned"
+            # If _dispatch_outcome raises (CompletionMarkerFailedError),
+            # propagate UP through this else: — active_run_id stays SET because
+            # the clear line below is unreachable on the exception path.
+            await self._dispatch_outcome(outcome, effective_run_id)
             self._state.active_run_id = None
             return effective_run_id
 
@@ -428,6 +460,7 @@ class Agent(Generic[TMessage]):
         )
 
     async def _run_prompt(self, messages: list[Message]) -> None:
+        sink = self._outcome_sink()
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop(
                 prompts=messages,
@@ -447,10 +480,12 @@ class Agent(Generic[TMessage]):
                 stream_options=self._build_stream_options(signal),
                 tool_execution=self.tool_execution,
                 emit=lambda e: self._process_event(e),
+                set_outcome=sink,
             )
         )
 
     async def _run_continuation(self) -> None:
+        sink = self._outcome_sink()
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop_continue(
                 context=self._create_context_snapshot(),
@@ -469,6 +504,7 @@ class Agent(Generic[TMessage]):
                 stream_options=self._build_stream_options(signal),
                 tool_execution=self.tool_execution,
                 emit=lambda e: self._process_event(e),
+                set_outcome=sink,
             )
         )
 

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -277,6 +277,24 @@ class Agent(Generic[TMessage]):
         self._steering_queue.clear()
         self._follow_up_queue.clear()
 
+    def _validate_input_run_ids(
+        self,
+        message: str | Message | list[Message],
+        effective_run_id: str,
+    ) -> None:
+        if isinstance(message, str):
+            return
+        if isinstance(message, list):
+            candidates: list[Message] = message
+        else:
+            candidates = [message]
+        for m in candidates:
+            if getattr(m, "run_id", None) is not None and m.run_id != effective_run_id:
+                raise ValueError(
+                    f"message.run_id={m.run_id!r} does not match "
+                    f"prompt(run_id={effective_run_id!r})"
+                )
+
     async def prompt(
         self,
         message: str | Message | list[Message],
@@ -294,6 +312,10 @@ class Agent(Generic[TMessage]):
                 "Use steer() or follow_up() to queue messages."
             )
         effective_run_id = run_id or uuid.uuid4().hex
+        # Reject mismatched caller-supplied Message.run_id BEFORE any state
+        # mutation so the supplied run_id remains reusable (Task 25 will add
+        # claim_run, which must not be called for a rejected prompt).
+        self._validate_input_run_ids(message, effective_run_id)
         self._state.active_run_id = effective_run_id
         try:
             async with self._run_lock:
@@ -307,7 +329,9 @@ class Agent(Generic[TMessage]):
                 if isinstance(message, str):
                     messages: list[Message] = [
                         UserMessage(
-                            content=[TextContent(text=message)], timestamp=time.time()
+                            content=[TextContent(text=message)],
+                            timestamp=time.time(),
+                            run_id=effective_run_id,
                         )
                     ]
                 elif isinstance(message, list):
@@ -757,10 +781,21 @@ class Agent(Generic[TMessage]):
         elif event.type == "message_update":
             self._state.streaming_message = event.message
         elif event.type == "message_end":
+            msg = event.message
+            active = self._state.active_run_id
+            if active is not None:
+                if msg.run_id is None:
+                    msg = msg.model_copy(update={"run_id": active})
+                    event = event.model_copy(update={"message": msg})
+                elif msg.run_id != active:
+                    raise ValueError(
+                        f"message.run_id={msg.run_id!r} does not match "
+                        f"active run_id={active!r}"
+                    )
             self._state.streaming_message = None
-            self._state._messages.append(event.message)
+            self._state._messages.append(msg)
             if self.checkpointer and self.thread_id:
-                await self.checkpointer.append(self.thread_id, [event.message])
+                await self.checkpointer.append(self.thread_id, [msg])
         elif event.type == "tool_execution_start":
             self._state._pending_tool_calls = self._state._pending_tool_calls | {
                 event.tool_call_id

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -558,7 +558,7 @@ class Agent(Generic[TMessage]):
 
     async def respond(
         self, *, question_id: str | None = None, answer: StructuredValue
-    ) -> None:  # pragma: no cover — E2E tested
+    ) -> None:
         from cubepi.hitl.exceptions import (
             HitlNoPendingRequest,
             HitlStaleAnswer,
@@ -569,11 +569,11 @@ class Agent(Generic[TMessage]):
         if not (self.thread_id and self.checkpointer):
             raise RuntimeError("respond() requires thread_id + checkpointer")
 
-        load_pending = getattr(self.checkpointer, "load_pending_request", None)
+        load_pending = getattr(self.checkpointer, "load_pending", None)
         if load_pending is None:
             raise HitlError(
                 "respond() requires a checkpointer that implements "
-                "load_pending_request (and save_pending_request)"
+                "load_pending (added in checkpointer v4)"
             )
 
         async with self._run_lock:
@@ -583,9 +583,10 @@ class Agent(Generic[TMessage]):
                     self._state._messages = list(data.messages or [])
                     self._extra = dict(data.extra or {})
 
-            pending = await load_pending(self.thread_id)
-            if pending is None:
+            loaded = await load_pending(self.thread_id)
+            if loaded is None:
                 raise HitlNoPendingRequest("no pending request on this thread")
+            pending, recovered_run_id = loaded
             if question_id is None:
                 question_id = pending.question_id
             if question_id != pending.question_id:
@@ -593,8 +594,27 @@ class Agent(Generic[TMessage]):
                     f"answer for {question_id}, pending is {pending.question_id}"
                 )
 
+            # Thread the recovered run_id into agent state so the resume loop
+            # stamps appended messages and _dispatch_outcome can mark the
+            # run complete. respond() does NOT call claim_run — the original
+            # prompt() already claimed it (single-claim invariant per spec).
+            if recovered_run_id is not None:
+                self._state.active_run_id = recovered_run_id
+            self._state.last_outcome = None
+
             self._channel.attach_resume_answer(question_id, answer)
-            await self._run_hitl_resume()
+            try:
+                await self._run_hitl_resume()
+            except BaseException:
+                # Spec §3.7: leave active_run_id SET on raise.
+                raise
+            else:
+                # Legacy guard: pending persisted without run_id (older
+                # save_pending_request callers) cannot drive dispatch.
+                if recovered_run_id is not None:
+                    outcome: RunOutcome = self._state.last_outcome or "abandoned"
+                    await self._dispatch_outcome(outcome, recovered_run_id)
+                self._state.active_run_id = None
 
     async def abort_pending(
         self, reason: str = "aborted by host"
@@ -728,6 +748,7 @@ class Agent(Generic[TMessage]):
             await self._process_event(AgentAbortedEvent(reason=reason))
 
     async def _run_hitl_resume(self) -> None:
+        sink = self._outcome_sink()
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop_resume(
                 context=self._create_context_snapshot(),
@@ -748,6 +769,7 @@ class Agent(Generic[TMessage]):
                 emit=lambda e: self._process_event(e),
                 checkpointer=self.checkpointer,
                 thread_id=self.thread_id,
+                set_outcome=sink,
             )
         )
 

--- a/cubepi/agent/loop.py
+++ b/cubepi/agent/loop.py
@@ -49,6 +49,7 @@ async def run_agent_loop(
     stream_options: StreamOptions | None = None,
     tool_execution: str = "parallel",
     system_prompt: str | None = None,
+    set_outcome: Callable[[str], None] | None = None,
 ) -> list[Message]:
     new_messages: list[Message] = list(prompts)
     current_context = AgentContext(
@@ -84,6 +85,7 @@ async def run_agent_loop(
         stream_options=stream_options,
         tool_execution=tool_execution,
         emit=emit,
+        set_outcome=set_outcome,
     )
     return new_messages
 
@@ -107,6 +109,7 @@ async def run_agent_loop_continue(
     stream_options: StreamOptions | None = None,
     tool_execution: str = "parallel",
     system_prompt: str | None = None,
+    set_outcome: Callable[[str], None] | None = None,
 ) -> list[Message]:
     if not context.messages:
         raise ValueError("Cannot continue: no messages in context")
@@ -142,6 +145,7 @@ async def run_agent_loop_continue(
         stream_options=stream_options,
         tool_execution=tool_execution,
         emit=emit,
+        set_outcome=set_outcome,
     )
     return new_messages
 
@@ -167,6 +171,7 @@ async def run_agent_loop_resume(
     system_prompt: str | None = None,
     checkpointer: Checkpointer | None = None,
     thread_id: str | None = None,
+    set_outcome: Callable[[str], None] | None = None,
 ) -> list[Message]:
     new_messages: list[Message] = []
 
@@ -192,15 +197,21 @@ async def run_agent_loop_resume(
             checkpointer=checkpointer,
             thread_id=thread_id,
             new_messages=new_messages,
+            set_outcome=set_outcome,
         )
-    except (HitlDetached, HitlAborted):  # pragma: no cover — E2E tested
-        # Same as _run_loop's outer catch: the Agent caller (Agent.detach /
-        # Agent.abort_pending) emitted the corresponding event already.
+    except HitlDetached:  # pragma: no cover — E2E tested
+        # The Agent caller (Agent.detach) emitted AgentSuspendedEvent already.
         # Loop exits silently — assistant message and pending state remain
-        # intact for the next respond() call. This catch covers the prelude
-        # (execute_tool_calls of the resumed tool batch) AND the fall-through
-        # to _run_loop, so a second HITL pause/abort during respond() also
-        # unwinds cleanly instead of escaping.
+        # intact for the next respond() call.
+        if set_outcome is not None:
+            set_outcome("suspended")
+        return new_messages
+    except HitlAborted:  # pragma: no cover — E2E tested
+        # The Agent caller (Agent.abort_pending) emitted AgentAbortedEvent
+        # already. Loop exits silently — synthetic deny + terminal aborted
+        # assistant message already appended by abort_pending.
+        if set_outcome is not None:
+            set_outcome("abandoned")
         return new_messages
 
 
@@ -226,6 +237,7 @@ async def _run_agent_loop_resume_body(  # pragma: no cover — E2E tested
     checkpointer,
     thread_id,
     new_messages: list,
+    set_outcome: Callable[[str], None] | None = None,
 ) -> list[Message]:
     from cubepi.hitl.exceptions import HitlInconsistentState
 
@@ -345,11 +357,15 @@ async def _run_agent_loop_resume_body(  # pragma: no cover — E2E tested
         )
         if await should_stop_after_turn(stop_ctx):
             await emit_event(emit, AgentEndEvent(messages=new_messages))
+            if set_outcome is not None:
+                set_outcome("complete")
             return new_messages
 
     # Terminate-by-tool semantics (codex BLOCKING: previous draft ignored).
     if terminated_by_tool:
         await emit_event(emit, AgentEndEvent(messages=new_messages))
+        if set_outcome is not None:
+            set_outcome("complete")
         return new_messages
 
     # Fall through to the normal loop for the next model turn.
@@ -371,6 +387,7 @@ async def _run_agent_loop_resume_body(  # pragma: no cover — E2E tested
         stream_options=stream_options,
         tool_execution=tool_execution,
         emit=emit,
+        set_outcome=set_outcome,
     )
     return new_messages
 
@@ -394,6 +411,7 @@ async def _run_loop(
     stream_options: StreamOptions | None,
     tool_execution: str,
     emit: Callable,
+    set_outcome: Callable[[str], None] | None = None,
 ) -> None:
     try:
         await _run_loop_inner(
@@ -414,16 +432,21 @@ async def _run_loop(
             stream_options=stream_options,
             tool_execution=tool_execution,
             emit=emit,
+            set_outcome=set_outcome,
         )
-    except (HitlDetached, HitlAborted):
-        # Per the spec design, HITL terminal events (AgentSuspendedEvent /
-        # AgentAbortedEvent) are emitted by the Agent layer (Agent.detach()
-        # / Agent.abort_pending()) BEFORE these exceptions are raised — they
-        # are mutually exclusive with AgentEndEvent. The loop intentionally
-        # exits silently here: emitting AgentEndEvent would double-signal
-        # termination to event-stream consumers who already saw the HITL
-        # event. Assistant message and pending state remain intact for the
-        # next respond() call.
+    except HitlDetached:
+        # AgentSuspendedEvent already emitted by Agent.detach() — exit silently
+        # so AgentEndEvent doesn't double-signal termination. Assistant message
+        # and pending state remain intact for the next respond() call.
+        if set_outcome is not None:
+            set_outcome("suspended")
+        return
+    except HitlAborted:
+        # AgentAbortedEvent already emitted by Agent.abort_pending() — exit
+        # silently. Synthetic deny + terminal aborted assistant message are
+        # already appended; conversation is closed.
+        if set_outcome is not None:
+            set_outcome("abandoned")
         return
 
 
@@ -446,6 +469,7 @@ async def _run_loop_inner(
     stream_options: StreamOptions | None,
     tool_execution: str,
     emit: Callable,
+    set_outcome: Callable[[str], None] | None = None,
 ) -> None:
     opts = stream_options or StreamOptions()
     first_turn = True
@@ -487,6 +511,8 @@ async def _run_loop_inner(
                 await emit_event(emit, MessageEndEvent(message=message))
                 await emit_event(emit, TurnEndEvent(message=message, tool_results=[]))
                 await emit_event(emit, AgentEndEvent(messages=new_messages))
+                if set_outcome is not None:
+                    set_outcome("abandoned")
                 return
 
             # Apply after_model_response hook if configured.
@@ -664,6 +690,8 @@ async def _run_loop_inner(
         break
 
     await emit_event(emit, AgentEndEvent(messages=new_messages))
+    if set_outcome is not None:
+        set_outcome("complete")
 
 
 async def _stream_assistant_response(

--- a/cubepi/agent/types.py
+++ b/cubepi/agent/types.py
@@ -6,6 +6,7 @@ from typing import Awaitable, Callable, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
 
+from cubepi.hitl.binding import HitlBinding
 from cubepi.hitl.types import HitlRequest
 from cubepi.providers.base import (
     AssistantMessage,
@@ -38,6 +39,7 @@ class AgentTool(Generic[TParams]):
     label: str = ""
     execution_mode: Literal["sequential", "parallel"] | None = None
     hitl_builtin: bool = False
+    hitl: HitlBinding | None = None
 
     def to_definition(self) -> ToolDefinition:
         schema = self.parameters.model_json_schema()

--- a/cubepi/agent/types.py
+++ b/cubepi/agent/types.py
@@ -218,3 +218,10 @@ AgentEvent = (
 AgentEventSink = Callable[[AgentEvent], Awaitable[None]]
 
 AgentListener = Callable[[AgentEvent, asyncio.Event | None], Awaitable[None] | None]
+
+
+@dataclass(frozen=True)
+class ForkOnceResult:
+    text: str
+    messages: list[Message]
+    stop_reason: str

--- a/cubepi/checkpointer/base.py
+++ b/cubepi/checkpointer/base.py
@@ -12,6 +12,7 @@ from cubepi.types import JsonObject
 class CheckpointData:
     messages: list[Message] = field(default_factory=list)
     extra: JsonObject = field(default_factory=dict)
+    parent_thread_id: str | None = None
 
 
 @runtime_checkable

--- a/cubepi/checkpointer/base.py
+++ b/cubepi/checkpointer/base.py
@@ -42,3 +42,53 @@ class Checkpointer(Protocol):
         Returns a ``HitlRequest`` instance or ``None``.
         """
         ...
+
+    async def snapshot(
+        self, thread_id: str, *, after_run_id: str
+    ) -> list[Message]:
+        """Return messages of completed runs of `thread_id` up through
+        and including `after_run_id`, in source seq order. Raises
+        ThreadNotFoundError or RunNotCompletedError."""
+        ...
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        after_run_id: str,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        """Atomically physical-copy messages of completed runs up
+        through `after_run_id` from src to new. See spec §3.2 / §3.4."""
+        ...
+
+    async def claim_run(
+        self,
+        thread_id: str,
+        run_id: str,
+    ) -> None:
+        """Insert cubepi_runs row with claimed_at=now, completed_at=NULL.
+        Lazily creates the threads row if needed. Raises
+        RunAlreadyClaimedError or RunAlreadyCompletedError on PK
+        conflict (distinguished by completed_at IS NULL/NOT NULL)."""
+        ...
+
+    async def mark_run_complete(
+        self,
+        thread_id: str,
+        run_id: str,
+    ) -> None:
+        """Allocate next per-thread completion_seq; UPDATE the run row.
+        Idempotent on already-completed rows (does NOT raise
+        RunAlreadyCompletedError). Raises RunNotClaimedError when no
+        row exists."""
+        ...
+
+    async def load_pending(
+        self,
+        thread_id: str,
+    ) -> tuple[HitlRequest, str | None] | None:
+        """Read (HitlRequest, run_id) atomically from the pending row,
+        or None when no pending request exists."""
+        ...

--- a/cubepi/checkpointer/base.py
+++ b/cubepi/checkpointer/base.py
@@ -43,9 +43,7 @@ class Checkpointer(Protocol):
         """
         ...
 
-    async def snapshot(
-        self, thread_id: str, *, after_run_id: str
-    ) -> list[Message]:
+    async def snapshot(self, thread_id: str, *, after_run_id: str) -> list[Message]:
         """Return messages of completed runs of `thread_id` up through
         and including `after_run_id`, in source seq order. Raises
         ThreadNotFoundError or RunNotCompletedError."""

--- a/cubepi/checkpointer/exceptions.py
+++ b/cubepi/checkpointer/exceptions.py
@@ -32,3 +32,70 @@ class CubepiSchemaMismatch(CubepiSchemaError):
         super().__init__(msg)
         self.expected = expected
         self.actual = actual
+
+
+class CheckpointerError(Exception):
+    """Base class for cubepi checkpointer runtime errors.
+
+    Distinct from ``CubepiSchemaError`` (schema-vs-library incompatibility).
+    ``CheckpointerError`` covers runtime operation outcomes — missing
+    thread, lock timeout, run state, etc.
+    """
+
+
+class ThreadNotFoundError(CheckpointerError):
+    pass
+
+
+class ThreadAlreadyExistsError(CheckpointerError):
+    pass
+
+
+class RunNotCompletedError(CheckpointerError):
+    """The cubepi_runs row for (thread_id, run_id) does not exist, or
+    exists with completed_at IS NULL (paused, abandoned, or in flight)."""
+
+
+class RunNotClaimedError(CheckpointerError):
+    """mark_run_complete() called but no cubepi_runs row exists for
+    (thread_id, run_id). Indicates an agent-loop logic bug."""
+
+
+class RunAlreadyClaimedError(CheckpointerError):
+    """claim_run() found an existing row with completed_at IS NULL.
+    Another process is currently running this run_id; retry with a
+    different run_id."""
+
+
+class RunAlreadyCompletedError(CheckpointerError):
+    """claim_run() found an existing row with completed_at IS NOT NULL.
+    Runs are append-only; start a new run with a different run_id.
+
+    NOT raised by mark_run_complete() — that path is idempotent on
+    already-completed rows (spec §3.6.2).
+    """
+
+
+class CheckpointerLockTimeoutError(CheckpointerError):
+    """Backend writer lock not acquired within the configured timeout
+    (SQLite busy_timeout, etc.)."""
+
+
+class CompletionMarkerFailedError(CheckpointerError):
+    """mark_run_complete() failed AFTER the run's final append succeeded.
+    Carries `run_id` so callers using prompt(run_id=None) can recover
+    the cubepi-generated value (spec §3.6.2)."""
+
+    def __init__(
+        self,
+        *,
+        thread_id: str,
+        run_id: str,
+        cause: BaseException,
+    ) -> None:
+        super().__init__(
+            f"mark_run_complete failed for ({thread_id}, {run_id}): {cause}"
+        )
+        self.thread_id = thread_id
+        self.run_id = run_id
+        self.__cause__ = cause

--- a/cubepi/checkpointer/exceptions.py
+++ b/cubepi/checkpointer/exceptions.py
@@ -1,8 +1,12 @@
-"""Backend-agnostic schema exceptions for SQL checkpointers.
+"""Checkpointer exceptions — schema errors and runtime operation errors.
 
-Shared by the Postgres and MySQL checkpointers so that ``except
-CubepiSchemaError`` works across backends and neither backend's package
-(and its driver) needs to be imported to obtain them.
+*Schema errors* (``CubepiSchemaError`` hierarchy): shared by the Postgres
+and MySQL checkpointers so that ``except CubepiSchemaError`` works across
+backends without importing either driver.
+
+*Runtime errors* (``CheckpointerError`` hierarchy): backend-agnostic
+operation outcomes — missing thread, run-state conflicts, lock timeout,
+completion-marker failure.
 """
 
 
@@ -44,11 +48,11 @@ class CheckpointerError(Exception):
 
 
 class ThreadNotFoundError(CheckpointerError):
-    pass
+    """No cubepi thread row exists for the given thread_id."""
 
 
 class ThreadAlreadyExistsError(CheckpointerError):
-    pass
+    """A cubepi thread row already exists for thread_id."""
 
 
 class RunNotCompletedError(CheckpointerError):
@@ -99,3 +103,4 @@ class CompletionMarkerFailedError(CheckpointerError):
         self.thread_id = thread_id
         self.run_id = run_id
         self.__cause__ = cause
+        self.__suppress_context__ = True

--- a/cubepi/checkpointer/memory.py
+++ b/cubepi/checkpointer/memory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import time
 from dataclasses import dataclass
 
@@ -9,6 +10,9 @@ from cubepi.checkpointer.exceptions import (
     RunAlreadyClaimedError,
     RunAlreadyCompletedError,
     RunNotClaimedError,
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
 )
 from cubepi.hitl.types import HitlRequest
 from cubepi.providers.base import Message
@@ -20,6 +24,10 @@ class _RunState:
     claimed_at: float
     completed_at: float | None = None
     completion_seq: int | None = None
+
+
+def _legible_message_copy(m: Message) -> Message:
+    return m.model_copy(deep=True)
 
 
 class MemoryCheckpointer:
@@ -112,3 +120,81 @@ class MemoryCheckpointer:
             next_seq = max(existing_seqs, default=0) + 1
             state.completed_at = time.time()
             state.completion_seq = next_seq
+
+    async def snapshot(self, thread_id: str, *, after_run_id: str) -> list[Message]:
+        async with self._lock:
+            data = self._store.get(thread_id)
+            if data is None and thread_id not in self._runs:
+                raise ThreadNotFoundError(f"thread={thread_id}")
+            runs = self._runs.get(thread_id, {})
+            cutoff_state = runs.get(after_run_id)
+            if cutoff_state is None or cutoff_state.completion_seq is None:
+                raise RunNotCompletedError(
+                    f"thread={thread_id} run={after_run_id} not completed"
+                )
+            cutoff = cutoff_state.completion_seq
+            selected: list[Message] = []
+            for m in data.messages if data else []:
+                if m.run_id is None:
+                    selected.append(_legible_message_copy(m))
+                    continue
+                rs = runs.get(m.run_id)
+                if rs is None or rs.completion_seq is None:
+                    continue
+                if rs.completion_seq <= cutoff:
+                    selected.append(_legible_message_copy(m))
+            return selected
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        after_run_id: str,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        async with self._lock:
+            if new_thread_id in self._store or new_thread_id in self._runs:
+                raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+            src_data = self._store.get(src_thread_id)
+            src_runs = self._runs.get(src_thread_id, {})
+            if src_data is None and not src_runs:
+                raise ThreadNotFoundError(f"thread={src_thread_id}")
+            cutoff_state = src_runs.get(after_run_id)
+            if cutoff_state is None or cutoff_state.completion_seq is None:
+                raise RunNotCompletedError(
+                    f"thread={src_thread_id} run={after_run_id} not completed"
+                )
+            cutoff = cutoff_state.completion_seq
+            # Select messages.
+            new_messages: list[Message] = []
+            for m in src_data.messages if src_data else []:
+                if m.run_id is None:
+                    new_messages.append(_legible_message_copy(m))
+                    continue
+                rs = src_runs.get(m.run_id)
+                if rs is None or rs.completion_seq is None:
+                    continue
+                if rs.completion_seq <= cutoff:
+                    new_messages.append(_legible_message_copy(m))
+            # Deep copy extra and merge metadata.
+            base_extra = copy.deepcopy(src_data.extra if src_data else {})
+            if metadata is not None:
+                base_extra["fork"] = copy.deepcopy(metadata)
+            # Carry completed runs satisfying cutoff.
+            new_runs: dict[str, _RunState] = {}
+            for rid, state in src_runs.items():
+                if state.completion_seq is None:
+                    continue
+                if state.completion_seq <= cutoff:
+                    new_runs[rid] = _RunState(
+                        claimed_at=state.claimed_at,
+                        completed_at=state.completed_at,
+                        completion_seq=state.completion_seq,
+                    )
+            self._store[new_thread_id] = CheckpointData(
+                messages=new_messages,
+                extra=base_extra,
+                parent_thread_id=src_thread_id,
+            )
+            self._runs[new_thread_id] = new_runs

--- a/cubepi/checkpointer/memory.py
+++ b/cubepi/checkpointer/memory.py
@@ -1,31 +1,57 @@
 from __future__ import annotations
 
+import asyncio
+import time
+from dataclasses import dataclass
+
 from cubepi.checkpointer.base import CheckpointData
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+)
 from cubepi.hitl.types import HitlRequest
 from cubepi.providers.base import Message
 from cubepi.types import JsonObject
+
+
+@dataclass
+class _RunState:
+    claimed_at: float
+    completed_at: float | None = None
+    completion_seq: int | None = None
 
 
 class MemoryCheckpointer:
     def __init__(self) -> None:
         self._store: dict[str, CheckpointData] = {}
         self._pending: dict[str, HitlRequest] = {}
-        # run_id slot, persisted alongside _pending. Cleared together with
-        # the pending request so clear-pending implicitly clears run_id.
         self._pending_run_id: dict[str, str | None] = {}
+        self._runs: dict[str, dict[str, _RunState]] = {}
+        self._lock = asyncio.Lock()
 
     async def load(self, thread_id: str) -> CheckpointData | None:
         return self._store.get(thread_id)
 
     async def append(self, thread_id: str, messages: list[Message]) -> None:
-        if thread_id not in self._store:
-            self._store[thread_id] = CheckpointData()
-        self._store[thread_id].messages.extend(messages)
+        async with self._lock:
+            for m in messages:
+                if m.run_id is None:
+                    continue
+                rs = self._runs.get(thread_id, {}).get(m.run_id)
+                if rs is not None and rs.completed_at is not None:
+                    raise RunAlreadyCompletedError(
+                        f"append on completed run thread={thread_id} run={m.run_id}"
+                    )
+            if thread_id not in self._store:
+                self._store[thread_id] = CheckpointData()
+            self._store[thread_id].messages.extend(messages)
 
     async def save_extra(self, thread_id: str, extra: JsonObject) -> None:
-        if thread_id not in self._store:
-            self._store[thread_id] = CheckpointData()
-        self._store[thread_id].extra.update(extra)
+        async with self._lock:
+            if thread_id not in self._store:
+                self._store[thread_id] = CheckpointData()
+            self._store[thread_id].extra.update(extra)
 
     async def save_pending_request(
         self,
@@ -34,15 +60,55 @@ class MemoryCheckpointer:
         *,
         run_id: str | None = None,
     ) -> None:
-        if request is None:
-            self._pending.pop(thread_id, None)
-            self._pending_run_id.pop(thread_id, None)
-        else:
-            self._pending[thread_id] = request
-            self._pending_run_id[thread_id] = run_id
+        async with self._lock:
+            if request is None:
+                self._pending.pop(thread_id, None)
+                self._pending_run_id.pop(thread_id, None)
+            else:
+                self._pending[thread_id] = request
+                self._pending_run_id[thread_id] = run_id
 
     async def load_pending_request(self, thread_id: str) -> HitlRequest | None:
         return self._pending.get(thread_id)
 
     async def load_pending_run_id(self, thread_id: str) -> str | None:
         return self._pending_run_id.get(thread_id)
+
+    async def load_pending(
+        self, thread_id: str
+    ) -> tuple[HitlRequest, str | None] | None:
+        req = self._pending.get(thread_id)
+        if req is None:
+            return None
+        return req, self._pending_run_id.get(thread_id)
+
+    async def claim_run(self, thread_id: str, run_id: str) -> None:
+        async with self._lock:
+            runs = self._runs.setdefault(thread_id, {})
+            existing = runs.get(run_id)
+            if existing is not None:
+                if existing.completed_at is None:
+                    raise RunAlreadyClaimedError(
+                        f"thread={thread_id} run={run_id} in flight"
+                    )
+                raise RunAlreadyCompletedError(
+                    f"thread={thread_id} run={run_id} already completed"
+                )
+            runs[run_id] = _RunState(claimed_at=time.time())
+
+    async def mark_run_complete(self, thread_id: str, run_id: str) -> None:
+        async with self._lock:
+            runs = self._runs.get(thread_id) or {}
+            state = runs.get(run_id)
+            if state is None:
+                raise RunNotClaimedError(
+                    f"thread={thread_id} run={run_id} has no claim row"
+                )
+            if state.completed_at is not None:
+                return  # idempotent
+            existing_seqs = [
+                s.completion_seq for s in runs.values() if s.completion_seq is not None
+            ]
+            next_seq = max(existing_seqs, default=0) + 1
+            state.completed_at = time.time()
+            state.completion_seq = next_seq

--- a/cubepi/checkpointer/mysql/alembic_helpers.py
+++ b/cubepi/checkpointer/mysql/alembic_helpers.py
@@ -45,6 +45,90 @@ def add_run_id_column_op() -> str:
     return "ALTER TABLE cubepi_threads ADD COLUMN run_id VARCHAR(64) NULL"
 
 
+def runs_partition_clause() -> str:
+    """Return the KEY-partition clause for the cubepi_runs CREATE TABLE.
+
+    Mirrors ``messages_partition_clause()``: KEY-partitioning the runs
+    table by thread_id keeps each run's row colocated with its messages
+    on the same partition shard. KEY (not HASH) because thread_id is a
+    VARCHAR.
+    """
+    return f"PARTITION BY KEY (thread_id) PARTITIONS {PARTITION_COUNT}"
+
+
+def add_messages_run_id_column_op() -> str:
+    """Return SQL adding the v4 `run_id` column + composite index to
+    cubepi_messages.
+
+    Call inside the host's alembic v3→v4 upgrade() via op.execute(). The
+    helper returns two ';'-separated statements (ALTER then CREATE INDEX);
+    MySQL/pymysql executes a single statement per call, so split before
+    executing::
+
+        for stmt in add_messages_run_id_column_op().split(";"):
+            if stmt.strip():
+                op.execute(stmt)
+
+    MySQL does not support IF NOT EXISTS for ADD COLUMN; guard with a
+    schema check in the alembic migration if idempotence is required.
+    """
+    return (
+        "ALTER TABLE cubepi_messages ADD COLUMN run_id VARCHAR(255) NULL; "
+        "CREATE INDEX ix_cubepi_messages_thread_run "
+        "ON cubepi_messages (thread_id, run_id);"
+    )
+
+
+def create_runs_table_op() -> str:
+    """Return SQL creating the partitioned ``cubepi_runs`` parent table.
+
+    Call inside the host's alembic v3→v4 upgrade() via op.execute(). The
+    returned statement includes the KEY-partition clause inline. NO FK to
+    ``cubepi_threads`` — MySQL forbids FKs on partitioned tables.
+    """
+    return (
+        "CREATE TABLE cubepi_runs ("
+        "  thread_id VARCHAR(255) COLLATE utf8mb4_bin NOT NULL,"
+        "  run_id VARCHAR(255) NOT NULL,"
+        "  claimed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+        "  completed_at TIMESTAMP NULL,"
+        "  completion_seq BIGINT NULL,"
+        "  PRIMARY KEY (thread_id, run_id),"
+        "  KEY ix_cubepi_runs_thread_seq (thread_id, completion_seq)"
+        ") ENGINE=InnoDB " + runs_partition_clause()
+    )
+
+
+def create_runs_partitions_op() -> str:
+    """Return SQL extending the runs table with KEY partitions.
+
+    Provided for symmetry with the Postgres helper of the same name.
+    For MySQL, partitions are declared inline by ``create_runs_table_op()``
+    (the KEY clause specifies the partition count). This helper returns
+    only the partition clause for callers that want to attach it
+    separately, e.g. via ALTER.
+    """
+    return runs_partition_clause()
+
+
+def upgrade_v3_to_v4_op() -> str:
+    """Return SQL applying the v3→v4 schema changes.
+
+    Adds the ``run_id`` column + composite index to ``cubepi_messages``
+    and creates the partitioned ``cubepi_runs`` table. Hosts must also
+    bump ``cubepi_schema_version`` via ``write_schema_version_op()``
+    (EXPECTED_SCHEMA_VERSION is now 4).
+
+    Returns multiple ';'-separated statements; MySQL/pymysql executes one
+    per call, so split before executing::
+
+        for stmt in upgrade_v3_to_v4_op().split(";"):
+            if stmt.strip():
+                op.execute(stmt)
+    """
+    return f"{add_messages_run_id_column_op()} {create_runs_table_op()};"
+
+
 def write_schema_version_op() -> str:
     """Return SQL setting cubepi_schema_version to the current version.
 

--- a/cubepi/checkpointer/mysql/checkpointer.py
+++ b/cubepi/checkpointer/mysql/checkpointer.py
@@ -21,6 +21,9 @@ from cubepi.checkpointer.exceptions import (
     RunAlreadyClaimedError,
     RunAlreadyCompletedError,
     RunNotClaimedError,
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
 )
 from cubepi.checkpointer.mysql.exceptions import (
     CubepiSchemaMismatch,
@@ -179,7 +182,8 @@ class MySQLCheckpointer:
                 )
                 msg_rows = await cur.fetchall()
                 await cur.execute(
-                    "SELECT extra FROM cubepi_threads WHERE thread_id = %s",
+                    "SELECT extra, parent_thread_id FROM cubepi_threads "
+                    "WHERE thread_id = %s",
                     (thread_id,),
                 )
                 extra_row = await cur.fetchone()
@@ -196,8 +200,15 @@ class MySQLCheckpointer:
             data["metadata"] = _decode_json(metadata)
             messages.append(cls.model_validate(data))
 
-        extra = _decode_json(extra_row[0]) if extra_row is not None else {}
-        return CheckpointData(messages=messages, extra=extra)
+        parent_thread_id: str | None = None
+        if extra_row is not None:
+            extra = _decode_json(extra_row[0])
+            parent_thread_id = extra_row[1]
+        else:
+            extra = {}
+        return CheckpointData(
+            messages=messages, extra=extra, parent_thread_id=parent_thread_id
+        )
 
     async def append(self, thread_id: str, messages: list[Message]) -> None:
         if not messages:
@@ -400,6 +411,171 @@ class MySQLCheckpointer:
         else:
             req = HitlRequest.model_validate(raw)
         return req, row[1]
+
+    async def snapshot(self, thread_id: str, *, after_run_id: str) -> list[Message]:
+        """Return the message slice that fork() would copy, without writing.
+
+        Includes legacy messages with NULL ``run_id`` plus messages whose
+        ``run_id`` belongs to a completed run at or before
+        ``after_run_id``'s completion cutoff. Raises ``ThreadNotFoundError``
+        if the source thread row is absent, or ``RunNotCompletedError`` if
+        ``after_run_id`` has not yet been completion-marked.
+        """
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT 1 FROM cubepi_threads WHERE thread_id = %s",
+                    (thread_id,),
+                )
+                if await cur.fetchone() is None:
+                    raise ThreadNotFoundError(f"thread={thread_id}")
+                await cur.execute(
+                    "SELECT completion_seq FROM cubepi_runs "
+                    "WHERE thread_id = %s AND run_id = %s",
+                    (thread_id, after_run_id),
+                )
+                cutoff_row = await cur.fetchone()
+                if cutoff_row is None or cutoff_row[0] is None:
+                    raise RunNotCompletedError(
+                        f"thread={thread_id} run={after_run_id} not completed"
+                    )
+                cutoff = cutoff_row[0]
+                await cur.execute(
+                    "SELECT seq, role, metadata, payload FROM cubepi_messages "
+                    "WHERE thread_id = %s AND ("
+                    "  run_id IS NULL OR run_id IN ("
+                    "    SELECT run_id FROM cubepi_runs "
+                    "    WHERE thread_id = %s "
+                    "    AND completion_seq IS NOT NULL "
+                    "    AND completion_seq <= %s"
+                    "  )"
+                    ") ORDER BY seq",
+                    (thread_id, thread_id, cutoff),
+                )
+                rows = await cur.fetchall()
+        messages: list[Message] = []
+        for _seq, role, metadata, payload in rows:
+            cls = _ROLE_TO_CLS.get(role)
+            if cls is None:
+                raise ValueError(f"unknown role in DB: {role!r}")
+            data = msgpack.unpackb(bytes(payload), raw=False)
+            data["metadata"] = _decode_json(metadata)
+            messages.append(cls.model_validate(data))
+        return messages
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        after_run_id: str,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        """Copy completed prefix of ``src_thread_id`` into ``new_thread_id``.
+
+        Threads-row first: the destination ``cubepi_threads`` row is
+        inserted before the message + runs copies so callers see a
+        complete view if they probe mid-fork. There is no cubepi_runs ->
+        cubepi_threads FK on MySQL (partition limitation), but we keep
+        the same ordering for semantic parity with Postgres.
+
+        Per-thread serialization: a ``SELECT … FOR UPDATE`` on the source
+        thread row fences concurrent forks/appends — without it, an
+        append racing the fork could leak a partial in-flight run into
+        the destination.
+        """
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            await conn.begin()
+            try:
+                async with conn.cursor() as cur:
+                    # Per-thread fence on the source thread.
+                    await cur.execute(
+                        "SELECT thread_id FROM cubepi_threads "
+                        "WHERE thread_id = %s FOR UPDATE",
+                        (src_thread_id,),
+                    )
+                    if await cur.fetchone() is None:
+                        raise ThreadNotFoundError(f"thread={src_thread_id}")
+                    # Destination must not exist.
+                    await cur.execute(
+                        "SELECT 1 FROM cubepi_threads WHERE thread_id = %s",
+                        (new_thread_id,),
+                    )
+                    if await cur.fetchone() is not None:
+                        raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+                    # Cutoff: after_run_id must be completed on src.
+                    await cur.execute(
+                        "SELECT completion_seq FROM cubepi_runs "
+                        "WHERE thread_id = %s AND run_id = %s",
+                        (src_thread_id, after_run_id),
+                    )
+                    cutoff_row = await cur.fetchone()
+                    if cutoff_row is None or cutoff_row[0] is None:
+                        raise RunNotCompletedError(
+                            f"thread={src_thread_id} run={after_run_id} not completed"
+                        )
+                    cutoff = cutoff_row[0]
+                    # Build merged extra (carry parent's extra + fork metadata).
+                    await cur.execute(
+                        "SELECT extra FROM cubepi_threads WHERE thread_id = %s",
+                        (src_thread_id,),
+                    )
+                    extra_row = await cur.fetchone()
+                    base_extra = (
+                        _decode_json(extra_row[0]) if extra_row is not None else {}
+                    )
+                    if metadata is not None:
+                        # Round-trip through json to coerce to plain JSON types.
+                        base_extra["fork"] = json.loads(json.dumps(metadata))
+                    # INSERT destination threads row first (semantic parity
+                    # with the Postgres FK-driven ordering, even though MySQL
+                    # has no FK on the partitioned messages/runs tables).
+                    await cur.execute(
+                        "INSERT INTO cubepi_threads "
+                        "(thread_id, parent_thread_id, forked_at_seq, extra) "
+                        "VALUES (%s, %s, %s, %s)",
+                        (
+                            new_thread_id,
+                            src_thread_id,
+                            cutoff,
+                            json.dumps(base_extra),
+                        ),
+                    )
+                    # Copy messages: legacy NULL run_id OR completed-at-cutoff.
+                    await cur.execute(
+                        "INSERT INTO cubepi_messages "
+                        "(thread_id, seq, role, metadata, payload, run_id) "
+                        "SELECT %s, seq, role, metadata, payload, run_id "
+                        "FROM cubepi_messages "
+                        "WHERE thread_id = %s AND ("
+                        "  run_id IS NULL OR run_id IN ("
+                        "    SELECT run_id FROM cubepi_runs "
+                        "    WHERE thread_id = %s "
+                        "    AND completion_seq IS NOT NULL "
+                        "    AND completion_seq <= %s"
+                        "  )"
+                        ") ORDER BY seq",
+                        (new_thread_id, src_thread_id, src_thread_id, cutoff),
+                    )
+                    # Copy completed runs satisfying the cutoff.
+                    await cur.execute(
+                        "INSERT INTO cubepi_runs "
+                        "(thread_id, run_id, claimed_at, completed_at, "
+                        " completion_seq) "
+                        "SELECT %s, run_id, claimed_at, completed_at, "
+                        "       completion_seq "
+                        "FROM cubepi_runs "
+                        "WHERE thread_id = %s "
+                        "AND completion_seq IS NOT NULL "
+                        "AND completion_seq <= %s",
+                        (new_thread_id, src_thread_id, cutoff),
+                    )
+                await conn.commit()
+            except BaseException:
+                await conn.rollback()
+                raise
 
     async def save_extra(self, thread_id: str, extra: JsonObject) -> None:
         assert self._pool is not None

--- a/cubepi/checkpointer/mysql/checkpointer.py
+++ b/cubepi/checkpointer/mysql/checkpointer.py
@@ -17,6 +17,11 @@ import msgpack
 import pymysql
 
 from cubepi.checkpointer.base import CheckpointData
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+)
 from cubepi.checkpointer.mysql.exceptions import (
     CubepiSchemaMismatch,
     CubepiSchemaUninitialized,
@@ -198,6 +203,9 @@ class MySQLCheckpointer:
         if not messages:
             return
         assert self._pool is not None
+        run_ids = {
+            rid for m in messages if (rid := getattr(m, "run_id", None)) is not None
+        }
         async with self._pool.acquire() as conn:
             await conn.begin()
             try:
@@ -216,6 +224,22 @@ class MySQLCheckpointer:
                         "WHERE thread_id = %s FOR UPDATE",
                         (thread_id,),
                     )
+                    # Pre-flight: reject append on any completed run_id.
+                    if run_ids:
+                        placeholders = ", ".join(["%s"] * len(run_ids))
+                        await cur.execute(
+                            f"SELECT run_id FROM cubepi_runs "
+                            f"WHERE thread_id = %s "
+                            f"AND run_id IN ({placeholders}) "
+                            f"AND completed_at IS NOT NULL",
+                            (thread_id, *run_ids),
+                        )
+                        done_rows = await cur.fetchall()
+                        if done_rows:
+                            bad = ", ".join(r[0] for r in done_rows)
+                            raise RunAlreadyCompletedError(
+                                f"append on completed run thread={thread_id} runs={bad}"
+                            )
                     await cur.execute(
                         "SELECT COALESCE(MAX(seq), 0) FROM cubepi_messages "
                         "WHERE thread_id = %s",
@@ -235,18 +259,147 @@ class MySQLCheckpointer:
                                 _role_of(m),
                                 json.dumps(m.metadata),
                                 payload,
+                                getattr(m, "run_id", None),
                             )
                         )
                     await cur.executemany(
                         "INSERT INTO cubepi_messages "
-                        "(thread_id, seq, role, metadata, payload) "
-                        "VALUES (%s, %s, %s, %s, %s)",
+                        "(thread_id, seq, role, metadata, payload, run_id) "
+                        "VALUES (%s, %s, %s, %s, %s, %s)",
                         rows,
                     )
                 await conn.commit()
-            except BaseException:  # pragma: no cover - defensive txn rollback
+            except BaseException:
                 await conn.rollback()
                 raise
+
+    async def claim_run(self, thread_id: str, run_id: str) -> None:
+        """Atomically claim a run_id on a thread.
+
+        Lazy-creates the cubepi_threads row, takes a per-thread FOR UPDATE
+        lock to serialize concurrent claims for the same thread, then
+        checks cubepi_runs for an existing row before inserting. The
+        pre-check matches the Postgres approach — using INSERT + catching
+        IntegrityError would also work, but a pre-SELECT lets us
+        distinguish in-flight vs completed cleanly without relying on the
+        error-class taxonomy.
+        """
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            await conn.begin()
+            try:
+                async with conn.cursor() as cur:
+                    # Lazy thread row creation (claim may precede any append).
+                    await cur.execute(
+                        "INSERT INTO cubepi_threads (thread_id) VALUES (%s) "
+                        "ON DUPLICATE KEY UPDATE thread_id = thread_id",
+                        (thread_id,),
+                    )
+                    # Per-thread fence: serializes claim_run/append/fork on
+                    # the same thread (matches Postgres's pg_advisory_xact_lock).
+                    await cur.execute(
+                        "SELECT thread_id FROM cubepi_threads "
+                        "WHERE thread_id = %s FOR UPDATE",
+                        (thread_id,),
+                    )
+                    await cur.execute(
+                        "SELECT completed_at FROM cubepi_runs "
+                        "WHERE thread_id = %s AND run_id = %s",
+                        (thread_id, run_id),
+                    )
+                    row = await cur.fetchone()
+                    if row is not None:
+                        if row[0] is not None:
+                            raise RunAlreadyCompletedError(
+                                f"thread={thread_id} run={run_id} already completed"
+                            )
+                        raise RunAlreadyClaimedError(
+                            f"thread={thread_id} run={run_id} in flight"
+                        )
+                    await cur.execute(
+                        "INSERT INTO cubepi_runs (thread_id, run_id) VALUES (%s, %s)",
+                        (thread_id, run_id),
+                    )
+                await conn.commit()
+            except BaseException:
+                await conn.rollback()
+                raise
+
+    async def mark_run_complete(self, thread_id: str, run_id: str) -> None:
+        """Mark (thread_id, run_id) complete with a monotonic completion_seq.
+
+        Idempotent: a second call on an already-completed row is a no-op.
+        Raises ``RunNotClaimedError`` if no claim row exists. The
+        completion_seq is the per-thread MAX(completion_seq) + 1, allocated
+        under the same per-thread FOR UPDATE fence as claim_run/append.
+        """
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            await conn.begin()
+            try:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        "SELECT thread_id FROM cubepi_threads "
+                        "WHERE thread_id = %s FOR UPDATE",
+                        (thread_id,),
+                    )
+                    await cur.execute(
+                        "SELECT completed_at FROM cubepi_runs "
+                        "WHERE thread_id = %s AND run_id = %s",
+                        (thread_id, run_id),
+                    )
+                    row = await cur.fetchone()
+                    if row is None:
+                        raise RunNotClaimedError(
+                            f"thread={thread_id} run={run_id} has no claim row"
+                        )
+                    if row[0] is not None:
+                        await conn.commit()
+                        return  # idempotent success
+                    await cur.execute(
+                        "SELECT COALESCE(MAX(completion_seq), 0) + 1 "
+                        "FROM cubepi_runs WHERE thread_id = %s "
+                        "AND completion_seq IS NOT NULL",
+                        (thread_id,),
+                    )
+                    (next_seq,) = await cur.fetchone()
+                    await cur.execute(
+                        "UPDATE cubepi_runs SET completed_at = CURRENT_TIMESTAMP, "
+                        "completion_seq = %s "
+                        "WHERE thread_id = %s AND run_id = %s",
+                        (next_seq, thread_id, run_id),
+                    )
+                await conn.commit()
+            except BaseException:
+                await conn.rollback()
+                raise
+
+    async def load_pending(
+        self, thread_id: str
+    ) -> tuple[HitlRequest, str | None] | None:
+        """Return the thread's pending HITL request + the owning run_id.
+
+        Single SELECT covers both columns (vs. ``load_pending_request`` +
+        ``load_pending_run_id``, which incur two round trips and can race
+        across a clear/set window). Returns None when no pending exists.
+        """
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "SELECT pending_request, run_id FROM cubepi_threads "
+                    "WHERE thread_id = %s",
+                    (thread_id,),
+                )
+                row = await cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        raw = row[0]
+        if isinstance(raw, str):
+            req = HitlRequest.model_validate_json(raw)
+        else:
+            req = HitlRequest.model_validate(raw)
+        return req, row[1]
 
     async def save_extra(self, thread_id: str, extra: JsonObject) -> None:
         assert self._pool is not None

--- a/cubepi/checkpointer/mysql/models.py
+++ b/cubepi/checkpointer/mysql/models.py
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.mysql import JSON, LONGBLOB, VARCHAR
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-EXPECTED_SCHEMA_VERSION = 3
+EXPECTED_SCHEMA_VERSION = 4
 PARTITION_COUNT = 64
 
 cubepi_metadata = sa.MetaData()
@@ -73,7 +73,10 @@ class CubepiThread(CubepiBase):
 
 class CubepiMessage(CubepiBase):
     __tablename__ = "cubepi_messages"
-    __table_args__ = {"mysql_engine": "InnoDB"}
+    __table_args__ = (
+        sa.Index("ix_cubepi_messages_thread_run", "thread_id", "run_id"),
+        {"mysql_engine": "InnoDB"},
+    )
 
     thread_id: Mapped[str] = mapped_column(_TID, primary_key=True)
     seq: Mapped[int] = mapped_column(sa.BigInteger, primary_key=True)
@@ -87,11 +90,49 @@ class CubepiMessage(CubepiBase):
         server_default=sa.text("(JSON_OBJECT())"),
     )
     payload: Mapped[bytes] = mapped_column(LONGBLOB, nullable=False)
+    # v4: opaque host-side run identifier stamped on each message. Lets
+    # fork/snapshot include only messages from completed runs. VARCHAR(255)
+    # to match the cubepi_messages indexing convention (thread_id is also
+    # VARCHAR(255) — keeps the composite index cardinality consistent).
+    run_id: Mapped[str | None] = mapped_column(
+        VARCHAR(255),
+        nullable=True,
+    )
     created_at: Mapped[_dt.datetime] = mapped_column(
         sa.TIMESTAMP,
         nullable=False,
         server_default=sa.text("CURRENT_TIMESTAMP"),
     )
+
+
+class CubepiRun(CubepiBase):
+    """v4 per-run lifecycle row.
+
+    Primary key (thread_id, run_id). KEY-partitioned by thread_id to match
+    cubepi_messages. NO FK to cubepi_threads — MySQL forbids FKs on
+    partitioned tables. The partition clause cannot be expressed in
+    SQLAlchemy declarative and lives in
+    ``alembic_helpers.runs_partition_clause()``.
+    """
+
+    __tablename__ = "cubepi_runs"
+    __table_args__ = (
+        sa.Index("ix_cubepi_runs_thread_seq", "thread_id", "completion_seq"),
+        {"mysql_engine": "InnoDB"},
+    )
+
+    thread_id: Mapped[str] = mapped_column(_TID, primary_key=True)
+    run_id: Mapped[str] = mapped_column(VARCHAR(255), primary_key=True)
+    claimed_at: Mapped[_dt.datetime] = mapped_column(
+        sa.TIMESTAMP,
+        nullable=False,
+        server_default=sa.text("CURRENT_TIMESTAMP"),
+    )
+    completed_at: Mapped[_dt.datetime | None] = mapped_column(
+        sa.TIMESTAMP,
+        nullable=True,
+    )
+    completion_seq: Mapped[int | None] = mapped_column(sa.BigInteger, nullable=True)
 
 
 class CubepiSchemaVersion(CubepiBase):

--- a/cubepi/checkpointer/postgres/alembic_helpers.py
+++ b/cubepi/checkpointer/postgres/alembic_helpers.py
@@ -41,6 +41,58 @@ def add_run_id_column_op() -> str:
     return "ALTER TABLE cubepi_threads ADD COLUMN IF NOT EXISTS run_id TEXT"
 
 
+def create_runs_partitions_op() -> str:
+    """Return SQL DDL creating all child partitions of cubepi_runs.
+
+    Call inside an alembic upgrade() via op.execute(), AFTER the parent
+    cubepi_runs partitioned table has been created. Uses the same
+    PARTITION_COUNT as cubepi_messages.
+    """
+    return "\n".join(
+        f"CREATE TABLE cubepi_runs_p{i:02d} "
+        f"PARTITION OF cubepi_runs "
+        f"FOR VALUES WITH (modulus {PARTITION_COUNT}, remainder {i});"
+        for i in range(PARTITION_COUNT)
+    )
+
+
+def upgrade_v3_to_v4_op() -> str:
+    """Return SQL applying the v3→v4 schema changes.
+
+    Adds the `run_id` column + index to `cubepi_messages` and creates
+    the partitioned `cubepi_runs` parent table with its child
+    partitions. Hosts must also bump `cubepi_schema_version` via
+    write_schema_version_op() (EXPECTED_SCHEMA_VERSION is now 4).
+
+    Call inside the host's alembic v3→v4 upgrade() via op.execute().
+    Idempotent under repeated execution via IF NOT EXISTS guards.
+    """
+    parts = [
+        "ALTER TABLE cubepi_messages ADD COLUMN IF NOT EXISTS run_id TEXT;",
+        (
+            "CREATE INDEX IF NOT EXISTS ix_cubepi_messages_thread_run "
+            "ON cubepi_messages (thread_id, run_id);"
+        ),
+        (
+            "CREATE TABLE IF NOT EXISTS cubepi_runs ("
+            "  thread_id TEXT NOT NULL REFERENCES cubepi_threads(thread_id) "
+            "ON DELETE CASCADE,"
+            "  run_id TEXT NOT NULL,"
+            "  claimed_at TIMESTAMPTZ NOT NULL DEFAULT now(),"
+            "  completed_at TIMESTAMPTZ,"
+            "  completion_seq BIGINT,"
+            "  PRIMARY KEY (thread_id, run_id)"
+            ") PARTITION BY HASH (thread_id);"
+        ),
+        (
+            "CREATE INDEX IF NOT EXISTS ix_cubepi_runs_thread_seq "
+            "ON cubepi_runs (thread_id, completion_seq);"
+        ),
+        create_runs_partitions_op(),
+    ]
+    return "\n".join(parts)
+
+
 def write_schema_version_op() -> str:
     """Return SQL setting cubepi_schema_version to the current version.
 

--- a/cubepi/checkpointer/postgres/checkpointer.py
+++ b/cubepi/checkpointer/postgres/checkpointer.py
@@ -16,6 +16,7 @@ from cubepi.checkpointer.base import CheckpointData
 from cubepi.checkpointer.exceptions import (
     RunAlreadyClaimedError,
     RunAlreadyCompletedError,
+    RunNotClaimedError,
 )
 from cubepi.checkpointer.postgres.exceptions import (
     CubepiSchemaMismatch,
@@ -263,6 +264,60 @@ class PostgresCheckpointer:
                     thread_id,
                     run_id,
                 )
+
+    async def mark_run_complete(self, thread_id: str, run_id: str) -> None:
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1))",
+                    thread_id,
+                )
+                row = await conn.fetchrow(
+                    "SELECT completed_at FROM cubepi_runs "
+                    "WHERE thread_id = $1 AND run_id = $2",
+                    thread_id,
+                    run_id,
+                )
+                if row is None:
+                    raise RunNotClaimedError(
+                        f"thread={thread_id} run={run_id} has no claim row"
+                    )
+                if row["completed_at"] is not None:
+                    return  # idempotent success
+                next_seq = await conn.fetchval(
+                    "SELECT COALESCE(MAX(completion_seq), 0) + 1 "
+                    "FROM cubepi_runs WHERE thread_id = $1 "
+                    "AND completion_seq IS NOT NULL",
+                    thread_id,
+                )
+                await conn.execute(
+                    "UPDATE cubepi_runs SET completed_at = now(), "
+                    "completion_seq = $3 "
+                    "WHERE thread_id = $1 AND run_id = $2",
+                    thread_id,
+                    run_id,
+                    next_seq,
+                )
+
+    async def load_pending(
+        self, thread_id: str
+    ) -> tuple[HitlRequest, str | None] | None:
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT pending_request, run_id FROM cubepi_threads "
+                "WHERE thread_id = $1",
+                thread_id,
+            )
+        if row is None or row["pending_request"] is None:
+            return None
+        raw = row["pending_request"]
+        if isinstance(raw, str):  # pragma: no cover — codec-dependent
+            req = HitlRequest.model_validate_json(raw)
+        else:
+            req = HitlRequest.model_validate(raw)
+        return req, row["run_id"]
 
     async def save_extra(self, thread_id: str, extra: JsonObject) -> None:
         assert self._pool is not None

--- a/cubepi/checkpointer/postgres/checkpointer.py
+++ b/cubepi/checkpointer/postgres/checkpointer.py
@@ -13,6 +13,10 @@ import asyncpg
 import msgpack
 
 from cubepi.checkpointer.base import CheckpointData
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+)
 from cubepi.checkpointer.postgres.exceptions import (
     CubepiSchemaMismatch,
     CubepiSchemaUninitialized,
@@ -160,6 +164,9 @@ class PostgresCheckpointer:
         if not messages:
             return
         assert self._pool is not None
+        run_ids = {
+            rid for m in messages if (rid := getattr(m, "run_id", None)) is not None
+        }
         async with self._pool.acquire() as conn:
             async with conn.transaction():
                 # Per-thread advisory lock for monotonic seq allocation
@@ -173,6 +180,20 @@ class PostgresCheckpointer:
                     "VALUES ($1) ON CONFLICT DO NOTHING",
                     thread_id,
                 )
+                # Pre-flight: reject append on any completed run_id.
+                if run_ids:
+                    done_rows = await conn.fetch(
+                        "SELECT run_id FROM cubepi_runs "
+                        "WHERE thread_id = $1 AND run_id = ANY($2::text[]) "
+                        "AND completed_at IS NOT NULL",
+                        thread_id,
+                        list(run_ids),
+                    )
+                    if done_rows:
+                        bad = ", ".join(r["run_id"] for r in done_rows)
+                        raise RunAlreadyCompletedError(
+                            f"append on completed run thread={thread_id} runs={bad}"
+                        )
                 last_seq = (
                     await conn.fetchval(
                         "SELECT COALESCE(MAX(seq), 0) FROM cubepi_messages "
@@ -195,13 +216,52 @@ class PostgresCheckpointer:
                             _role_of(m),
                             json.dumps(m.metadata),
                             payload,
+                            getattr(m, "run_id", None),
                         )
                     )
                 await conn.executemany(
                     "INSERT INTO cubepi_messages "
-                    "(thread_id, seq, role, metadata, payload) "
-                    "VALUES ($1, $2, $3, $4, $5)",
+                    "(thread_id, seq, role, metadata, payload, run_id) "
+                    "VALUES ($1, $2, $3, $4, $5, $6)",
                     rows,
+                )
+
+    async def claim_run(self, thread_id: str, run_id: str) -> None:
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1))",
+                    thread_id,
+                )
+                # Lazy thread row creation (claim may precede any append).
+                await conn.execute(
+                    "INSERT INTO cubepi_threads (thread_id) "
+                    "VALUES ($1) ON CONFLICT (thread_id) DO NOTHING",
+                    thread_id,
+                )
+                # Pre-check under the advisory lock so a duplicate doesn't
+                # raise UniqueViolation (which would abort the txn before
+                # we could distinguish in-flight vs completed).
+                row = await conn.fetchrow(
+                    "SELECT completed_at FROM cubepi_runs "
+                    "WHERE thread_id = $1 AND run_id = $2",
+                    thread_id,
+                    run_id,
+                )
+                if row is not None:
+                    if row["completed_at"] is not None:
+                        raise RunAlreadyCompletedError(
+                            f"thread={thread_id} run={run_id} already completed"
+                        )
+                    raise RunAlreadyClaimedError(
+                        f"thread={thread_id} run={run_id} in flight"
+                    )
+                await conn.execute(
+                    "INSERT INTO cubepi_runs (thread_id, run_id) "
+                    "VALUES ($1, $2)",
+                    thread_id,
+                    run_id,
                 )
 
     async def save_extra(self, thread_id: str, extra: JsonObject) -> None:

--- a/cubepi/checkpointer/postgres/checkpointer.py
+++ b/cubepi/checkpointer/postgres/checkpointer.py
@@ -17,6 +17,9 @@ from cubepi.checkpointer.exceptions import (
     RunAlreadyClaimedError,
     RunAlreadyCompletedError,
     RunNotClaimedError,
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
 )
 from cubepi.checkpointer.postgres.exceptions import (
     CubepiSchemaMismatch,
@@ -128,7 +131,8 @@ class PostgresCheckpointer:
                 thread_id,
             )
             extra_row = await conn.fetchrow(
-                "SELECT extra FROM cubepi_threads WHERE thread_id = $1",
+                "SELECT extra, parent_thread_id FROM cubepi_threads "
+                "WHERE thread_id = $1",
                 thread_id,
             )
 
@@ -149,6 +153,7 @@ class PostgresCheckpointer:
             )
             messages.append(cls.model_validate(data))
 
+        parent_thread_id: str | None = None
         if extra_row is not None:
             raw_extra = extra_row["extra"]
             extra = (
@@ -156,10 +161,13 @@ class PostgresCheckpointer:
                 if isinstance(raw_extra, str)
                 else (raw_extra or {})
             )
+            parent_thread_id = extra_row["parent_thread_id"]
         else:
             extra = {}
 
-        return CheckpointData(messages=messages, extra=extra)
+        return CheckpointData(
+            messages=messages, extra=extra, parent_thread_id=parent_thread_id
+        )
 
     async def append(self, thread_id: str, messages: list[Message]) -> None:
         if not messages:
@@ -259,8 +267,7 @@ class PostgresCheckpointer:
                         f"thread={thread_id} run={run_id} in flight"
                     )
                 await conn.execute(
-                    "INSERT INTO cubepi_runs (thread_id, run_id) "
-                    "VALUES ($1, $2)",
+                    "INSERT INTO cubepi_runs (thread_id, run_id) VALUES ($1, $2)",
                     thread_id,
                     run_id,
                 )
@@ -318,6 +325,154 @@ class PostgresCheckpointer:
         else:
             req = HitlRequest.model_validate(raw)
         return req, row["run_id"]
+
+    async def snapshot(self, thread_id: str, *, after_run_id: str) -> list[Message]:
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            # Source thread must exist.
+            t_row = await conn.fetchrow(
+                "SELECT 1 FROM cubepi_threads WHERE thread_id = $1",
+                thread_id,
+            )
+            if t_row is None:
+                raise ThreadNotFoundError(f"thread={thread_id}")
+            cutoff = await conn.fetchval(
+                "SELECT completion_seq FROM cubepi_runs "
+                "WHERE thread_id = $1 AND run_id = $2",
+                thread_id,
+                after_run_id,
+            )
+            if cutoff is None:
+                raise RunNotCompletedError(
+                    f"thread={thread_id} run={after_run_id} not completed"
+                )
+            rows = await conn.fetch(
+                "SELECT seq, role, metadata, payload FROM cubepi_messages "
+                "WHERE thread_id = $1 AND ("
+                "  run_id IS NULL OR run_id IN ("
+                "    SELECT run_id FROM cubepi_runs "
+                "    WHERE thread_id = $1 "
+                "    AND completion_seq IS NOT NULL "
+                "    AND completion_seq <= $2"
+                "  )"
+                ") ORDER BY seq",
+                thread_id,
+                cutoff,
+            )
+        messages: list[Message] = []
+        for r in rows:
+            cls = _ROLE_TO_CLS.get(r["role"])
+            if cls is None:
+                raise ValueError(f"unknown role in DB: {r['role']!r}")
+            data = msgpack.unpackb(bytes(r["payload"]), raw=False)
+            raw_meta = r["metadata"]
+            data["metadata"] = (
+                json.loads(raw_meta) if isinstance(raw_meta, str) else (raw_meta or {})
+            )
+            messages.append(cls.model_validate(data))
+        return messages
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        after_run_id: str,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        assert self._pool is not None
+        async with self._pool.acquire() as conn:
+            async with conn.transaction():
+                # Serialize concurrent forks/appends on src by taking the
+                # src thread's per-thread advisory lock.
+                await conn.execute(
+                    "SELECT pg_advisory_xact_lock(hashtext($1))",
+                    src_thread_id,
+                )
+                # Source must exist (threads row is created lazily by append
+                # / claim_run / save_extra / save_pending_request — so its
+                # presence is the canonical "thread exists" gate).
+                t_row = await conn.fetchrow(
+                    "SELECT 1 FROM cubepi_threads WHERE thread_id = $1",
+                    src_thread_id,
+                )
+                if t_row is None:
+                    raise ThreadNotFoundError(f"thread={src_thread_id}")
+                # Destination must not exist.
+                dst_row = await conn.fetchrow(
+                    "SELECT 1 FROM cubepi_threads WHERE thread_id = $1",
+                    new_thread_id,
+                )
+                if dst_row is not None:
+                    raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+                # Cutoff: after_run_id must be completed on src.
+                cutoff = await conn.fetchval(
+                    "SELECT completion_seq FROM cubepi_runs "
+                    "WHERE thread_id = $1 AND run_id = $2",
+                    src_thread_id,
+                    after_run_id,
+                )
+                if cutoff is None:
+                    raise RunNotCompletedError(
+                        f"thread={src_thread_id} run={after_run_id} not completed"
+                    )
+                # Build merged extra (carry parent's extra + fork metadata).
+                src_extra_row = await conn.fetchrow(
+                    "SELECT extra FROM cubepi_threads WHERE thread_id = $1",
+                    src_thread_id,
+                )
+                raw_extra = (
+                    src_extra_row["extra"] if src_extra_row is not None else None
+                )
+                if isinstance(raw_extra, str):
+                    base_extra = json.loads(raw_extra)
+                else:
+                    base_extra = dict(raw_extra) if raw_extra else {}
+                if metadata is not None:
+                    base_extra["fork"] = json.loads(json.dumps(metadata))
+                # INSERT destination threads row first to satisfy the
+                # cubepi_messages / cubepi_runs FKs on subsequent copies.
+                await conn.execute(
+                    "INSERT INTO cubepi_threads "
+                    "(thread_id, parent_thread_id, forked_at_seq, extra) "
+                    "VALUES ($1, $2, $3, $4::jsonb)",
+                    new_thread_id,
+                    src_thread_id,
+                    cutoff,
+                    json.dumps(base_extra),
+                )
+                # Copy messages whose run is NULL (legacy prefix) or completed
+                # at or before cutoff. Preserve seq from the source.
+                await conn.execute(
+                    "INSERT INTO cubepi_messages "
+                    "(thread_id, seq, role, metadata, payload, run_id) "
+                    "SELECT $1, seq, role, metadata, payload, run_id "
+                    "FROM cubepi_messages "
+                    "WHERE thread_id = $2 AND ("
+                    "  run_id IS NULL OR run_id IN ("
+                    "    SELECT run_id FROM cubepi_runs "
+                    "    WHERE thread_id = $2 "
+                    "    AND completion_seq IS NOT NULL "
+                    "    AND completion_seq <= $3"
+                    "  )"
+                    ") ORDER BY seq",
+                    new_thread_id,
+                    src_thread_id,
+                    cutoff,
+                )
+                # Copy completed runs satisfying the cutoff.
+                await conn.execute(
+                    "INSERT INTO cubepi_runs "
+                    "(thread_id, run_id, claimed_at, completed_at, completion_seq) "
+                    "SELECT $1, run_id, claimed_at, completed_at, completion_seq "
+                    "FROM cubepi_runs "
+                    "WHERE thread_id = $2 "
+                    "AND completion_seq IS NOT NULL "
+                    "AND completion_seq <= $3",
+                    new_thread_id,
+                    src_thread_id,
+                    cutoff,
+                )
 
     async def save_extra(self, thread_id: str, extra: JsonObject) -> None:
         assert self._pool is not None

--- a/cubepi/checkpointer/postgres/models.py
+++ b/cubepi/checkpointer/postgres/models.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-EXPECTED_SCHEMA_VERSION = 3
+EXPECTED_SCHEMA_VERSION = 4
 PARTITION_COUNT = 64
 
 cubepi_metadata = sa.MetaData()
@@ -75,6 +75,7 @@ class CubepiMessage(CubepiBase):
             postgresql_using="gin",
             postgresql_ops={"metadata": "jsonb_path_ops"},
         ),
+        sa.Index("ix_cubepi_messages_thread_run", "thread_id", "run_id"),
         {"postgresql_partition_by": "HASH (thread_id)"},
     )
 
@@ -95,10 +96,38 @@ class CubepiMessage(CubepiBase):
         server_default=sa.text("'{}'::jsonb"),
     )
     payload: Mapped[bytes] = mapped_column(sa.LargeBinary, nullable=False)
+    # v4: opaque host-side run identifier stamped on each message. Lets
+    # fork/snapshot include only messages from completed runs.
+    run_id: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
     created_at: Mapped[_dt.datetime] = mapped_column(
         sa.TIMESTAMP(timezone=True),
         nullable=False,
         server_default=sa.text("now()"),
+    )
+
+
+class CubepiRun(CubepiBase):
+    __tablename__ = "cubepi_runs"
+    __table_args__ = (
+        sa.Index("ix_cubepi_runs_thread_seq", "thread_id", "completion_seq"),
+        {"postgresql_partition_by": "HASH (thread_id)"},
+    )
+    thread_id: Mapped[str] = mapped_column(
+        sa.Text,
+        sa.ForeignKey("cubepi_threads.thread_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    run_id: Mapped[str] = mapped_column(sa.Text, primary_key=True)
+    claimed_at: Mapped[_dt.datetime] = mapped_column(
+        sa.TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=sa.text("now()"),
+    )
+    completed_at: Mapped[_dt.datetime | None] = mapped_column(
+        sa.TIMESTAMP(timezone=True), nullable=True
+    )
+    completion_seq: Mapped[int | None] = mapped_column(
+        sa.BigInteger, nullable=True
     )
 
 

--- a/cubepi/checkpointer/postgres/models.py
+++ b/cubepi/checkpointer/postgres/models.py
@@ -126,9 +126,7 @@ class CubepiRun(CubepiBase):
     completed_at: Mapped[_dt.datetime | None] = mapped_column(
         sa.TIMESTAMP(timezone=True), nullable=True
     )
-    completion_seq: Mapped[int | None] = mapped_column(
-        sa.BigInteger, nullable=True
-    )
+    completion_seq: Mapped[int | None] = mapped_column(sa.BigInteger, nullable=True)
 
 
 class CubepiSchemaVersion(CubepiBase):

--- a/cubepi/checkpointer/sqlite.py
+++ b/cubepi/checkpointer/sqlite.py
@@ -25,6 +25,9 @@ class SQLiteCheckpointer:
 
     async def __aenter__(self) -> SQLiteCheckpointer:
         self._db = await aiosqlite.connect(self._db_path)
+        # Set busy_timeout to 5s — gives writer contention a chance to wait
+        # rather than immediately failing with SQLITE_BUSY.
+        await self._db.execute("PRAGMA busy_timeout = 5000")
         await self._db.execute(
             "CREATE TABLE IF NOT EXISTS messages ("
             "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -47,6 +50,20 @@ class SQLiteCheckpointer:
             "  created_at REAL NOT NULL DEFAULT (julianday('now'))"
             ")"
         )
+        await self._db.execute(
+            "CREATE TABLE IF NOT EXISTS runs ("
+            "  thread_id TEXT NOT NULL,"
+            "  run_id TEXT NOT NULL,"
+            "  claimed_at REAL NOT NULL DEFAULT (julianday('now')),"
+            "  completed_at REAL,"
+            "  completion_seq INTEGER,"
+            "  PRIMARY KEY (thread_id, run_id)"
+            ")"
+        )
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS ix_runs_thread_completion "
+            "ON runs (thread_id, completion_seq)"
+        )
         # One-shot migration: older DBs (created before run_id existed) have
         # the table without the run_id column. SQLite has no schema_version
         # gate, so we ALTER inline when it's missing.
@@ -55,6 +72,18 @@ class SQLiteCheckpointer:
         if "run_id" not in cols:
             await self._db.execute(
                 "ALTER TABLE thread_pending_request ADD COLUMN run_id TEXT"
+            )
+        # Same one-shot ALTER pattern for the new run_id column on messages.
+        cur = await self._db.execute("PRAGMA table_info(messages)")
+        cols = {row[1] for row in await cur.fetchall()}
+        if "run_id" not in cols:
+            await self._db.execute("ALTER TABLE messages ADD COLUMN run_id TEXT")
+        # And for parent_thread_id on thread_extra.
+        cur = await self._db.execute("PRAGMA table_info(thread_extra)")
+        cols = {row[1] for row in await cur.fetchall()}
+        if "parent_thread_id" not in cols:
+            await self._db.execute(
+                "ALTER TABLE thread_extra ADD COLUMN parent_thread_id TEXT"
             )
         await self._db.commit()
         return self

--- a/cubepi/checkpointer/sqlite.py
+++ b/cubepi/checkpointer/sqlite.py
@@ -8,7 +8,12 @@ from typing import Any, AsyncIterator, cast
 import aiosqlite
 
 from cubepi.checkpointer.base import CheckpointData
-from cubepi.checkpointer.exceptions import CheckpointerLockTimeoutError
+from cubepi.checkpointer.exceptions import (
+    CheckpointerLockTimeoutError,
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+)
 from cubepi.hitl.types import HitlRequest
 from cubepi.providers.base import (
     AssistantMessage,
@@ -142,7 +147,26 @@ class SQLiteCheckpointer:
 
     async def append(self, thread_id: str, messages: list[Message]) -> None:
         assert self._db is not None
+        run_ids = {
+            rid
+            for m in messages
+            if (rid := getattr(m, "run_id", None)) is not None
+        }
         async with self._lock, _writer_txn(self._db):
+            if run_ids:
+                placeholders = ",".join("?" for _ in run_ids)
+                cur = await self._db.execute(
+                    f"SELECT run_id FROM runs WHERE thread_id = ? "
+                    f"AND run_id IN ({placeholders}) "
+                    f"AND completed_at IS NOT NULL",
+                    (thread_id, *run_ids),
+                )
+                done = await cur.fetchall()
+                if done:
+                    bad = ", ".join(r[0] for r in done)
+                    raise RunAlreadyCompletedError(
+                        f"append on completed run thread={thread_id} runs={bad}"
+                    )
             for msg in messages:
                 msg_json = _serialize_message(msg)
                 await self._db.execute(
@@ -195,6 +219,71 @@ class SQLiteCheckpointer:
                     "(thread_id, request_json, run_id) VALUES (?, ?, ?)",
                     (thread_id, payload, run_id),
                 )
+
+    async def claim_run(self, thread_id: str, run_id: str) -> None:
+        assert self._db is not None
+        async with self._lock, _writer_txn(self._db):
+            cur = await self._db.execute(
+                "SELECT completed_at FROM runs "
+                "WHERE thread_id = ? AND run_id = ?",
+                (thread_id, run_id),
+            )
+            row = await cur.fetchone()
+            if row is not None:
+                completed_at = row[0]
+                if completed_at is None:
+                    raise RunAlreadyClaimedError(
+                        f"thread={thread_id} run={run_id} in flight"
+                    )
+                raise RunAlreadyCompletedError(
+                    f"thread={thread_id} run={run_id} already completed"
+                )
+            await self._db.execute(
+                "INSERT INTO runs (thread_id, run_id) VALUES (?, ?)",
+                (thread_id, run_id),
+            )
+
+    async def mark_run_complete(self, thread_id: str, run_id: str) -> None:
+        assert self._db is not None
+        async with self._lock, _writer_txn(self._db):
+            cur = await self._db.execute(
+                "SELECT completed_at FROM runs "
+                "WHERE thread_id = ? AND run_id = ?",
+                (thread_id, run_id),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                raise RunNotClaimedError(
+                    f"thread={thread_id} run={run_id} has no claim row"
+                )
+            if row[0] is not None:
+                return  # idempotent success
+            cur = await self._db.execute(
+                "SELECT COALESCE(MAX(completion_seq), 0) + 1 FROM runs "
+                "WHERE thread_id = ? AND completion_seq IS NOT NULL",
+                (thread_id,),
+            )
+            (next_seq,) = await cur.fetchone()
+            await self._db.execute(
+                "UPDATE runs SET completed_at = julianday('now'), "
+                "completion_seq = ? WHERE thread_id = ? AND run_id = ?",
+                (next_seq, thread_id, run_id),
+            )
+
+    async def load_pending(
+        self, thread_id: str
+    ) -> tuple[HitlRequest, str | None] | None:
+        assert self._db is not None
+        async with self._lock:
+            cur = await self._db.execute(
+                "SELECT request_json, run_id FROM thread_pending_request "
+                "WHERE thread_id = ?",
+                (thread_id,),
+            )
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return HitlRequest.model_validate_json(row[0]), row[1]
 
     async def load_pending_request(self, thread_id: str) -> HitlRequest | None:
         assert self._db is not None

--- a/cubepi/checkpointer/sqlite.py
+++ b/cubepi/checkpointer/sqlite.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, cast
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, cast
 
 import aiosqlite
 
 from cubepi.checkpointer.base import CheckpointData
+from cubepi.checkpointer.exceptions import CheckpointerLockTimeoutError
 from cubepi.hitl.types import HitlRequest
 from cubepi.providers.base import (
     AssistantMessage,
@@ -15,6 +17,25 @@ from cubepi.providers.base import (
     UserMessage,
 )
 from cubepi.types import JsonObject
+
+
+@asynccontextmanager
+async def _writer_txn(db: aiosqlite.Connection) -> AsyncIterator[None]:
+    """Wrap a writer transaction in BEGIN IMMEDIATE and surface
+    SQLITE_BUSY as CheckpointerLockTimeoutError."""
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+    except aiosqlite.OperationalError as exc:
+        if "lock" in str(exc).lower() or "busy" in str(exc).lower():
+            raise CheckpointerLockTimeoutError(str(exc)) from exc
+        raise
+    try:
+        yield
+    except BaseException:
+        await db.rollback()
+        raise
+    else:
+        await db.commit()
 
 
 class SQLiteCheckpointer:
@@ -121,18 +142,18 @@ class SQLiteCheckpointer:
 
     async def append(self, thread_id: str, messages: list[Message]) -> None:
         assert self._db is not None
-        async with self._lock:
+        async with self._lock, _writer_txn(self._db):
             for msg in messages:
                 msg_json = _serialize_message(msg)
                 await self._db.execute(
-                    "INSERT INTO messages (thread_id, message_json) VALUES (?, ?)",
-                    (thread_id, msg_json),
+                    "INSERT INTO messages (thread_id, message_json, run_id) "
+                    "VALUES (?, ?, ?)",
+                    (thread_id, msg_json, getattr(msg, "run_id", None)),
                 )
-            await self._db.commit()
 
     async def save_extra(self, thread_id: str, extra: JsonObject) -> None:
         assert self._db is not None
-        async with self._lock:
+        async with self._lock, _writer_txn(self._db):
             existing_cursor = await self._db.execute(
                 "SELECT extra_json FROM thread_extra WHERE thread_id = ?",
                 (thread_id,),
@@ -150,7 +171,6 @@ class SQLiteCheckpointer:
                     "INSERT INTO thread_extra (thread_id, extra_json) VALUES (?, ?)",
                     (thread_id, json.dumps(extra)),
                 )
-            await self._db.commit()
 
     async def save_pending_request(
         self,
@@ -160,7 +180,7 @@ class SQLiteCheckpointer:
         run_id: str | None = None,
     ) -> None:
         assert self._db is not None
-        async with self._lock:
+        async with self._lock, _writer_txn(self._db):
             if request is None:
                 # Clearing pending implicitly clears the associated run_id.
                 await self._db.execute(
@@ -175,7 +195,6 @@ class SQLiteCheckpointer:
                     "(thread_id, request_json, run_id) VALUES (?, ?, ?)",
                     (thread_id, payload, run_id),
                 )
-            await self._db.commit()
 
     async def load_pending_request(self, thread_id: str) -> HitlRequest | None:
         assert self._db is not None

--- a/cubepi/checkpointer/sqlite.py
+++ b/cubepi/checkpointer/sqlite.py
@@ -13,6 +13,9 @@ from cubepi.checkpointer.exceptions import (
     RunAlreadyClaimedError,
     RunAlreadyCompletedError,
     RunNotClaimedError,
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
 )
 from cubepi.hitl.types import HitlRequest
 from cubepi.providers.base import (
@@ -129,7 +132,8 @@ class SQLiteCheckpointer:
             rows = await cursor.fetchall()
 
             extra_cursor = await self._db.execute(
-                "SELECT extra_json FROM thread_extra WHERE thread_id = ?",
+                "SELECT extra_json, parent_thread_id FROM thread_extra "
+                "WHERE thread_id = ?",
                 (thread_id,),
             )
             extra_row = await extra_cursor.fetchone()
@@ -143,14 +147,15 @@ class SQLiteCheckpointer:
                 messages.append(_deserialize_message(msg_data))
 
             extra = json.loads(extra_row[0]) if extra_row else {}
-            return CheckpointData(messages=messages, extra=extra)
+            parent = extra_row[1] if extra_row else None
+            return CheckpointData(
+                messages=messages, extra=extra, parent_thread_id=parent
+            )
 
     async def append(self, thread_id: str, messages: list[Message]) -> None:
         assert self._db is not None
         run_ids = {
-            rid
-            for m in messages
-            if (rid := getattr(m, "run_id", None)) is not None
+            rid for m in messages if (rid := getattr(m, "run_id", None)) is not None
         }
         async with self._lock, _writer_txn(self._db):
             if run_ids:
@@ -224,8 +229,7 @@ class SQLiteCheckpointer:
         assert self._db is not None
         async with self._lock, _writer_txn(self._db):
             cur = await self._db.execute(
-                "SELECT completed_at FROM runs "
-                "WHERE thread_id = ? AND run_id = ?",
+                "SELECT completed_at FROM runs WHERE thread_id = ? AND run_id = ?",
                 (thread_id, run_id),
             )
             row = await cur.fetchone()
@@ -247,8 +251,7 @@ class SQLiteCheckpointer:
         assert self._db is not None
         async with self._lock, _writer_txn(self._db):
             cur = await self._db.execute(
-                "SELECT completed_at FROM runs "
-                "WHERE thread_id = ? AND run_id = ?",
+                "SELECT completed_at FROM runs WHERE thread_id = ? AND run_id = ?",
                 (thread_id, run_id),
             )
             row = await cur.fetchone()
@@ -263,7 +266,9 @@ class SQLiteCheckpointer:
                 "WHERE thread_id = ? AND completion_seq IS NOT NULL",
                 (thread_id,),
             )
-            (next_seq,) = await cur.fetchone()
+            seq_row = await cur.fetchone()
+            assert seq_row is not None
+            next_seq = seq_row[0]
             await self._db.execute(
                 "UPDATE runs SET completed_at = julianday('now'), "
                 "completion_seq = ? WHERE thread_id = ? AND run_id = ?",
@@ -304,6 +309,126 @@ class SQLiteCheckpointer:
             )
             row = await cursor.fetchone()
         return row[0] if row else None
+
+    async def snapshot(self, thread_id: str, *, after_run_id: str) -> list[Message]:
+        assert self._db is not None
+        async with self._lock:
+            cur = await self._db.execute(
+                "SELECT completion_seq FROM runs WHERE thread_id = ? AND run_id = ?",
+                (thread_id, after_run_id),
+            )
+            row = await cur.fetchone()
+            if row is None or row[0] is None:
+                raise RunNotCompletedError(
+                    f"thread={thread_id} run={after_run_id} not completed"
+                )
+            cutoff = row[0]
+            cur = await self._db.execute(
+                "SELECT message_json FROM messages WHERE thread_id = ? "
+                "AND (run_id IS NULL OR run_id IN ("
+                "  SELECT run_id FROM runs WHERE thread_id = ? "
+                "  AND completion_seq IS NOT NULL "
+                "  AND completion_seq <= ?"
+                ")) ORDER BY id",
+                (thread_id, thread_id, cutoff),
+            )
+            rows = await cur.fetchall()
+            return [_deserialize_message(json.loads(r[0])) for r in rows]
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        after_run_id: str,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        assert self._db is not None
+        async with self._lock, _writer_txn(self._db):
+            # Source existence: messages OR thread_extra OR runs.
+            cur = await self._db.execute(
+                "SELECT 1 FROM messages WHERE thread_id = ? LIMIT 1",
+                (src_thread_id,),
+            )
+            src_has_msg = await cur.fetchone() is not None
+            cur = await self._db.execute(
+                "SELECT 1 FROM thread_extra WHERE thread_id = ?",
+                (src_thread_id,),
+            )
+            src_has_extra = await cur.fetchone() is not None
+            cur = await self._db.execute(
+                "SELECT 1 FROM runs WHERE thread_id = ? LIMIT 1",
+                (src_thread_id,),
+            )
+            src_has_runs = await cur.fetchone() is not None
+            if not (src_has_msg or src_has_extra or src_has_runs):
+                raise ThreadNotFoundError(f"thread={src_thread_id}")
+            # Destination collision.
+            cur = await self._db.execute(
+                "SELECT 1 FROM messages WHERE thread_id = ? LIMIT 1",
+                (new_thread_id,),
+            )
+            if await cur.fetchone():
+                raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+            cur = await self._db.execute(
+                "SELECT 1 FROM thread_extra WHERE thread_id = ?",
+                (new_thread_id,),
+            )
+            if await cur.fetchone():
+                raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+            cur = await self._db.execute(
+                "SELECT 1 FROM runs WHERE thread_id = ? LIMIT 1",
+                (new_thread_id,),
+            )
+            if await cur.fetchone():
+                raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+            # Cutoff.
+            cur = await self._db.execute(
+                "SELECT completion_seq FROM runs WHERE thread_id = ? AND run_id = ?",
+                (src_thread_id, after_run_id),
+            )
+            row = await cur.fetchone()
+            if row is None or row[0] is None:
+                raise RunNotCompletedError(
+                    f"thread={src_thread_id} run={after_run_id} not completed"
+                )
+            cutoff = row[0]
+            # Copy messages.
+            await self._db.execute(
+                "INSERT INTO messages (thread_id, run_id, message_json) "
+                "SELECT ?, run_id, message_json FROM messages "
+                "WHERE thread_id = ? AND ("
+                "  run_id IS NULL OR run_id IN ("
+                "    SELECT run_id FROM runs WHERE thread_id = ? "
+                "    AND completion_seq IS NOT NULL "
+                "    AND completion_seq <= ?"
+                "  )"
+                ") ORDER BY id",
+                (new_thread_id, src_thread_id, src_thread_id, cutoff),
+            )
+            # Copy runs.
+            await self._db.execute(
+                "INSERT INTO runs (thread_id, run_id, claimed_at, "
+                "completed_at, completion_seq) "
+                "SELECT ?, run_id, claimed_at, completed_at, completion_seq "
+                "FROM runs WHERE thread_id = ? "
+                "AND completion_seq IS NOT NULL AND completion_seq <= ?",
+                (new_thread_id, src_thread_id, cutoff),
+            )
+            # Build merged extra.
+            cur = await self._db.execute(
+                "SELECT extra_json FROM thread_extra WHERE thread_id = ?",
+                (src_thread_id,),
+            )
+            row = await cur.fetchone()
+            merged_extra = json.loads(row[0]) if row else {}
+            if metadata is not None:
+                merged_extra["fork"] = json.loads(json.dumps(metadata))
+            await self._db.execute(
+                "INSERT INTO thread_extra (thread_id, extra_json, "
+                "parent_thread_id) VALUES (?, ?, ?)",
+                (new_thread_id, json.dumps(merged_extra), src_thread_id),
+            )
 
 
 def _serialize_message(msg: Any) -> str:

--- a/cubepi/hitl/ask_user.py
+++ b/cubepi/hitl/ask_user.py
@@ -8,7 +8,8 @@ from typing import cast
 from pydantic import BaseModel
 
 from cubepi.agent.types import AgentTool, AgentToolResult
-from cubepi.hitl.channel import HitlChannel
+from cubepi.hitl.binding import HitlBinding
+from cubepi.hitl.channel import CheckpointedChannel, HitlChannel
 from cubepi.hitl.types import Option, Question
 from cubepi.providers.base import TextContent
 from cubepi.types import StructuredObject, StructuredValue
@@ -106,12 +107,18 @@ def ask_user_tool(channel: HitlChannel) -> AgentTool[AskUserParams]:
             ),
         )
 
+    checkpointed = isinstance(channel, CheckpointedChannel)
+    binding = HitlBinding(
+        checkpointed=checkpointed,
+        run_id=getattr(channel, "_run_id", None) if checkpointed else None,
+    )
     tool = AgentTool(
         name="ask_user",
         description=_DESCRIPTION,
         parameters=AskUserParams,
         execute=execute,
         execution_mode="sequential",
+        hitl=binding,
     )
     # Signal to _execute_prepared that this is a built-in HITL tool so the
     # ContextVar durability guard is NOT set on entry — only custom tool

--- a/cubepi/hitl/binding.py
+++ b/cubepi/hitl/binding.py
@@ -1,0 +1,26 @@
+"""HitlBinding — structural attribute on AgentTool and Middleware
+declaring how a HITL element integrates with the checkpointer.
+
+See dev/specs/2026-06-05-conversation-fork.md §3.6.3.1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HitlBinding:
+    """How a tool/middleware integrates with HITL.
+
+    Attributes:
+        checkpointed: True iff backed by ``CheckpointedChannel`` (writes
+            ``pending_request`` to the source thread on pause).
+        run_id: The channel's bound run_id. For checkpointed HITL this
+            MUST be a non-empty string; ``None`` is a configuration
+            error and is rejected at ``Agent.prompt()`` entry. For
+            in-memory HITL it is ``None``.
+    """
+
+    checkpointed: bool
+    run_id: str | None

--- a/cubepi/hitl/middleware.py
+++ b/cubepi/hitl/middleware.py
@@ -6,7 +6,8 @@ from typing import Awaitable, Callable, Iterable, Protocol, Union, cast
 from pydantic import BaseModel
 
 from cubepi.agent.types import BeforeToolCallContext, BeforeToolCallResult
-from cubepi.hitl.channel import HitlChannel
+from cubepi.hitl.binding import HitlBinding
+from cubepi.hitl.channel import CheckpointedChannel, HitlChannel
 from cubepi.hitl.exceptions import HitlCancelled, HitlTimedOut
 from cubepi.hitl.policy import Approve, ApprovalDecision, AskUser, Deny
 from cubepi.middleware.base import Middleware
@@ -36,6 +37,11 @@ class ApprovalPolicyMiddleware(Middleware):
     ):
         self._channel = channel
         self._policy = policy
+        checkpointed = isinstance(channel, CheckpointedChannel)
+        self.hitl = HitlBinding(
+            checkpointed=checkpointed,
+            run_id=getattr(channel, "_run_id", None) if checkpointed else None,
+        )
 
     async def before_tool_call(
         self, ctx: BeforeToolCallContext, *, signal=None

--- a/cubepi/middleware/base.py
+++ b/cubepi/middleware/base.py
@@ -12,6 +12,7 @@ from cubepi.agent.types import (
     BeforeToolCallContext,
     BeforeToolCallResult,
 )
+from cubepi.hitl.binding import HitlBinding
 from cubepi.providers.base import AssistantMessage, Message, Model, Provider
 from cubepi.types import JsonObject, StructuredObject
 
@@ -31,6 +32,8 @@ class TurnAction:
 
 
 class Middleware:
+    hitl: HitlBinding | None = None
+
     async def transform_context(
         self,
         messages: list[Message],

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -127,6 +127,7 @@ class UserMessage(BaseModel):
     content: list[Content]
     timestamp: float | None = None
     metadata: JsonObject = Field(default_factory=dict)
+    run_id: str | None = None
 
 
 class AssistantMessage(BaseModel):
@@ -140,6 +141,7 @@ class AssistantMessage(BaseModel):
     model_id: str = ""
     response_id: str | None = None
     metadata: JsonObject = Field(default_factory=dict)
+    run_id: str | None = None
 
 
 class ToolResultMessage(BaseModel):
@@ -151,6 +153,7 @@ class ToolResultMessage(BaseModel):
     is_error: bool = False
     timestamp: float | None = None
     metadata: JsonObject = Field(default_factory=dict)
+    run_id: str | None = None
 
 
 Message = UserMessage | AssistantMessage | ToolResultMessage

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -4025,34 +4025,79 @@ Expected: `respond()` either reclaims or doesn't propagate run_id.
 
 - [ ] **Step 3: Modify `Agent.respond()`**
 
-At the start of `respond()` (after the existing locking / state
-guards), recover the run_id from pending state and apply the same
-lifecycle pattern as `prompt()` — set on entry, clear on clean return,
-leave set on raise:
+**Edit the existing `respond()` body — DO NOT replace it.** Preserve
+the existing `HitlNoPendingRequest` / `HitlStaleAnswer` raises, the
+lazy history reload, and the `attach_resume_answer` call. The
+respond body today is at `agent.py:431-469`. Make these three
+changes:
+
+1. Replace `load_pending = getattr(self.checkpointer,
+   "load_pending_request", None)` (and the matching `await
+   load_pending(self.thread_id)` call) with the new
+   `load_pending()` Protocol method (Task 6) that returns
+   `(HitlRequest, run_id | None)`. Keep the same fallback error
+   when the method is missing.
+2. Set `self._state.active_run_id` from the recovered run_id.
+3. Wrap the `_run_hitl_resume()` call in try/except/else for
+   outcome dispatch, mirroring `prompt()` (Task 26).
+
+Concretely, the new `respond()` body looks like:
 
 ```python
-pending = await self.checkpointer.load_pending(self.thread_id)
-if pending is None:
-    raise HitlError("no pending request")
-_req, recovered_run_id = pending
-if recovered_run_id is not None:
-    self._state.active_run_id = recovered_run_id
-self._state.last_outcome = None
-try:
-    # `_run_hitl_resume(self)` (no args; takes everything from
-    # self._state) re-enters the agent loop. It calls
-    # run_agent_loop_resume(set_outcome=self._outcome_sink(), …)
-    # internally — the loop's exit-path catches populate
-    # self._state.last_outcome.
-    await self._run_hitl_resume()
-except BaseException:
-    # Leave active_run_id SET on raise (spec §3.7).
-    raise
-else:
-    outcome = self._state.last_outcome or "abandoned"
-    await self._dispatch_outcome(outcome, recovered_run_id)
-    # Clear on successful resume completion.
-    self._state.active_run_id = None
+async def respond(
+    self, *, question_id: str | None = None, answer: StructuredValue
+) -> None:
+    from cubepi.hitl.exceptions import (
+        HitlNoPendingRequest,
+        HitlStaleAnswer,
+    )
+
+    if self._channel is None:
+        raise HitlError("agent has no channel bound")
+    if not (self.thread_id and self.checkpointer):
+        raise RuntimeError("respond() requires thread_id + checkpointer")
+
+    load_pending = getattr(self.checkpointer, "load_pending", None)
+    if load_pending is None:
+        raise HitlError(
+            "respond() requires a checkpointer that implements "
+            "load_pending (added in checkpointer v4)"
+        )
+
+    async with self._run_lock:
+        if not self._state._messages:
+            data = await self.checkpointer.load(self.thread_id)
+            if data:
+                self._state._messages = list(data.messages or [])
+                self._extra = dict(data.extra or {})
+
+        loaded = await load_pending(self.thread_id)
+        if loaded is None:
+            raise HitlNoPendingRequest("no pending request on this thread")
+        pending, recovered_run_id = loaded
+        if question_id is None:
+            question_id = pending.question_id
+        if question_id != pending.question_id:
+            raise HitlStaleAnswer(
+                f"answer for {question_id}, pending is {pending.question_id}"
+            )
+
+        # NEW: thread the recovered run_id into agent state.
+        if recovered_run_id is not None:
+            self._state.active_run_id = recovered_run_id
+        self._state.last_outcome = None
+
+        self._channel.attach_resume_answer(question_id, answer)
+        try:
+            await self._run_hitl_resume()
+        except BaseException:
+            # Spec §3.7: leave active_run_id SET on raise.
+            raise
+        else:
+            outcome = self._state.last_outcome or "abandoned"
+            await self._dispatch_outcome(outcome, recovered_run_id)
+            # Clear on successful resume completion.
+            self._state.active_run_id = None
 ```
 
 **Do not call `claim_run` here.** All subsequent append calls use

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -4109,7 +4109,15 @@ Add a regression test mirroring the legacy case:
 @pytest.mark.asyncio
 async def test_respond_resume_with_legacy_pending_does_not_crash():
     """A pre-spec pending row was written without run_id. respond()
-    must resume cleanly: no claim, no mark, no crash."""
+    must resume cleanly: dispatch is skipped (no mark), no crash.
+
+    Setup nuance: the initial prompt DOES claim R1 (Task 25's
+    pre-flight). The legacy-ness we're simulating is on the
+    pending row only — `save_pending_request(run_id=None)`. The
+    assertion is therefore "completed_at remains None" for R1 (the
+    resume saw a None recovered_run_id and skipped dispatch),
+    NOT "no R1 row at all".
+    """
     cp = MemoryCheckpointer()
     p = _pause_then_finish_provider()
     a, task = await _drive_pause(cp, lambda: p.model("faux-model"))
@@ -4133,9 +4141,10 @@ async def test_respond_resume_with_legacy_pending_does_not_crash():
     qid = pending[0].question_id
     # Must not raise.
     await a2.respond(question_id=qid, answer="yes")
-    # No marker (run_id was None on resume) — but the messages are
-    # persisted and the thread is in a coherent state.
-    assert "R1" not in cp._runs.get("t", {})
+    # R1's claim row still exists from the initial prompt, but no
+    # marker was written because dispatch was skipped on the
+    # None-run_id resume.
+    assert cp._runs["t"]["R1"].completed_at is None
 ```
 
 **Do not call `claim_run` here.** All subsequent append calls use

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -3551,13 +3551,17 @@ Modify `cubepi/agent/agent.py`:
   outcome = self._state.last_outcome or "abandoned"
   await self._dispatch_outcome(outcome, effective_run_id)
   ```
-- In `Agent.respond()`:
+- `Agent.respond()` dispatch wiring is **not** part of Task 26 —
+  it needs the `recovered_run_id` from `load_pending()` which is
+  introduced in Task 28 (Step 3). Task 28 adds the matching
   ```python
   self._state.last_outcome = None
   await self._run_hitl_resume(...)
   outcome = self._state.last_outcome or "abandoned"
   await self._dispatch_outcome(outcome, recovered_run_id)
   ```
+  block. Tests for respond's marker-on-clean-resume therefore live
+  in Task 28.
 
 `tests/agent/test_loop.py` does NOT need updates — public return
 type AND default behavior are unchanged (sink is optional). The
@@ -4033,31 +4037,51 @@ if pending is None:
 _req, recovered_run_id = pending
 if recovered_run_id is not None:
     self._state.active_run_id = recovered_run_id
+self._state.last_outcome = None
 try:
-    # ... existing respond() body, which will:
-    # - re-enter the agent loop
-    # - eventually call _dispatch_outcome (Task 26) which writes the
-    #   marker on outcome == "complete"
-    ...
+    # ... existing respond() body — re-enter the agent loop via
+    # _run_hitl_resume(...) (which receives set_outcome=
+    # self._outcome_sink() from Task 26's plumbing, so the loop's
+    # exit-path catches populate state.last_outcome) ...
+    await self._run_hitl_resume(...)
 except BaseException:
     # Leave active_run_id SET on raise (spec §3.7).
     raise
 else:
+    outcome = self._state.last_outcome or "abandoned"
+    await self._dispatch_outcome(outcome, recovered_run_id)
     # Clear on successful resume completion.
     self._state.active_run_id = None
 ```
 
 **Do not call `claim_run` here.** All subsequent append calls use
 `self._state.active_run_id` (the same chokepoint as prompt — see
-Task 23). At terminal clean exit, `_dispatch_outcome` from Task 26
+Task 23). At terminal clean exit, `_dispatch_outcome` (from Task 26)
 fires `mark_run_complete`.
 
-Add a test asserting:
+Add tests asserting:
+
 ```python
 @pytest.mark.asyncio
 async def test_respond_clears_active_run_id_on_clean_resume():
-    # ... drive a HITL pause then resume to clean completion ...
+    # Mirror tests/hitl/test_agent_respond.py setup: provider script
+    # ask_user → final assistant; CheckpointedChannel; pause; resume
+    # via respond(question_id=qid, answer="yes").
+    ...
     assert agent.state.active_run_id is None
+
+
+@pytest.mark.asyncio
+async def test_respond_resume_writes_marker():
+    """Cross-reference: Task 26's
+    test_hitl_detached_outcome_suspended_no_mark stops at the
+    suspended assertion. This test reaches the resume path and
+    asserts cp._runs[t][R1].completed_at IS NOT None after
+    respond()."""
+    # Same setup as test_hitl_detached_outcome_suspended_no_mark
+    # from Task 26, then continue with respond and assert the marker.
+    ...
+    assert cp._runs["t"]["R1"].completed_at is not None
 ```
 
 - [ ] **Step 4: Run tests → expect pass**

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -117,7 +117,7 @@ To inject provider-side errors / slow streams, subclass
 
 ```python
 class _RaisingProvider(FauxProvider):
-    async def stream_message(self, *args, **kwargs):
+    async def stream(self, *args, **kwargs):
         raise RuntimeError("provider down")
 ```
 
@@ -1943,23 +1943,37 @@ Provide a downgrade that drops the table + column.
 - [ ] **Step 5: Extend `_setup_schema` to v4 + add `pg_v4_dsn` fixture**
 
 In `tests/checkpointer/test_postgres.py`, the existing `_setup_schema`
-helper (`test_postgres.py:177`) builds the v3 schema. Extend it to
-also apply the v4 changes from Task 14:
+helper (`test_postgres.py:177`) builds the v3 schema. **Edit it
+in place** to ALSO apply the v4 changes from Task 14:
 - `ALTER TABLE cubepi_messages ADD COLUMN run_id TEXT NULL`
 - `CREATE INDEX ix_cubepi_messages_thread_run ON cubepi_messages (thread_id, run_id)`
 - Create the partitioned `cubepi_runs` table + partitions (mirror
   `create_message_partitions_op` from `alembic_helpers.py`)
 - Bump `cubepi_schema_version` from 3 to 4
 
-Move `_setup_schema` from `test_postgres.py` into
-`tests/checkpointer/conftest.py` so other test modules can reuse it.
-Add a fixture there:
+**Do NOT move the helper** — leaving it in `test_postgres.py` means
+all existing call sites in that file keep working. Update the
+existing `def test_expected_schema_version` assertion in that file
+from `== 3` to `== 4` (and the parallel one in `test_mysql.py`).
+
+Then add the new fixture in `tests/checkpointer/conftest.py`:
 ```python
+# tests/checkpointer/conftest.py
+import pytest_asyncio
+from tests.checkpointer.test_postgres import _setup_schema as _setup_pg_schema
+
+
 @pytest_asyncio.fixture
 async def pg_v4_dsn(clean_db: str):
-    await _setup_schema(clean_db)
+    await _setup_pg_schema(clean_db)
     yield clean_db
 ```
+
+(Importing from a sibling test module is unusual but acceptable for
+this kind of shared schema helper; the alternative — duplicating the
+~80 lines of DDL into conftest.py — is worse. If pytest complains
+about the import at collection time, move the helper to
+`tests/checkpointer/_schema.py` and import from there in both places.)
 
 PG tests that exercise a PostgresCheckpointer instance MUST use
 `pg_v4_dsn` instead of raw `clean_db`. Tests that only assert
@@ -2421,9 +2435,17 @@ Steps parallel Task 14 with MySQL syntax:
 - Add `run_id VARCHAR(255) NULL` to `CubepiMessage` + composite index.
 - Add `CubepiRun` model (KEY-partitioned by thread_id, no FK).
 - Extend `_setup_schema(dsn)` in `test_mysql.py` (mirror of the
-  Postgres helper at `test_postgres.py:177`) to apply the v4 DDL.
-  Move it to `conftest.py` and expose a `mysql_v4_dsn` fixture:
+  Postgres helper at `test_postgres.py:177`) **in place** to apply
+  the v4 DDL. Update the parallel `test_expected_schema_version`
+  assertion in that file from `== 3` to `== 4`.
+
+  Then add the `mysql_v4_dsn` fixture in
+  `tests/checkpointer/conftest.py`, importing from the existing
+  module (same pattern as `pg_v4_dsn` in Task 14):
   ```python
+  from tests.checkpointer.test_mysql import _setup_schema as _setup_mysql_schema
+
+
   @pytest_asyncio.fixture
   async def mysql_v4_dsn(clean_mysql_db: str):
       await _setup_mysql_schema(clean_mysql_db)
@@ -2699,7 +2721,7 @@ async def test_prompt_sets_then_clears_active_run_id_on_clean_return():
 async def test_prompt_leaves_active_run_id_set_on_raise():
     # FauxProvider has no `error=` kwarg — subclass to raise inside the loop.
     class _RaisingProvider(FauxProvider):
-        async def stream_message(self, *args, **kwargs):
+        async def stream(self, *args, **kwargs):
             raise RuntimeError("provider down")
     a = Agent(model=_RaisingProvider().model("faux-model"))
     with pytest.raises(Exception):
@@ -2807,9 +2829,10 @@ async def test_appended_messages_carry_run_id():
 
 
 @pytest.mark.asyncio
-async def test_appending_message_with_mismatched_run_id_raises():
+async def test_prompt_rejects_mismatched_run_id_before_claim():
     """Caller pre-stamps a Message with a different run_id than the
-    active one. _process_event must reject rather than silently stamp."""
+    one supplied to prompt(). Reject BEFORE claim_run so no row is
+    written and the run_id is still reusable."""
     from cubepi.checkpointer.memory import MemoryCheckpointer
     from cubepi.providers.base import TextContent, UserMessage
 
@@ -2822,8 +2845,13 @@ async def test_appending_message_with_mismatched_run_id_raises():
     bad_msg = UserMessage(
         content=[TextContent(text="hi")], run_id="WRONG"
     )
-    with pytest.raises(ValueError, match="does not match active run_id"):
+    with pytest.raises(ValueError, match="does not match"):
         await a.prompt(bad_msg, run_id="R1")
+    # No claim row written — "R1" still freely claimable.
+    assert "R1" not in cp._runs.get("t", {})
+    # ... and a second prompt with the same run_id succeeds:
+    await a.prompt("hi", run_id="R1")
+    assert "R1" in cp._runs["t"]
 ```
 
 - [ ] **Step 2: Run → expect failure**
@@ -2833,12 +2861,39 @@ Expected: `m.run_id` is None.
 
 - [ ] **Step 3: Stamp in `Agent._process_event` (single chokepoint)**
 
+**Pre-flight in `Agent.prompt()` (BEFORE `claim_run`).** Validating
+caller-supplied `Message.run_id` mismatches only at `_process_event`
+time is too late — by then `claim_run` has already written a row.
+Walk the prompt input first:
+
+```python
+def _validate_input_run_ids(
+    self, message, effective_run_id: str
+) -> None:
+    if isinstance(message, str):
+        return
+    if isinstance(message, list):
+        candidates = message
+    else:
+        candidates = [message]
+    for m in candidates:
+        if getattr(m, "run_id", None) is not None and m.run_id != effective_run_id:
+            raise ValueError(
+                f"message.run_id={m.run_id!r} does not match "
+                f"prompt(run_id={effective_run_id!r})"
+            )
+```
+
+Call `self._validate_input_run_ids(message, effective_run_id)`
+immediately after `effective_run_id` is decided, BEFORE the HITL
+binding check, BEFORE `claim_run`.
+
+**Defense-in-depth in `_process_event`** (still keep this — the
+agent loop's own streaming may construct Messages elsewhere):
+
 In `cubepi/agent/agent.py`, locate `_process_event(self, event)` and
 the `MessageEndEvent` branch. Stamp `run_id` from
-`self._state.active_run_id` onto the message BEFORE it's appended /
-mirrored into state. **Validate any caller-supplied `run_id` matches**
-the active run — silent mismatch would split a run's identity in two
-and corrupt fork selection:
+`self._state.active_run_id` onto the message before it's appended:
 
 ```python
 elif isinstance(event, MessageEndEvent):
@@ -2849,6 +2904,9 @@ elif isinstance(event, MessageEndEvent):
             msg = msg.model_copy(update={"run_id": active})
             event = event.model_copy(update={"message": msg})
         elif msg.run_id != active:
+            # Should be impossible after the pre-flight in prompt(),
+            # but defend against future code paths that construct
+            # Messages with stale run_ids.
             raise ValueError(
                 f"message.run_id={msg.run_id!r} does not match "
                 f"active run_id={active!r}"
@@ -3213,7 +3271,7 @@ async def test_clean_success_marks_complete():
 @pytest.mark.asyncio
 async def test_provider_error_does_not_mark():
     class _RaisingProvider(FauxProvider):
-        async def stream_message(self, *args, **kwargs):
+        async def stream(self, *args, **kwargs):
             raise RuntimeError("provider down")
     a, cp = _agent(_RaisingProvider())
     with pytest.raises(Exception):
@@ -3224,32 +3282,42 @@ async def test_provider_error_does_not_mark():
 
 @pytest.mark.asyncio
 async def test_hitl_detached_outcome_suspended_no_mark():
-    """HitlDetached raised inside the loop → caught at loop.py:196 →
-    outcome 'suspended', no mark. respond() resume completes."""
-    from cubepi.hitl.testing import ScriptedHitlChannel
-    # Drive HITL via cubepi.hitl.testing.ScriptedHitlChannel which
-    # supports detach + reconnect; assert cp._runs[...].completed_at
-    # IS None after the detach, then after respond() IS NOT None.
-    # ... full setup mirrors tests/hitl/test_detach.py existing
-    # pattern (read that file before writing the test) ...
+    """Detach the channel mid-pause → loop catch at loop.py:196 sets
+    state.last_outcome="suspended" → no mark. After respond(), marker
+    IS written.
+
+    **Read tests/hitl/test_agent_respond.py first** — it contains the
+    real pattern for HITL pause + respond plumbing using
+    cubepi.hitl.testing helpers. Implement the test mirroring that
+    pattern; assert:
+      - After the pause: cp._runs["t"]["R1"].completed_at is None
+      - After respond("answer"): cp._runs["t"]["R1"].completed_at is not None
+    Do NOT invent a ScriptedHitlChannel — use the actual exports from
+    cubepi.hitl.testing.
+    """
 
 
 @pytest.mark.asyncio
 async def test_hitl_aborted_via_abort_pending_does_not_mark():
-    """abort_pending raises HitlAborted in the loop → caught at
-    loop.py:418 → outcome 'abandoned' (NOT 'suspended'). The
-    synthetic deny + terminal aborted assistant are appended by
-    agent.py:582-595 — assert they're present and that
-    cp._runs[...].completed_at is None."""
-    # ... setup pauses on HITL, then awaits agent.abort_pending(reason="x") ...
+    """abort_pending raises HitlAborted → loop.py:418 catch sets
+    state.last_outcome="abandoned" (NOT "suspended"). agent.py:582-595
+    appends the synthetic deny + terminal aborted assistant.
+
+    **Read tests/hitl/test_agent_abort_pending.py first** for the
+    abort_pending plumbing. Assert:
+      - cp._runs["t"]["R1"].completed_at is None
+      - The persisted messages contain a terminal aborted assistant
+        (`stop_reason == "aborted"`)
+    """
 
 
 @pytest.mark.asyncio
 async def test_incomplete_tool_cycle_does_not_mark():
     """after_model_response(decision='stop') on a tool-use response
-    triggers Task 27's invariant. Outcome 'incomplete', no marker."""
+    triggers the pre-completion invariant (Task 27).
+    state.last_outcome="incomplete" → no marker."""
+    from cubepi.middleware.base import TurnAction   # real module
     from cubepi.providers.base import ToolCall
-    from cubepi.agent.types import TurnAction
 
     p = FauxProvider()
     p.set_responses([
@@ -3258,8 +3326,13 @@ async def test_incomplete_tool_cycle_does_not_mark():
             stop_reason="tool_use",
         ),
     ])
+
+    # after_model_response signature: see
+    # cubepi/middleware/base.py:82 for the real argument shape.
+    # Verify against that signature when implementing.
     async def _stop_after(ctx):
         return TurnAction(decision="stop")
+
     cp = MemoryCheckpointer()
     a = Agent(
         model=p.model("faux-model"),
@@ -3275,7 +3348,7 @@ async def test_incomplete_tool_cycle_does_not_mark():
 @pytest.mark.asyncio
 async def test_propagating_cancel_does_not_mark():
     class _SlowProvider(FauxProvider):
-        async def stream_message(self, *args, **kwargs):
+        async def stream(self, *args, **kwargs):
             await asyncio.sleep(10)
             return  # unreachable
     a, cp = _agent(_SlowProvider())
@@ -3328,34 +3401,42 @@ RunOutcome = Literal["complete", "suspended", "incomplete", "abandoned"]
 ```
 
 Modify `cubepi/agent/loop.py`. **The existing public helpers
-`run_agent_loop`, `run_agent_loop_continue`, and `run_agent_loop_resume`
-return `list[Message]` and have callers in `tests/agent/test_loop.py`
-that assert on the list.** To avoid breaking them, change the return
-type to `tuple[list[Message], RunOutcome]` rather than replacing it.
+`run_agent_loop`, `run_agent_loop_continue`, `run_agent_loop_resume`
+return `list[Message]` and are exported from `cubepi`.** Do NOT change
+their public signatures — external callers and `tests/agent/test_loop.py`
+depend on the existing shape. Communicate outcome via state instead.
 
-- `run_agent_loop`, `run_agent_loop_continue`, `run_agent_loop_resume`,
-  `_run_loop`, `_run_loop_inner` return
-  `tuple[list[Message], RunOutcome]`. Existing exit paths
-  (currently `return new_messages`) become
-  `return new_messages, <outcome>`. The literals:
+Add a new field on `AgentState` (introduced in Task 5):
+```python
+class AgentState:
+    # ... existing fields ...
+    active_run_id: str | None = None
+    last_outcome: RunOutcome | None = None   # NEW
+```
+
+In `loop.py`, set `state.last_outcome = "<literal>"` at each exit path
+**before** the existing `return new_messages`. Public return type
+remains `list[Message]`. The literals:
   - After clean `AgentEndEvent` with terminal stop_reason and no
-    pending HITL → `return new_messages, "complete"`
+    pending HITL → set `state.last_outcome = "complete"` then
+    `return new_messages`
   - The existing combined `except (HitlDetached, HitlAborted)` blocks
     at `loop.py:196` and `loop.py:418` must be **split by exception
     type**:
     ```python
     except HitlDetached:
-        return new_messages, "suspended"
+        state.last_outcome = "suspended"
+        return new_messages
     except HitlAborted:
-        return new_messages, "abandoned"
+        state.last_outcome = "abandoned"
+        return new_messages
     ```
-    `HitlDetached` means "channel detached, the run can still be
-    resumed via respond()" — completion deferred to resume.
-    `HitlAborted` means "abort_pending was called; the synthetic deny
-    and terminal aborted assistant have already been appended by
-    `agent.py:582-595`" — terminal abandonment, no marker.
+    `HitlDetached` = channel detached, resumable via respond().
+    `HitlAborted` = abort_pending called; synthetic deny + terminal
+    aborted assistant already appended by `agent.py:582-595`.
   - After the early-exit branch on `stop_reason in ("error", "aborted")`
-    at `loop.py:485` → `return new_messages, "abandoned"`
+    at `loop.py:485` → set `state.last_outcome = "abandoned"`
+    then `return new_messages`
   - When `check_tool_cycle(...)` (from Task 27) raises
     `ToolCycleViolation` immediately before declaring `complete`,
     catch it and `return "incomplete"` instead
@@ -3365,26 +3446,28 @@ type to `tuple[list[Message], RunOutcome]` rather than replacing it.
   must also forward the outcome.
 
 Modify `cubepi/agent/agent.py`:
-- `_run_prompt` and `_run_hitl_resume` return
-  `tuple[list[Message], RunOutcome]`.
+- `_run_prompt` and `_run_hitl_resume` return `list[Message]` (no
+  signature change).
 - In `Agent.prompt()` (replacing the placeholder line `await
   self._run_prompt(...)`):
   ```python
-  _new_messages, outcome = await self._run_prompt(
-      message, run_id=effective_run_id
-  )
+  self._state.last_outcome = None
+  await self._run_prompt(message, run_id=effective_run_id)
+  outcome = self._state.last_outcome or "abandoned"
   await self._dispatch_outcome(outcome, effective_run_id)
   ```
 - In `Agent.respond()`:
   ```python
-  _new_messages, outcome = await self._run_hitl_resume(...)
+  self._state.last_outcome = None
+  await self._run_hitl_resume(...)
+  outcome = self._state.last_outcome or "abandoned"
   await self._dispatch_outcome(outcome, recovered_run_id)
   ```
 
-**Update `tests/agent/test_loop.py`** to expect tuples. Existing
-assertions of the form `result = await run_agent_loop(...)` become
-`messages, _outcome = await run_agent_loop(...)`. Mention this
-explicitly in the task body so the implementer doesn't skip it.
+`tests/agent/test_loop.py` does NOT need updates — public return
+type is unchanged. The breaking surface stays limited to
+`Agent.prompt()` return type (`None` → `str`), already in the
+spec's documented breaking-changes list.
 - New private helper `_dispatch_outcome`:
   ```python
   async def _dispatch_outcome(
@@ -3635,13 +3718,63 @@ def check_tool_cycle(messages: list[Message]) -> None:
             )
 ```
 
-- [ ] **Step 4: Wire into the loop's completion path**
+- [ ] **Step 4: Wire into the Agent-layer completion dispatch**
 
-In `cubepi/agent/loop.py`, just before declaring outcome `complete` for
-a run, gather the messages tagged with this `run_id` appended since
-claim and call `check_tool_cycle(run_messages)`. On `ToolCycleViolation`,
-set the outcome to `"incomplete"` instead of `"complete"` — that flows
-into Task 26's outcome dispatcher (no mark, claim remains).
+`loop.py` has no `run_id` parameter — the active run_id lives on
+`AgentState.active_run_id` (Task 5). Apply the invariant from `Agent`,
+NOT `loop.py`:
+
+In `cubepi/agent/agent.py`, modify the `_dispatch_outcome` helper
+introduced in Task 26 Step 3. BEFORE writing the mark, when
+`outcome == "complete"`, scan the run's messages and demote on
+violation:
+
+```python
+from cubepi.agent._tool_cycle import ToolCycleViolation, check_tool_cycle
+
+
+async def _dispatch_outcome(
+    self, outcome: RunOutcome, run_id: str
+) -> None:
+    if outcome == "complete":
+        run_messages = [
+            m for m in self._state.messages if m.run_id == run_id
+        ]
+        try:
+            check_tool_cycle(run_messages)
+        except ToolCycleViolation:
+            outcome = "incomplete"
+    if outcome != "complete":
+        return
+    if not (self._run_aware and self.thread_id):
+        return
+    try:
+        await self.checkpointer.mark_run_complete(
+            self.thread_id, run_id
+        )
+    except Exception as exc:
+        raise CompletionMarkerFailedError(
+            thread_id=self.thread_id, run_id=run_id, cause=exc
+        ) from exc
+```
+
+**On HITL resume specifically.** When `respond()` resumes a run, the
+pre-suspend tool-use assistant is still in `state.messages`
+(loaded from the checkpointer at lazy-load time and carrying the same
+`run_id`). Filtering by `m.run_id == run_id` picks up the full
+cross-suspend run. The invariant therefore catches a tool-use that
+remained unresolved across the pause.
+
+Add a resume-path test to Task 26 (or as an extra in
+`tests/agent/test_tool_cycle_invariant.py`):
+```python
+@pytest.mark.asyncio
+async def test_tool_cycle_invariant_spans_hitl_resume(memory_cp):
+    """Pause mid-tool-use; resume; if resume returns without resolving
+    the tool_use, mark must NOT be written even though respond's
+    last-segment messages look 'clean'."""
+    # ... pattern from tests/hitl/test_agent_respond.py ...
+```
 
 - [ ] **Step 5: Run tests → expect pass**
 

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -3270,45 +3270,96 @@ async def test_clean_success_marks_complete():
 
 @pytest.mark.asyncio
 async def test_provider_error_does_not_mark():
+    """A provider exception is caught by the agent lifecycle, which
+    appends a synthetic assistant with stop_reason='error' and
+    RETURNS NORMALLY (does not re-raise). state.last_outcome is set
+    to "abandoned" via the loop.py:485 branch, dispatch sees
+    not-complete, mark_run_complete is not called."""
     class _RaisingProvider(FauxProvider):
         async def stream(self, *args, **kwargs):
             raise RuntimeError("provider down")
     a, cp = _agent(_RaisingProvider())
-    with pytest.raises(Exception):
-        await a.prompt("hi", run_id="R1")
+    await a.prompt("hi", run_id="R1")  # returns normally, no raise
     rs = cp._runs["t"]["R1"]
     assert rs.completed_at is None
+    # The synthetic error assistant is persisted.
+    data = await cp.load("t")
+    assert any(
+        getattr(m, "stop_reason", None) == "error"
+        for m in data.messages
+    )
 
 
 @pytest.mark.asyncio
 async def test_hitl_detached_outcome_suspended_no_mark():
-    """Detach the channel mid-pause → loop catch at loop.py:196 sets
+    """Detach the channel mid-pause → loop catch sets
     state.last_outcome="suspended" → no mark. After respond(), marker
     IS written.
 
-    **Read tests/hitl/test_agent_respond.py first** — it contains the
-    real pattern for HITL pause + respond plumbing using
-    cubepi.hitl.testing helpers. Implement the test mirroring that
-    pattern; assert:
-      - After the pause: cp._runs["t"]["R1"].completed_at is None
-      - After respond("answer"): cp._runs["t"]["R1"].completed_at is not None
-    Do NOT invent a ScriptedHitlChannel — use the actual exports from
-    cubepi.hitl.testing.
+    Implementation note: BEFORE writing this test, open
+    `tests/hitl/test_agent_respond.py` and mirror its full setup —
+    Provider that emits an ask_user tool_call, CheckpointedChannel
+    construction, `Agent.prompt()` awaited inside an asyncio.Task
+    that detaches the channel mid-flight, then `Agent.respond()`
+    on a fresh Agent constructed from the same checkpointer/thread_id.
     """
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+    from cubepi.hitl.ask_user import ask_user_tool
+    from cubepi.hitl.channel import CheckpointedChannel
+
+    cp = MemoryCheckpointer()
+    # ... mirror tests/hitl/test_agent_respond.py setup ...
+    # Step 1: scripted FauxProvider that returns an ask_user tool_call
+    #         on first stream() invocation, then a final assistant on
+    #         the second (after the answer is appended).
+    # Step 2: ch = CheckpointedChannel(checkpointer=cp, thread_id="t",
+    #                                  run_id="R1")
+    #         tool = ask_user_tool(ch)
+    #         a = Agent(model=..., tools=[tool], checkpointer=cp,
+    #                   thread_id="t")
+    # Step 3: task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    # Step 4: await pending = wait for pending_request row
+    # Step 5: ch.detach() / channel HitlDetached path
+    # Step 6: await task  # returns; state.last_outcome == "suspended"
+
+    assert cp._runs["t"]["R1"].completed_at is None
+
+    # Resume with a fresh Agent + answer.
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(model=..., tools=[tool2], checkpointer=cp, thread_id="t")
+    # Find the pending question_id from cp.load_pending("t")
+    pending = await cp.load_pending("t")
+    qid = pending[0].question_id
+    await a2.respond(qid, "yes")
+    assert cp._runs["t"]["R1"].completed_at is not None
 
 
 @pytest.mark.asyncio
 async def test_hitl_aborted_via_abort_pending_does_not_mark():
-    """abort_pending raises HitlAborted → loop.py:418 catch sets
+    """abort_pending raises HitlAborted → loop catch sets
     state.last_outcome="abandoned" (NOT "suspended"). agent.py:582-595
     appends the synthetic deny + terminal aborted assistant.
 
-    **Read tests/hitl/test_agent_abort_pending.py first** for the
-    abort_pending plumbing. Assert:
-      - cp._runs["t"]["R1"].completed_at is None
-      - The persisted messages contain a terminal aborted assistant
-        (`stop_reason == "aborted"`)
+    Mirror tests/hitl/test_agent_abort_pending.py for the
+    abort_pending plumbing.
     """
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+    from cubepi.hitl.ask_user import ask_user_tool
+    from cubepi.hitl.channel import CheckpointedChannel
+
+    cp = MemoryCheckpointer()
+    # ... mirror tests/hitl/test_agent_abort_pending.py setup ...
+    # Construct as in the detached test, then instead of detach +
+    # respond, call await a.abort_pending(reason="user cancelled").
+
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is None
+    data = await cp.load("t")
+    assert any(
+        getattr(m, "stop_reason", None) == "aborted"
+        for m in data.messages
+    )
 
 
 @pytest.mark.asyncio
@@ -3327,10 +3378,13 @@ async def test_incomplete_tool_cycle_does_not_mark():
         ),
     ])
 
-    # after_model_response signature: see
-    # cubepi/middleware/base.py:82 for the real argument shape.
-    # Verify against that signature when implementing.
-    async def _stop_after(ctx):
+    # after_model_response signature per cubepi/middleware/base.py:76:
+    #   async def after_model_response(
+    #       self, response: AssistantMessage, ctx: AgentContext,
+    #       *, signal: asyncio.Event | None = None,
+    #   ) -> TurnAction | None
+    # As a callable hook passed to Agent, drop `self`:
+    async def _stop_after(response, ctx, *, signal=None):
         return TurnAction(decision="stop")
 
     cp = MemoryCheckpointer()
@@ -3403,10 +3457,12 @@ RunOutcome = Literal["complete", "suspended", "incomplete", "abandoned"]
 Modify `cubepi/agent/loop.py`. **The existing public helpers
 `run_agent_loop`, `run_agent_loop_continue`, `run_agent_loop_resume`
 return `list[Message]` and are exported from `cubepi`.** Do NOT change
-their public signatures — external callers and `tests/agent/test_loop.py`
-depend on the existing shape. Communicate outcome via state instead.
+their public return type. But `loop.py` has no `AgentState` reference
+(it receives an `AgentContext` snapshot), so the outcome can't be
+written to state from inside the loop. Use an **outcome sink callback**.
 
-Add a new field on `AgentState` (introduced in Task 5):
+Add a new field on `AgentState` (Task 5 introduced `active_run_id`;
+this adds the sibling):
 ```python
 class AgentState:
     # ... existing fields ...
@@ -3414,28 +3470,51 @@ class AgentState:
     last_outcome: RunOutcome | None = None   # NEW
 ```
 
-In `loop.py`, set `state.last_outcome = "<literal>"` at each exit path
-**before** the existing `return new_messages`. Public return type
-remains `list[Message]`. The literals:
+Add an optional callback parameter to each public loop helper
+(`run_agent_loop`, `run_agent_loop_continue`, `run_agent_loop_resume`)
+AND the private `_run_loop` / `_run_loop_inner`:
+
+```python
+async def run_agent_loop(
+    *,
+    # ... all existing params unchanged ...
+    set_outcome: Callable[[str], None] | None = None,
+) -> list[Message]:
+    ...
+```
+
+External callers omit `set_outcome` (default `None`) — completely
+non-breaking. Tests in `tests/agent/test_loop.py` keep working without
+changes.
+
+Inside the loop helpers, at each exit path call
+`set_outcome("<literal>")` BEFORE the existing `return new_messages`
+(guarded by `set_outcome is not None`). Pass `set_outcome` down through
+`_run_loop` / `_run_loop_inner` the same way other callables are
+threaded today.
+
+The literals:
   - After clean `AgentEndEvent` with terminal stop_reason and no
-    pending HITL → set `state.last_outcome = "complete"` then
+    pending HITL → `if set_outcome: set_outcome("complete")` then
     `return new_messages`
   - The existing combined `except (HitlDetached, HitlAborted)` blocks
     at `loop.py:196` and `loop.py:418` must be **split by exception
     type**:
     ```python
     except HitlDetached:
-        state.last_outcome = "suspended"
+        if set_outcome is not None:
+            set_outcome("suspended")
         return new_messages
     except HitlAborted:
-        state.last_outcome = "abandoned"
+        if set_outcome is not None:
+            set_outcome("abandoned")
         return new_messages
     ```
     `HitlDetached` = channel detached, resumable via respond().
     `HitlAborted` = abort_pending called; synthetic deny + terminal
     aborted assistant already appended by `agent.py:582-595`.
   - After the early-exit branch on `stop_reason in ("error", "aborted")`
-    at `loop.py:485` → set `state.last_outcome = "abandoned"`
+    at `loop.py:485` → `if set_outcome: set_outcome("abandoned")`
     then `return new_messages`
   - When `check_tool_cycle(...)` (from Task 27) raises
     `ToolCycleViolation` immediately before declaring `complete`,
@@ -3447,7 +3526,16 @@ remains `list[Message]`. The literals:
 
 Modify `cubepi/agent/agent.py`:
 - `_run_prompt` and `_run_hitl_resume` return `list[Message]` (no
-  signature change).
+  signature change) and internally pass `set_outcome=` to
+  `run_agent_loop` / `run_agent_loop_resume`. The sink writes into
+  `self._state.last_outcome`:
+  ```python
+  def _outcome_sink(self):
+      def _sink(value: str) -> None:
+          self._state.last_outcome = value
+      return _sink
+  ```
+  Each call site passes `set_outcome=self._outcome_sink()`.
 - In `Agent.prompt()` (replacing the placeholder line `await
   self._run_prompt(...)`):
   ```python
@@ -3465,9 +3553,10 @@ Modify `cubepi/agent/agent.py`:
   ```
 
 `tests/agent/test_loop.py` does NOT need updates — public return
-type is unchanged. The breaking surface stays limited to
-`Agent.prompt()` return type (`None` → `str`), already in the
-spec's documented breaking-changes list.
+type AND default behavior are unchanged (sink is optional). The
+breaking surface stays limited to `Agent.prompt()` return type
+(`None` → `str`), already in the spec's documented breaking-changes
+list.
 - New private helper `_dispatch_outcome`:
   ```python
   async def _dispatch_outcome(
@@ -3769,11 +3858,26 @@ Add a resume-path test to Task 26 (or as an extra in
 `tests/agent/test_tool_cycle_invariant.py`):
 ```python
 @pytest.mark.asyncio
-async def test_tool_cycle_invariant_spans_hitl_resume(memory_cp):
-    """Pause mid-tool-use; resume; if resume returns without resolving
-    the tool_use, mark must NOT be written even though respond's
-    last-segment messages look 'clean'."""
-    # ... pattern from tests/hitl/test_agent_respond.py ...
+async def test_tool_cycle_invariant_spans_hitl_resume():
+    """Pause mid-tool-use; resume; if resume returns without
+    resolving the tool_use (e.g., an after_model_response middleware
+    rewrites the assistant to drop the unresolved tool_use), mark
+    must NOT be written even though respond's last-segment messages
+    look 'clean' on their own.
+
+    Setup mirror: tests/hitl/test_agent_respond.py for the pause +
+    respond plumbing. Provider script: turn 1 = assistant with
+    ask_user tool_call → pause. Resume: turn 2 = assistant with an
+    unrelated unresolved tool_call (e.g., name='lookup', id='c1', no
+    matching ToolResultMessage). The invariant filters state.messages
+    by m.run_id=='R1' — sees the unresolved c1 → outcome demoted to
+    'incomplete' → marker NOT written.
+    """
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+    cp = MemoryCheckpointer()
+    # ... full setup omitted; pattern is identical to
+    # test_hitl_detached_outcome_suspended_no_mark in Task 26 ...
+    assert cp._runs["t"]["R1"].completed_at is None
 ```
 
 - [ ] **Step 5: Run tests → expect pass**

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -3348,21 +3348,10 @@ async def test_hitl_detached_outcome_suspended_no_mark():
     await task  # returns normally; state.last_outcome == "suspended"
     assert cp._runs["t"]["R1"].completed_at is None
 
-    # Resume with a fresh Agent on a fresh channel; provide answer.
-    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
-    tool2 = ask_user_tool(ch2)
-    a2 = Agent(
-        model=p.model("faux-model"),
-        tools=[tool2],
-        checkpointer=cp,
-        thread_id="t",
-        channel=ch2,
-    )
-    pending = await cp.load_pending("t")
-    qid = pending[0].question_id
-    # respond() is keyword-only — see agent.py:431.
-    await a2.respond(question_id=qid, answer="yes")
-    assert cp._runs["t"]["R1"].completed_at is not None
+    # NOTE: The resume-writes-marker assertion lives in Task 28
+    # (test_respond_resume_writes_marker), because run_id recovery
+    # via load_pending() is implemented there. At Task 26 we only
+    # assert the suspended-state-no-marker portion.
 
 
 @pytest.mark.asyncio
@@ -3410,41 +3399,11 @@ async def test_hitl_aborted_via_abort_pending_does_not_mark():
     )
 
 
-@pytest.mark.asyncio
-async def test_incomplete_tool_cycle_does_not_mark():
-    """after_model_response(decision='stop') on a tool-use response
-    triggers the pre-completion invariant (Task 27).
-    state.last_outcome="incomplete" → no marker."""
-    from cubepi.middleware.base import TurnAction   # real module
-    from cubepi.providers.base import ToolCall
-
-    p = FauxProvider()
-    p.set_responses([
-        AssistantMessage(
-            content=[ToolCall(id="c1", name="t", arguments={})],
-            stop_reason="tool_use",
-        ),
-    ])
-
-    # after_model_response signature per cubepi/middleware/base.py:76:
-    #   async def after_model_response(
-    #       self, response: AssistantMessage, ctx: AgentContext,
-    #       *, signal: asyncio.Event | None = None,
-    #   ) -> TurnAction | None
-    # As a callable hook passed to Agent, drop `self`:
-    async def _stop_after(response, ctx, *, signal=None):
-        return TurnAction(decision="stop")
-
-    cp = MemoryCheckpointer()
-    a = Agent(
-        model=p.model("faux-model"),
-        checkpointer=cp,
-        thread_id="t",
-        after_model_response=_stop_after,
-    )
-    await a.prompt("hi", run_id="R1")
-    rs = cp._runs["t"]["R1"]
-    assert rs.completed_at is None
+# Note: test_incomplete_tool_cycle_does_not_mark is implemented in
+# Task 27 alongside the _tool_cycle.py helper that demotes
+# "complete" → "incomplete". The outcome table row above is covered
+# by that task's tests; we do not stub it here at Task 26 because
+# the check_tool_cycle helper doesn't exist yet.
 
 
 @pytest.mark.asyncio
@@ -3902,9 +3861,47 @@ pre-suspend tool-use assistant is still in `state.messages`
 cross-suspend run. The invariant therefore catches a tool-use that
 remained unresolved across the pause.
 
-Add a resume-path test to Task 26 (or as an extra in
-`tests/agent/test_tool_cycle_invariant.py`):
+Add TWO tests to `tests/agent/test_tool_cycle_invariant.py`. The
+first is the straight `after_model_response(decision="stop")` case
+that was moved out of Task 26 because the helper this task
+introduces is what catches it:
+
 ```python
+@pytest.mark.asyncio
+async def test_incomplete_tool_cycle_does_not_mark():
+    """after_model_response(decision='stop') on a tool-use response
+    leaves an unresolved tool_call. _dispatch_outcome filters
+    state.messages by run_id and demotes 'complete' to 'incomplete'
+    via check_tool_cycle. Marker not written."""
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+    from cubepi.middleware.base import TurnAction
+    from cubepi.providers.base import (
+        AssistantMessage, ToolCall,
+    )
+    from cubepi.providers.faux import FauxProvider
+
+    p = FauxProvider()
+    p.set_responses([
+        AssistantMessage(
+            content=[ToolCall(id="c1", name="t", arguments={})],
+            stop_reason="tool_use",
+        ),
+    ])
+
+    async def _stop_after(response, ctx, *, signal=None):
+        return TurnAction(decision="stop")
+
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=p.model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+        after_model_response=_stop_after,
+    )
+    await a.prompt("hi", run_id="R1")
+    assert cp._runs["t"]["R1"].completed_at is None
+
+
 @pytest.mark.asyncio
 async def test_tool_cycle_invariant_spans_hitl_resume():
     """Pause mid-tool-use (ask_user). Resume; provider then emits an

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -1,0 +1,3835 @@
+# Conversation Fork — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement run-based conversation fork (`Agent.fork()` + `Agent.fork_once()`) per `dev/specs/2026-06-05-conversation-fork.md` (V2, codex-clean at commit d27276d).
+
+**Architecture:**
+- Add per-message `run_id`, a `cubepi_runs` table per backend tracking
+  `(thread_id, run_id, claimed_at, completed_at, completion_seq)`, and the
+  Checkpointer Protocol methods `claim_run` / `mark_run_complete` /
+  `snapshot` / `fork` / `load_pending`. Agent.prompt() claims at start,
+  marks at clean terminal exit; fork is a set-based physical copy keyed by
+  completed `run_id`s.
+- Implementations across Memory / SQLite / Postgres / MySQL, with a
+  legacy-degraded mode for third-party v3-only checkpointers.
+- HITL channel run_id binding enforced at prompt() entry via a structural
+  `HitlBinding` attribute on `AgentTool` / `Middleware`.
+
+**Tech Stack:** Python 3.13, pydantic v2, asyncio, aiosqlite, asyncpg,
+aiomysql, SQLAlchemy 2.0, pytest (asyncio_mode=auto), uv, ruff, mypy.
+
+**Out of scope (separate spec):** `Agent.delete_run()`, cubebox UI wiring,
+backfill of legacy threads.
+
+---
+
+## Phase 0 — Bootstrap & spec checkpoint
+
+### Task 0: Pre-flight
+
+**Files:** none modified
+
+- [ ] **Step 1: Confirm worktree + branch**
+
+Run:
+```
+git rev-parse --abbrev-ref HEAD
+git status
+```
+Expected: branch `2026-06-05-conversation-fork`, working tree clean.
+
+- [ ] **Step 2: Confirm spec is the codex-clean V2**
+
+Run: `git log --oneline 3a1490e..HEAD | head -1`
+Expected: most recent commit is `d27276d spec: address v2 R10 codex finding (tighten tool-cycle invariant)`.
+
+- [ ] **Step 3: Install + baseline test run**
+
+Run:
+```
+uv sync --all-extras --dev
+uv run pytest tests/ -x -q
+```
+Expected: all green (existing tests, no impl changes yet).
+
+---
+
+## Phase 1 — Foundation types
+
+Define the data shapes the rest of the plan builds on. No behavior yet.
+
+### Task 1: Add `CheckpointerError` runtime base + fork-error types
+
+**Files:**
+- Modify: `cubepi/checkpointer/exceptions.py`
+- Test: `tests/checkpointer/test_exceptions.py` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/checkpointer/test_exceptions.py`:
+```python
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    CheckpointerError,
+    CheckpointerLockTimeoutError,
+    CompletionMarkerFailedError,
+    CubepiSchemaError,
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [
+        ThreadNotFoundError,
+        ThreadAlreadyExistsError,
+        RunNotCompletedError,
+        RunNotClaimedError,
+        RunAlreadyClaimedError,
+        RunAlreadyCompletedError,
+        CheckpointerLockTimeoutError,
+    ],
+)
+def test_runtime_errors_inherit_checkpointer_error(exc_cls):
+    assert issubclass(exc_cls, CheckpointerError)
+    assert issubclass(exc_cls, Exception)
+
+
+def test_checkpointer_error_separate_from_schema_error():
+    assert not issubclass(CheckpointerError, CubepiSchemaError)
+    assert not issubclass(CubepiSchemaError, CheckpointerError)
+
+
+def test_completion_marker_failed_error_carries_run_id():
+    cause = RuntimeError("db timeout")
+    exc = CompletionMarkerFailedError(
+        thread_id="t1", run_id="r1", cause=cause
+    )
+    assert exc.thread_id == "t1"
+    assert exc.run_id == "r1"
+    assert exc.__cause__ is cause
+    assert "t1" in str(exc) and "r1" in str(exc)
+
+
+def test_runtime_errors_constructable_with_kwargs():
+    e = ThreadNotFoundError("missing thread t1")
+    assert "t1" in str(e)
+    e = RunNotCompletedError("thread=t1 run=r1")
+    assert "r1" in str(e)
+```
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_exceptions.py -v`
+Expected: `ImportError: cannot import name 'CheckpointerError' …`
+
+- [ ] **Step 3: Extend `cubepi/checkpointer/exceptions.py`**
+
+Append to the existing file:
+```python
+class CheckpointerError(Exception):
+    """Base class for cubepi checkpointer runtime errors.
+
+    Distinct from ``CubepiSchemaError`` (schema-vs-library incompatibility).
+    ``CheckpointerError`` covers runtime operation outcomes — missing
+    thread, lock timeout, run state, etc.
+    """
+
+
+class ThreadNotFoundError(CheckpointerError):
+    pass
+
+
+class ThreadAlreadyExistsError(CheckpointerError):
+    pass
+
+
+class RunNotCompletedError(CheckpointerError):
+    """The cubepi_runs row for (thread_id, run_id) does not exist, or
+    exists with completed_at IS NULL (paused, abandoned, or in flight)."""
+
+
+class RunNotClaimedError(CheckpointerError):
+    """mark_run_complete() called but no cubepi_runs row exists for
+    (thread_id, run_id). Indicates an agent-loop logic bug."""
+
+
+class RunAlreadyClaimedError(CheckpointerError):
+    """claim_run() found an existing row with completed_at IS NULL.
+    Another process is currently running this run_id; retry with a
+    different run_id."""
+
+
+class RunAlreadyCompletedError(CheckpointerError):
+    """claim_run() found an existing row with completed_at IS NOT NULL.
+    Runs are append-only; start a new run with a different run_id.
+
+    NOT raised by mark_run_complete() — that path is idempotent on
+    already-completed rows (spec §3.6.2).
+    """
+
+
+class CheckpointerLockTimeoutError(CheckpointerError):
+    """Backend writer lock not acquired within the configured timeout
+    (SQLite busy_timeout, etc.)."""
+
+
+class CompletionMarkerFailedError(CheckpointerError):
+    """mark_run_complete() failed AFTER the run's final append succeeded.
+    Carries `run_id` so callers using prompt(run_id=None) can recover
+    the cubepi-generated value (spec §3.6.2)."""
+
+    def __init__(
+        self,
+        *,
+        thread_id: str,
+        run_id: str,
+        cause: BaseException,
+    ) -> None:
+        super().__init__(
+            f"mark_run_complete failed for ({thread_id}, {run_id}): {cause}"
+        )
+        self.thread_id = thread_id
+        self.run_id = run_id
+        self.__cause__ = cause
+```
+
+- [ ] **Step 4: Run test → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_exceptions.py -v`
+Expected: 11 passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/exceptions.py tests/checkpointer/test_exceptions.py
+git commit -m "feat(checkpointer): add CheckpointerError runtime hierarchy"
+```
+
+---
+
+### Task 2: Add `parent_thread_id` to `CheckpointData`
+
+**Files:**
+- Modify: `cubepi/checkpointer/base.py`
+- Test: `tests/checkpointer/test_base.py` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/checkpointer/test_base.py`:
+```python
+from cubepi.checkpointer.base import CheckpointData
+
+
+def test_checkpoint_data_default_parent_is_none():
+    cd = CheckpointData()
+    assert cd.parent_thread_id is None
+    assert cd.messages == []
+    assert cd.extra == {}
+
+
+def test_checkpoint_data_with_parent():
+    cd = CheckpointData(parent_thread_id="src_thread")
+    assert cd.parent_thread_id == "src_thread"
+
+
+def test_checkpoint_data_keyword_construction_unchanged():
+    cd = CheckpointData(messages=[], extra={"k": "v"})
+    assert cd.extra == {"k": "v"}
+    assert cd.parent_thread_id is None
+```
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_base.py -v`
+Expected: `AttributeError: 'CheckpointData' object has no attribute 'parent_thread_id'`.
+
+- [ ] **Step 3: Extend `CheckpointData`**
+
+In `cubepi/checkpointer/base.py`, modify the `CheckpointData` dataclass:
+```python
+@dataclass
+class CheckpointData:
+    messages: list[Message] = field(default_factory=list)
+    extra: JsonObject = field(default_factory=dict)
+    parent_thread_id: str | None = None
+```
+
+- [ ] **Step 4: Run test → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_base.py -v`
+Expected: 3 passed. Also run existing checkpointer tests: `uv run pytest tests/checkpointer/ -q` — all green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/base.py tests/checkpointer/test_base.py
+git commit -m "feat(checkpointer): add parent_thread_id field to CheckpointData"
+```
+
+---
+
+### Task 3: Add `run_id` to all three Message variants
+
+**Files:**
+- Modify: `cubepi/providers/base.py`
+- Test: `tests/providers/test_message_run_id.py` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/providers/test_message_run_id.py`:
+```python
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolResultMessage,
+    UserMessage,
+)
+
+
+def test_user_message_run_id_default_none():
+    m = UserMessage(content=[TextContent(text="hi")])
+    assert m.run_id is None
+
+
+def test_assistant_message_run_id_default_none():
+    m = AssistantMessage(content=[])
+    assert m.run_id is None
+
+
+def test_tool_result_message_run_id_default_none():
+    m = ToolResultMessage(
+        tool_call_id="tc1", tool_name="foo", content=[]
+    )
+    assert m.run_id is None
+
+
+def test_run_id_round_trip_serialization():
+    src = AssistantMessage(content=[], run_id="r-1")
+    blob = src.model_dump_json()
+    dst = AssistantMessage.model_validate_json(blob)
+    assert dst.run_id == "r-1"
+
+
+def test_run_id_is_keyword_only_in_practice():
+    # All existing call sites pass content positionally / by keyword;
+    # adding run_id as a defaulted field at the end is non-breaking.
+    m = UserMessage(content=[TextContent(text="hi")], run_id="r-2")
+    assert m.run_id == "r-2"
+```
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/providers/test_message_run_id.py -v`
+Expected: `ValidationError` or attribute errors on `run_id`.
+
+- [ ] **Step 3: Add field to all three variants**
+
+In `cubepi/providers/base.py`, add `run_id: str | None = None` to
+`UserMessage`, `AssistantMessage`, and `ToolResultMessage` — last field
+in each class so positional construction is unaffected:
+
+```python
+class UserMessage(BaseModel):
+    role: Literal["user"] = "user"
+    content: list[Content]
+    timestamp: float | None = None
+    metadata: JsonObject = Field(default_factory=dict)
+    run_id: str | None = None
+
+
+class AssistantMessage(BaseModel):
+    role: Literal["assistant"] = "assistant"
+    content: list[Content | ThinkingContent | ToolCall]
+    stop_reason: str = "stop"
+    error_message: str | None = None
+    usage: Usage | None = None
+    timestamp: float | None = None
+    provider_id: str = ""
+    model_id: str = ""
+    response_id: str | None = None
+    metadata: JsonObject = Field(default_factory=dict)
+    run_id: str | None = None
+
+
+class ToolResultMessage(BaseModel):
+    role: Literal["tool_result"] = "tool_result"
+    tool_call_id: str
+    tool_name: str
+    content: list[Content]
+    details: StructuredValue = None
+    is_error: bool = False
+    timestamp: float | None = None
+    metadata: JsonObject = Field(default_factory=dict)
+    run_id: str | None = None
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/providers/test_message_run_id.py tests/providers/ -q`
+Expected: all pass. Also `uv run mypy cubepi/providers/base.py` clean.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/providers/base.py tests/providers/test_message_run_id.py
+git commit -m "feat(providers): add run_id field to Message variants"
+```
+
+---
+
+### Task 4: Add `HitlBinding` type + attach to `AgentTool` and `Middleware`
+
+**Files:**
+- Modify: `cubepi/agent/types.py`
+- Modify: `cubepi/middleware/base.py`
+- Create: `cubepi/hitl/binding.py` (so importing it doesn't pull the agent module)
+- Test: `tests/agent/test_hitl_binding.py` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/agent/test_hitl_binding.py`:
+```python
+from cubepi.agent.types import AgentTool
+from cubepi.hitl.binding import HitlBinding
+from cubepi.middleware.base import Middleware
+from pydantic import BaseModel
+
+
+class _NoArgs(BaseModel):
+    pass
+
+
+async def _noop(tool_call_id, args, *, signal=None, on_update=None):
+    raise NotImplementedError
+
+
+def test_agent_tool_hitl_default_none():
+    t = AgentTool(
+        name="t",
+        description="d",
+        parameters=_NoArgs,
+        execute=_noop,
+    )
+    assert t.hitl is None
+
+
+def test_agent_tool_hitl_can_be_set():
+    binding = HitlBinding(checkpointed=True, run_id="r-1")
+    t = AgentTool(
+        name="t",
+        description="d",
+        parameters=_NoArgs,
+        execute=_noop,
+        hitl=binding,
+    )
+    assert t.hitl is binding
+    assert t.hitl.checkpointed is True
+    assert t.hitl.run_id == "r-1"
+
+
+def test_middleware_hitl_default_none():
+    class _Mw(Middleware):
+        pass
+
+    assert _Mw().hitl is None
+
+
+def test_middleware_hitl_can_be_set_in_subclass():
+    class _Mw(Middleware):
+        def __init__(self) -> None:
+            self.hitl = HitlBinding(checkpointed=False, run_id=None)
+
+    mw = _Mw()
+    assert mw.hitl is not None
+    assert mw.hitl.checkpointed is False
+    assert mw.hitl.run_id is None
+
+
+def test_hitl_binding_is_frozen():
+    b = HitlBinding(checkpointed=True, run_id="r-1")
+    try:
+        b.checkpointed = False  # type: ignore[misc]
+    except Exception:
+        return
+    assert False, "HitlBinding should be frozen"
+```
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/agent/test_hitl_binding.py -v`
+Expected: `ImportError: cannot import name 'HitlBinding'`.
+
+- [ ] **Step 3: Create `cubepi/hitl/binding.py`**
+
+```python
+"""HitlBinding — structural attribute on AgentTool and Middleware
+declaring how a HITL element integrates with the checkpointer.
+
+See dev/specs/2026-06-05-conversation-fork.md §3.6.3.1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HitlBinding:
+    """How a tool/middleware integrates with HITL.
+
+    Attributes:
+        checkpointed: True iff backed by ``CheckpointedChannel`` (writes
+            ``pending_request`` to the source thread on pause).
+        run_id: The channel's bound run_id. For checkpointed HITL this
+            MUST be a non-empty string; ``None`` is a configuration
+            error and is rejected at ``Agent.prompt()`` entry. For
+            in-memory HITL it is ``None``.
+    """
+
+    checkpointed: bool
+    run_id: str | None
+```
+
+- [ ] **Step 4: Add `hitl: HitlBinding | None = None` to `AgentTool`**
+
+In `cubepi/agent/types.py`, extend `AgentTool` (last field):
+```python
+from cubepi.hitl.binding import HitlBinding
+
+
+@dataclass
+class AgentTool(Generic[TParams]):
+    name: str
+    description: str
+    parameters: type[TParams]
+    execute: Callable[..., Awaitable[AgentToolResult]]
+    label: str = ""
+    execution_mode: Literal["sequential", "parallel"] | None = None
+    hitl_builtin: bool = False
+    hitl: HitlBinding | None = None
+```
+
+Note: `hitl_builtin` is the pre-existing flag for "this tool is one of
+cubepi's built-in HITL tools" — leave it alone. The new `hitl`
+attribute is independent and carries structural binding info.
+
+- [ ] **Step 5: Add `hitl: HitlBinding | None = None` to `Middleware`**
+
+In `cubepi/middleware/base.py`, add a class-level default on
+`Middleware`:
+```python
+from cubepi.hitl.binding import HitlBinding
+
+
+class Middleware:
+    hitl: HitlBinding | None = None
+
+    async def transform_context(self, ...): ...
+    # rest unchanged
+```
+
+- [ ] **Step 6: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_hitl_binding.py -v`
+Expected: 5 passed. Also `uv run mypy cubepi/agent/types.py cubepi/middleware/base.py cubepi/hitl/binding.py` clean.
+
+- [ ] **Step 7: Commit**
+
+```
+git add cubepi/hitl/binding.py cubepi/agent/types.py cubepi/middleware/base.py tests/agent/test_hitl_binding.py
+git commit -m "feat(hitl): add HitlBinding attribute to AgentTool and Middleware"
+```
+
+---
+
+### Task 5: Add `active_run_id` field to `AgentState`
+
+**Files:**
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_agent_state.py` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/agent/test_agent_state.py`:
+```python
+from cubepi.agent.agent import AgentState
+
+
+def test_agent_state_default_active_run_id_none():
+    s = AgentState()
+    assert s.active_run_id is None
+
+
+def test_agent_state_active_run_id_settable():
+    s = AgentState()
+    s.active_run_id = "r-1"
+    assert s.active_run_id == "r-1"
+    s.active_run_id = None
+    assert s.active_run_id is None
+```
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/agent/test_agent_state.py -v`
+Expected: `AttributeError: 'AgentState' object has no attribute 'active_run_id'`.
+
+- [ ] **Step 3: Add the field**
+
+In `cubepi/agent/agent.py`, locate `class AgentState` (around line 92).
+Add:
+```python
+class AgentState:
+    # ... existing fields ...
+    active_run_id: str | None = None
+```
+
+(Use the same dataclass/attrs style the existing class uses; just add
+the new attribute as a sibling with a `None` default.)
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_agent_state.py tests/agent/ -q`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py tests/agent/test_agent_state.py
+git commit -m "feat(agent): add active_run_id field to AgentState"
+```
+
+---
+
+## Phase 2 — Checkpointer Protocol additions
+
+### Task 6: Declare new Protocol methods on `Checkpointer`
+
+**Files:**
+- Modify: `cubepi/checkpointer/base.py`
+
+This is a Protocol-only change. No structural runtime test — the methods
+will be tested per-backend in Phases 3–6.
+
+- [ ] **Step 1: Add the method signatures**
+
+In `cubepi/checkpointer/base.py`, after the existing methods on the
+`Checkpointer` Protocol, add:
+
+```python
+from cubepi.hitl.types import HitlRequest
+
+
+@runtime_checkable
+class Checkpointer(Protocol):
+    # ... existing: load, append, save_extra, save_pending_request,
+    # load_pending_request ...
+
+    async def snapshot(
+        self, thread_id: str, *, after_run_id: str
+    ) -> list[Message]:
+        """Return messages of completed runs of `thread_id` up through
+        and including `after_run_id`, in source seq order. Raises
+        ThreadNotFoundError or RunNotCompletedError."""
+        ...
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        after_run_id: str,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        """Atomically physical-copy messages of completed runs up
+        through `after_run_id` from src to new. See spec §3.2 / §3.4."""
+        ...
+
+    async def claim_run(
+        self,
+        thread_id: str,
+        run_id: str,
+    ) -> None:
+        """Insert cubepi_runs row with claimed_at=now, completed_at=NULL.
+        Lazily creates the threads row if needed. Raises
+        RunAlreadyClaimedError or RunAlreadyCompletedError on PK
+        conflict (distinguished by completed_at IS NULL/NOT NULL)."""
+        ...
+
+    async def mark_run_complete(
+        self,
+        thread_id: str,
+        run_id: str,
+    ) -> None:
+        """Allocate next per-thread completion_seq; UPDATE the run row.
+        Idempotent on already-completed rows (does NOT raise
+        RunAlreadyCompletedError). Raises RunNotClaimedError when no
+        row exists."""
+        ...
+
+    async def load_pending(
+        self,
+        thread_id: str,
+    ) -> tuple[HitlRequest, str | None] | None:
+        """Read (HitlRequest, run_id) atomically from the pending row,
+        or None when no pending request exists."""
+        ...
+```
+
+- [ ] **Step 2: Verify protocol signatures import cleanly**
+
+Run: `uv run python -c "from cubepi.checkpointer.base import Checkpointer; print(Checkpointer.__annotations__)"`
+Expected: prints attributes incl. the new methods. Also
+`uv run mypy cubepi/checkpointer/base.py` clean.
+
+- [ ] **Step 3: Commit**
+
+```
+git add cubepi/checkpointer/base.py
+git commit -m "feat(checkpointer): declare snapshot/fork/claim_run/mark_run_complete/load_pending on Protocol"
+```
+
+---
+
+## Phase 3 — Memory backend
+
+Memory is the simplest backend; nail the semantics here before
+tackling SQL.
+
+### Task 7: Memory backend — shared lock + RunState dict
+
+**Files:**
+- Modify: `cubepi/checkpointer/memory.py`
+- Test: `tests/checkpointer/test_memory_runs.py` (new)
+
+- [ ] **Step 1: Write failing test (lock + state map exist)**
+
+Create `tests/checkpointer/test_memory_runs.py`:
+```python
+import asyncio
+
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+)
+from cubepi.checkpointer.memory import MemoryCheckpointer
+
+
+@pytest.mark.asyncio
+async def test_claim_then_complete_roundtrip():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    await cp.mark_run_complete("t", "r1")
+    # Idempotent: second mark is a no-op.
+    await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_in_flight_raises_claimed():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    with pytest.raises(RunAlreadyClaimedError):
+        await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_completed_raises_completed():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    await cp.mark_run_complete("t", "r1")
+    with pytest.raises(RunAlreadyCompletedError):
+        await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_mark_without_claim_raises_not_claimed():
+    cp = MemoryCheckpointer()
+    with pytest.raises(RunNotClaimedError):
+        await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_completion_seq_monotonic_per_thread():
+    cp = MemoryCheckpointer()
+    for rid in ("A", "B", "C"):
+        await cp.claim_run("t", rid)
+        await cp.mark_run_complete("t", rid)
+    # Internal inspection: completion_seq for A < B < C strictly.
+    seqs = [cp._runs["t"][rid].completion_seq for rid in ("A", "B", "C")]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == 3
+```
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_memory_runs.py -v`
+Expected: `AttributeError: 'MemoryCheckpointer' object has no attribute 'claim_run'`.
+
+- [ ] **Step 3: Extend `MemoryCheckpointer`**
+
+Replace `cubepi/checkpointer/memory.py` with:
+```python
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+from cubepi.checkpointer.base import CheckpointData
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
+from cubepi.hitl.types import HitlRequest
+from cubepi.providers.base import Message
+from cubepi.types import JsonObject
+
+
+@dataclass
+class _RunState:
+    claimed_at: float
+    completed_at: float | None = None
+    completion_seq: int | None = None
+
+
+class MemoryCheckpointer:
+    def __init__(self) -> None:
+        self._store: dict[str, CheckpointData] = {}
+        self._pending: dict[str, HitlRequest] = {}
+        self._pending_run_id: dict[str, str | None] = {}
+        self._runs: dict[str, dict[str, _RunState]] = {}
+        self._lock = asyncio.Lock()
+
+    async def load(self, thread_id: str) -> CheckpointData | None:
+        return self._store.get(thread_id)
+
+    async def append(self, thread_id: str, messages: list[Message]) -> None:
+        async with self._lock:
+            for m in messages:
+                if m.run_id is None:
+                    continue
+                rs = self._runs.get(thread_id, {}).get(m.run_id)
+                if rs is not None and rs.completed_at is not None:
+                    raise RunAlreadyCompletedError(
+                        f"append on completed run thread={thread_id} run={m.run_id}"
+                    )
+            if thread_id not in self._store:
+                self._store[thread_id] = CheckpointData()
+            self._store[thread_id].messages.extend(messages)
+
+    async def save_extra(self, thread_id: str, extra: JsonObject) -> None:
+        async with self._lock:
+            if thread_id not in self._store:
+                self._store[thread_id] = CheckpointData()
+            self._store[thread_id].extra.update(extra)
+
+    async def save_pending_request(
+        self,
+        thread_id: str,
+        request: HitlRequest | None,
+        *,
+        run_id: str | None = None,
+    ) -> None:
+        async with self._lock:
+            if request is None:
+                self._pending.pop(thread_id, None)
+                self._pending_run_id.pop(thread_id, None)
+            else:
+                self._pending[thread_id] = request
+                self._pending_run_id[thread_id] = run_id
+
+    async def load_pending_request(self, thread_id: str) -> HitlRequest | None:
+        return self._pending.get(thread_id)
+
+    async def load_pending_run_id(self, thread_id: str) -> str | None:
+        return self._pending_run_id.get(thread_id)
+
+    async def load_pending(
+        self, thread_id: str
+    ) -> tuple[HitlRequest, str | None] | None:
+        req = self._pending.get(thread_id)
+        if req is None:
+            return None
+        return req, self._pending_run_id.get(thread_id)
+
+    async def claim_run(self, thread_id: str, run_id: str) -> None:
+        async with self._lock:
+            runs = self._runs.setdefault(thread_id, {})
+            existing = runs.get(run_id)
+            if existing is not None:
+                if existing.completed_at is None:
+                    raise RunAlreadyClaimedError(
+                        f"thread={thread_id} run={run_id} in flight"
+                    )
+                raise RunAlreadyCompletedError(
+                    f"thread={thread_id} run={run_id} already completed"
+                )
+            runs[run_id] = _RunState(claimed_at=time.time())
+
+    async def mark_run_complete(self, thread_id: str, run_id: str) -> None:
+        async with self._lock:
+            runs = self._runs.get(thread_id) or {}
+            state = runs.get(run_id)
+            if state is None:
+                raise RunNotClaimedError(
+                    f"thread={thread_id} run={run_id} has no claim row"
+                )
+            if state.completed_at is not None:
+                return  # idempotent
+            existing_seqs = [
+                s.completion_seq
+                for s in runs.values()
+                if s.completion_seq is not None
+            ]
+            next_seq = max(existing_seqs, default=0) + 1
+            state.completed_at = time.time()
+            state.completion_seq = next_seq
+```
+
+(Note: `snapshot` and `fork` are added in Task 9.)
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_memory_runs.py tests/checkpointer/test_memory.py -v`
+Expected: new tests pass; existing memory tests still green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/memory.py tests/checkpointer/test_memory_runs.py
+git commit -m "feat(memory): claim_run + mark_run_complete with shared asyncio.Lock"
+```
+
+---
+
+### Task 8: Memory backend — `append()` rejects completed run_ids; `load_pending` returns tuple
+
+Already implemented in Task 7. Add explicit tests.
+
+**Files:**
+- Test: `tests/checkpointer/test_memory_runs.py` (extend)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `tests/checkpointer/test_memory_runs.py`:
+```python
+from cubepi.providers.base import TextContent, UserMessage
+
+
+@pytest.mark.asyncio
+async def test_append_on_completed_run_id_rejected():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    await cp.mark_run_complete("t", "r1")
+    msg = UserMessage(content=[TextContent(text="late")], run_id="r1")
+    with pytest.raises(RunAlreadyCompletedError):
+        await cp.append("t", [msg])
+
+
+@pytest.mark.asyncio
+async def test_append_in_flight_run_id_ok():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    msg = UserMessage(content=[TextContent(text="ok")], run_id="r1")
+    await cp.append("t", [msg])
+    data = await cp.load("t")
+    assert data is not None and len(data.messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_tuple_with_run_id():
+    from cubepi.hitl.types import HitlRequest
+
+    cp = MemoryCheckpointer()
+    req = HitlRequest(question_id="q1", question="hi", schema={}, choices=None)
+    await cp.save_pending_request("t", req, run_id="r-1")
+    res = await cp.load_pending("t")
+    assert res is not None
+    got_req, got_run_id = res
+    assert got_req.question_id == "q1"
+    assert got_run_id == "r-1"
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_none_when_empty():
+    cp = MemoryCheckpointer()
+    assert await cp.load_pending("t") is None
+```
+
+- [ ] **Step 2: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_memory_runs.py -v`
+Expected: 9 passed.
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/checkpointer/test_memory_runs.py
+git commit -m "test(memory): cover append-on-completed and load_pending tuple"
+```
+
+---
+
+### Task 9: Memory backend — `snapshot()` + `fork()`
+
+**Files:**
+- Modify: `cubepi/checkpointer/memory.py`
+- Test: `tests/checkpointer/test_memory_fork.py` (new)
+
+- [ ] **Step 1: Write failing tests covering set-based selection**
+
+Create `tests/checkpointer/test_memory_fork.py`:
+```python
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+def _msg(run_id: str | None, text: str) -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)], run_id=run_id)
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_completed_runs_only():
+    cp = MemoryCheckpointer()
+    # Two completed runs A and B.
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1"), _msg("A", "a2")])
+    await cp.mark_run_complete("src", "A")
+    await cp.claim_run("src", "B")
+    await cp.append("src", [_msg("B", "b1")])
+    await cp.mark_run_complete("src", "B")
+    # An in-flight run C — must be excluded.
+    await cp.claim_run("src", "C")
+    await cp.append("src", [_msg("C", "c1")])
+    await cp.fork("src", "dst", after_run_id="B")
+    loaded = await cp.load("dst")
+    assert loaded is not None
+    texts = [m.content[0].text for m in loaded.messages]
+    assert texts == ["a1", "a2", "b1"]
+    assert loaded.parent_thread_id == "src"
+
+
+@pytest.mark.asyncio
+async def test_fork_includes_legacy_null_run_id_prefix():
+    cp = MemoryCheckpointer()
+    # Legacy NULL-run_id message.
+    await cp.append("src", [_msg(None, "legacy")])
+    # One completed run.
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    await cp.fork("src", "dst", after_run_id="A")
+    loaded = await cp.load("dst")
+    assert [m.content[0].text for m in loaded.messages] == ["legacy", "a1"]
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_src_raises_thread_not_found():
+    cp = MemoryCheckpointer()
+    with pytest.raises(ThreadNotFoundError):
+        await cp.fork("missing", "dst", after_run_id="X")
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_run_id_raises_not_completed():
+    cp = MemoryCheckpointer()
+    await cp.append("src", [_msg(None, "x")])
+    with pytest.raises(RunNotCompletedError):
+        await cp.fork("src", "dst", after_run_id="missing")
+
+
+@pytest.mark.asyncio
+async def test_fork_destination_collision_raises_already_exists():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    await cp.fork("src", "dst", after_run_id="A")
+    with pytest.raises(ThreadAlreadyExistsError):
+        await cp.fork("src", "dst", after_run_id="A")
+
+
+@pytest.mark.asyncio
+async def test_fork_carries_extra_and_writes_metadata():
+    cp = MemoryCheckpointer()
+    await cp.save_extra("src", {"original": "x"})
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    await cp.fork("src", "dst", after_run_id="A", metadata={"source": "test"})
+    loaded = await cp.load("dst")
+    assert loaded.extra["original"] == "x"
+    assert loaded.extra["fork"] == {"source": "test"}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_matches_fork_messages():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    msgs = await cp.snapshot("src", after_run_id="A")
+    assert [m.content[0].text for m in msgs] == ["a1"]
+```
+
+- [ ] **Step 2: Run tests → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_memory_fork.py -v`
+Expected: `AttributeError: 'MemoryCheckpointer' object has no attribute 'fork'`.
+
+- [ ] **Step 3: Implement `snapshot()` + `fork()` on `MemoryCheckpointer`**
+
+Append to `cubepi/checkpointer/memory.py`:
+```python
+import copy
+
+
+def _legible_message_copy(m):
+    return m.model_copy(deep=True)
+
+
+class MemoryCheckpointer:  # continue class
+    async def snapshot(
+        self, thread_id: str, *, after_run_id: str
+    ) -> list[Message]:
+        async with self._lock:
+            data = self._store.get(thread_id)
+            if data is None and thread_id not in self._runs:
+                raise ThreadNotFoundError(f"thread={thread_id}")
+            runs = self._runs.get(thread_id, {})
+            cutoff_state = runs.get(after_run_id)
+            if cutoff_state is None or cutoff_state.completion_seq is None:
+                raise RunNotCompletedError(
+                    f"thread={thread_id} run={after_run_id} not completed"
+                )
+            cutoff = cutoff_state.completion_seq
+            selected: list[Message] = []
+            for m in (data.messages if data else []):
+                if m.run_id is None:
+                    selected.append(_legible_message_copy(m))
+                    continue
+                rs = runs.get(m.run_id)
+                if rs is None or rs.completion_seq is None:
+                    continue
+                if rs.completion_seq <= cutoff:
+                    selected.append(_legible_message_copy(m))
+            return selected
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        after_run_id: str,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        async with self._lock:
+            if new_thread_id in self._store or new_thread_id in self._runs:
+                raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+            src_data = self._store.get(src_thread_id)
+            src_runs = self._runs.get(src_thread_id, {})
+            if src_data is None and not src_runs:
+                raise ThreadNotFoundError(f"thread={src_thread_id}")
+            cutoff_state = src_runs.get(after_run_id)
+            if cutoff_state is None or cutoff_state.completion_seq is None:
+                raise RunNotCompletedError(
+                    f"thread={src_thread_id} run={after_run_id} not completed"
+                )
+            cutoff = cutoff_state.completion_seq
+            # Select messages.
+            new_messages: list[Message] = []
+            for m in (src_data.messages if src_data else []):
+                if m.run_id is None:
+                    new_messages.append(_legible_message_copy(m))
+                    continue
+                rs = src_runs.get(m.run_id)
+                if rs is None or rs.completion_seq is None:
+                    continue
+                if rs.completion_seq <= cutoff:
+                    new_messages.append(_legible_message_copy(m))
+            # Deep copy extra and merge metadata.
+            base_extra = copy.deepcopy(
+                src_data.extra if src_data else {}
+            )
+            if metadata is not None:
+                base_extra["fork"] = copy.deepcopy(metadata)
+            # Carry completed runs satisfying cutoff.
+            new_runs: dict[str, _RunState] = {}
+            for rid, state in src_runs.items():
+                if state.completion_seq is None:
+                    continue
+                if state.completion_seq <= cutoff:
+                    new_runs[rid] = _RunState(
+                        claimed_at=state.claimed_at,
+                        completed_at=state.completed_at,
+                        completion_seq=state.completion_seq,
+                    )
+            self._store[new_thread_id] = CheckpointData(
+                messages=new_messages,
+                extra=base_extra,
+                parent_thread_id=src_thread_id,
+            )
+            self._runs[new_thread_id] = new_runs
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_memory_fork.py tests/checkpointer/ -q`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/memory.py tests/checkpointer/test_memory_fork.py
+git commit -m "feat(memory): snapshot + fork with set-based run_id selection"
+```
+
+---
+
+## Phase 4 — SQLite backend
+
+### Task 10: SQLite — schema additions + `BEGIN IMMEDIATE` + `busy_timeout`
+
+**Files:**
+- Modify: `cubepi/checkpointer/sqlite.py`
+- Test: `tests/checkpointer/test_sqlite_schema.py` (new)
+
+- [ ] **Step 1: Write failing schema test**
+
+Create `tests/checkpointer/test_sqlite_schema.py`:
+```python
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cubepi.checkpointer.sqlite import SQLiteCheckpointer
+
+
+@pytest.mark.asyncio
+async def test_runs_table_and_columns_exist_after_init():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "x.db"
+        async with SQLiteCheckpointer(str(path)) as cp:
+            cur = await cp._db.execute("PRAGMA table_info(runs)")
+            cols = {row[1] for row in await cur.fetchall()}
+            assert {
+                "thread_id",
+                "run_id",
+                "claimed_at",
+                "completed_at",
+                "completion_seq",
+            } <= cols
+
+            cur = await cp._db.execute("PRAGMA table_info(messages)")
+            cols = {row[1] for row in await cur.fetchall()}
+            assert "run_id" in cols
+
+            cur = await cp._db.execute("PRAGMA table_info(thread_extra)")
+            cols = {row[1] for row in await cur.fetchall()}
+            assert "parent_thread_id" in cols
+
+
+@pytest.mark.asyncio
+async def test_busy_timeout_is_set():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "x.db"
+        async with SQLiteCheckpointer(str(path)) as cp:
+            cur = await cp._db.execute("PRAGMA busy_timeout")
+            (val,) = await cur.fetchone()
+            assert val >= 5000
+```
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_sqlite_schema.py -v`
+Expected: `OperationalError: no such table: runs` (or busy_timeout = 0).
+
+- [ ] **Step 3: Extend `SQLiteCheckpointer.__aenter__`**
+
+In `cubepi/checkpointer/sqlite.py`, add the new DDL + `PRAGMA busy_timeout`
+inside `__aenter__` after the existing tables are created. Use the
+existing PRAGMA-probe pattern for ALTER TABLE on `messages` and
+`thread_extra`:
+
+```python
+async def __aenter__(self) -> "SQLiteCheckpointer":
+    self._db = await aiosqlite.connect(self._db_path)
+    await self._db.execute("PRAGMA busy_timeout = 5000")
+    await self._db.execute(
+        "CREATE TABLE IF NOT EXISTS messages ("
+        "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  thread_id TEXT NOT NULL,"
+        "  message_json TEXT NOT NULL,"
+        "  created_at REAL NOT NULL DEFAULT (julianday('now'))"
+        ")"
+    )
+    # ... thread_extra and thread_pending_request unchanged ...
+
+    # New: runs table.
+    await self._db.execute(
+        "CREATE TABLE IF NOT EXISTS runs ("
+        "  thread_id TEXT NOT NULL,"
+        "  run_id TEXT NOT NULL,"
+        "  claimed_at REAL NOT NULL DEFAULT (julianday('now')),"
+        "  completed_at REAL,"
+        "  completion_seq INTEGER,"
+        "  PRIMARY KEY (thread_id, run_id)"
+        ")"
+    )
+    await self._db.execute(
+        "CREATE INDEX IF NOT EXISTS ix_runs_thread_completion "
+        "ON runs (thread_id, completion_seq)"
+    )
+
+    # Add run_id column to messages if missing.
+    cur = await self._db.execute("PRAGMA table_info(messages)")
+    cols = {row[1] for row in await cur.fetchall()}
+    if "run_id" not in cols:
+        await self._db.execute(
+            "ALTER TABLE messages ADD COLUMN run_id TEXT"
+        )
+
+    # Add parent_thread_id to thread_extra if missing.
+    cur = await self._db.execute("PRAGMA table_info(thread_extra)")
+    cols = {row[1] for row in await cur.fetchall()}
+    if "parent_thread_id" not in cols:
+        await self._db.execute(
+            "ALTER TABLE thread_extra ADD COLUMN parent_thread_id TEXT"
+        )
+
+    # ... existing run_id backfill on thread_pending_request unchanged ...
+    await self._db.commit()
+    return self
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_sqlite_schema.py tests/checkpointer/test_sqlite.py -v`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/sqlite.py tests/checkpointer/test_sqlite_schema.py
+git commit -m "feat(sqlite): add runs table, run_id + parent_thread_id columns, busy_timeout"
+```
+
+---
+
+### Task 11: SQLite — promote all writers to `BEGIN IMMEDIATE` + surface lock timeout
+
+**Files:**
+- Modify: `cubepi/checkpointer/sqlite.py`
+- Test: `tests/checkpointer/test_sqlite_concurrency.py` (new)
+
+- [ ] **Step 1: Failing test for `CheckpointerLockTimeoutError`**
+
+Create `tests/checkpointer/test_sqlite_concurrency.py`:
+```python
+import asyncio
+import tempfile
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from cubepi.checkpointer.exceptions import CheckpointerLockTimeoutError
+from cubepi.checkpointer.sqlite import SQLiteCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+@pytest.mark.asyncio
+async def test_lock_timeout_surfaces_as_typed_error(monkeypatch):
+    """Hold a write lock from a second connection long enough that the
+    busy_timeout expires; the checkpointer must raise
+    CheckpointerLockTimeoutError, not the raw aiosqlite error."""
+    with tempfile.TemporaryDirectory() as d:
+        path = str(Path(d) / "x.db")
+        async with SQLiteCheckpointer(path) as cp:
+            # Make the timeout tiny so the test is fast.
+            await cp._db.execute("PRAGMA busy_timeout = 100")
+            other = await aiosqlite.connect(path)
+            try:
+                await other.execute("BEGIN IMMEDIATE")
+                msg = UserMessage(content=[TextContent(text="x")])
+                with pytest.raises(CheckpointerLockTimeoutError):
+                    await cp.append("t", [msg])
+            finally:
+                await other.rollback()
+                await other.close()
+```
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_sqlite_concurrency.py -v`
+Expected: raw `OperationalError` propagates.
+
+- [ ] **Step 3: Add a writer-wrapper helper + use `BEGIN IMMEDIATE`**
+
+In `cubepi/checkpointer/sqlite.py`, define a helper at module scope:
+
+```python
+from contextlib import asynccontextmanager
+
+import aiosqlite
+
+from cubepi.checkpointer.exceptions import CheckpointerLockTimeoutError
+
+
+@asynccontextmanager
+async def _writer_txn(db):
+    """Wrap a writer transaction in BEGIN IMMEDIATE and surface
+    SQLITE_BUSY as CheckpointerLockTimeoutError."""
+    try:
+        await db.execute("BEGIN IMMEDIATE")
+    except aiosqlite.OperationalError as exc:
+        if "lock" in str(exc).lower() or "busy" in str(exc).lower():
+            raise CheckpointerLockTimeoutError(str(exc)) from exc
+        raise
+    try:
+        yield
+    except BaseException:
+        await db.rollback()
+        raise
+    else:
+        await db.commit()
+```
+
+Then update each writer method (`append`, `save_extra`,
+`save_pending_request`) to use this helper INSTEAD OF the bare
+`async with self._lock` + per-statement commits. Example for `append`:
+
+```python
+async def append(self, thread_id: str, messages: list[Message]) -> None:
+    assert self._db is not None
+    async with self._lock, _writer_txn(self._db):
+        for msg in messages:
+            msg_json = _serialize_message(msg)
+            run_id = getattr(msg, "run_id", None)
+            await self._db.execute(
+                "INSERT INTO messages (thread_id, message_json, run_id) "
+                "VALUES (?, ?, ?)",
+                (thread_id, msg_json, run_id),
+            )
+```
+
+Drop the inner `self._db.commit()` calls — `_writer_txn` commits on
+clean exit. Do the same for `save_extra` and `save_pending_request`.
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_sqlite_concurrency.py tests/checkpointer/test_sqlite.py -v`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/sqlite.py tests/checkpointer/test_sqlite_concurrency.py
+git commit -m "feat(sqlite): BEGIN IMMEDIATE writer txn + CheckpointerLockTimeoutError"
+```
+
+---
+
+### Task 12: SQLite — `claim_run`, `mark_run_complete`, `load_pending`
+
+**Files:**
+- Modify: `cubepi/checkpointer/sqlite.py`
+- Test: `tests/checkpointer/test_sqlite_runs.py` (new)
+
+- [ ] **Step 1: Write tests (mirror the Memory test set)**
+
+Create `tests/checkpointer/test_sqlite_runs.py` — copy the structure of
+`tests/checkpointer/test_memory_runs.py`, replacing the factory with
+SQLite via `tempfile.TemporaryDirectory`. Cover the same assertions:
+claim+complete roundtrip; idempotent second mark; in-flight collision →
+`RunAlreadyClaimedError`; completed collision → `RunAlreadyCompletedError`;
+mark without claim → `RunNotClaimedError`; per-thread monotonic
+`completion_seq`; append on completed run_id rejected; `load_pending`
+tuple round-trip.
+
+- [ ] **Step 2: Run test → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_sqlite_runs.py -v`
+Expected: missing methods.
+
+- [ ] **Step 3: Implement the three methods**
+
+Append to `cubepi/checkpointer/sqlite.py`:
+
+```python
+async def claim_run(self, thread_id: str, run_id: str) -> None:
+    assert self._db is not None
+    async with self._lock, _writer_txn(self._db):
+        cur = await self._db.execute(
+            "SELECT completed_at FROM runs "
+            "WHERE thread_id = ? AND run_id = ?",
+            (thread_id, run_id),
+        )
+        row = await cur.fetchone()
+        if row is not None:
+            completed_at = row[0]
+            if completed_at is None:
+                raise RunAlreadyClaimedError(
+                    f"thread={thread_id} run={run_id} in flight"
+                )
+            raise RunAlreadyCompletedError(
+                f"thread={thread_id} run={run_id} already completed"
+            )
+        await self._db.execute(
+            "INSERT INTO runs (thread_id, run_id) VALUES (?, ?)",
+            (thread_id, run_id),
+        )
+
+async def mark_run_complete(
+    self, thread_id: str, run_id: str
+) -> None:
+    assert self._db is not None
+    async with self._lock, _writer_txn(self._db):
+        cur = await self._db.execute(
+            "SELECT completed_at FROM runs "
+            "WHERE thread_id = ? AND run_id = ?",
+            (thread_id, run_id),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            raise RunNotClaimedError(
+                f"thread={thread_id} run={run_id} has no claim row"
+            )
+        if row[0] is not None:
+            return  # idempotent success
+        cur = await self._db.execute(
+            "SELECT COALESCE(MAX(completion_seq), 0) + 1 FROM runs "
+            "WHERE thread_id = ? AND completion_seq IS NOT NULL",
+            (thread_id,),
+        )
+        (next_seq,) = await cur.fetchone()
+        await self._db.execute(
+            "UPDATE runs SET completed_at = julianday('now'), "
+            "completion_seq = ? WHERE thread_id = ? AND run_id = ?",
+            (next_seq, thread_id, run_id),
+        )
+
+async def load_pending(
+    self, thread_id: str
+) -> tuple[HitlRequest, str | None] | None:
+    assert self._db is not None
+    async with self._lock:
+        cur = await self._db.execute(
+            "SELECT request_json, run_id FROM thread_pending_request "
+            "WHERE thread_id = ?",
+            (thread_id,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return HitlRequest.model_validate_json(row[0]), row[1]
+```
+
+Also update `append` to reject completed run_ids (defense in depth):
+
+```python
+async def append(self, thread_id: str, messages: list[Message]) -> None:
+    assert self._db is not None
+    run_ids = {m.run_id for m in messages if m.run_id is not None}
+    async with self._lock, _writer_txn(self._db):
+        if run_ids:
+            placeholders = ",".join("?" for _ in run_ids)
+            cur = await self._db.execute(
+                f"SELECT run_id FROM runs WHERE thread_id = ? "
+                f"AND run_id IN ({placeholders}) "
+                f"AND completed_at IS NOT NULL",
+                (thread_id, *run_ids),
+            )
+            done = await cur.fetchall()
+            if done:
+                bad = ", ".join(r[0] for r in done)
+                raise RunAlreadyCompletedError(
+                    f"append on completed run thread={thread_id} runs={bad}"
+                )
+        for msg in messages:
+            msg_json = _serialize_message(msg)
+            await self._db.execute(
+                "INSERT INTO messages (thread_id, message_json, run_id) "
+                "VALUES (?, ?, ?)",
+                (thread_id, msg_json, getattr(msg, "run_id", None)),
+            )
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_sqlite_runs.py tests/checkpointer/test_sqlite.py -v`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/sqlite.py tests/checkpointer/test_sqlite_runs.py
+git commit -m "feat(sqlite): claim_run, mark_run_complete, load_pending"
+```
+
+---
+
+### Task 13: SQLite — `snapshot()` + `fork()`
+
+**Files:**
+- Modify: `cubepi/checkpointer/sqlite.py`
+- Test: `tests/checkpointer/test_sqlite_fork.py` (new)
+
+- [ ] **Step 1: Write tests (mirror Memory fork test set)**
+
+Create `tests/checkpointer/test_sqlite_fork.py` mirroring
+`tests/checkpointer/test_memory_fork.py`, with the SQLite factory.
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_sqlite_fork.py -v`
+Expected: `AttributeError: ... no attribute 'fork'`.
+
+- [ ] **Step 3: Implement `snapshot()` + `fork()`**
+
+Append to `cubepi/checkpointer/sqlite.py`:
+
+```python
+async def snapshot(
+    self, thread_id: str, *, after_run_id: str
+) -> list[Message]:
+    assert self._db is not None
+    async with self._lock:
+        cur = await self._db.execute(
+            "SELECT completion_seq FROM runs "
+            "WHERE thread_id = ? AND run_id = ?",
+            (thread_id, after_run_id),
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            raise RunNotCompletedError(
+                f"thread={thread_id} run={after_run_id} not completed"
+            )
+        cutoff = row[0]
+        cur = await self._db.execute(
+            "SELECT message_json FROM messages WHERE thread_id = ? "
+            "AND (run_id IS NULL OR run_id IN ("
+            "  SELECT run_id FROM runs WHERE thread_id = ? "
+            "  AND completion_seq IS NOT NULL "
+            "  AND completion_seq <= ?"
+            ")) ORDER BY id",
+            (thread_id, thread_id, cutoff),
+        )
+        rows = await cur.fetchall()
+        return [_deserialize_message(json.loads(r[0])) for r in rows]
+
+async def fork(
+    self,
+    src_thread_id: str,
+    new_thread_id: str,
+    *,
+    after_run_id: str,
+    metadata: JsonObject | None = None,
+) -> None:
+    assert self._db is not None
+    async with self._lock, _writer_txn(self._db):
+        # Source existence: messages OR thread_extra.
+        cur = await self._db.execute(
+            "SELECT 1 FROM messages WHERE thread_id = ? LIMIT 1",
+            (src_thread_id,),
+        )
+        src_has_msg = await cur.fetchone() is not None
+        cur = await self._db.execute(
+            "SELECT 1 FROM thread_extra WHERE thread_id = ?",
+            (src_thread_id,),
+        )
+        src_has_extra = await cur.fetchone() is not None
+        if not (src_has_msg or src_has_extra):
+            raise ThreadNotFoundError(f"thread={src_thread_id}")
+        # Destination collision.
+        cur = await self._db.execute(
+            "SELECT 1 FROM messages WHERE thread_id = ? LIMIT 1",
+            (new_thread_id,),
+        )
+        if await cur.fetchone():
+            raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+        cur = await self._db.execute(
+            "SELECT 1 FROM thread_extra WHERE thread_id = ?",
+            (new_thread_id,),
+        )
+        if await cur.fetchone():
+            raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+        # Cutoff.
+        cur = await self._db.execute(
+            "SELECT completion_seq FROM runs "
+            "WHERE thread_id = ? AND run_id = ?",
+            (src_thread_id, after_run_id),
+        )
+        row = await cur.fetchone()
+        if row is None or row[0] is None:
+            raise RunNotCompletedError(
+                f"thread={src_thread_id} run={after_run_id} not completed"
+            )
+        cutoff = row[0]
+        # Copy messages.
+        await self._db.execute(
+            "INSERT INTO messages (thread_id, run_id, message_json) "
+            "SELECT ?, run_id, message_json FROM messages "
+            "WHERE thread_id = ? AND ("
+            "  run_id IS NULL OR run_id IN ("
+            "    SELECT run_id FROM runs WHERE thread_id = ? "
+            "    AND completion_seq IS NOT NULL "
+            "    AND completion_seq <= ?"
+            "  )"
+            ") ORDER BY id",
+            (new_thread_id, src_thread_id, src_thread_id, cutoff),
+        )
+        # Copy runs.
+        await self._db.execute(
+            "INSERT INTO runs (thread_id, run_id, claimed_at, "
+            "completed_at, completion_seq) "
+            "SELECT ?, run_id, claimed_at, completed_at, completion_seq "
+            "FROM runs WHERE thread_id = ? "
+            "AND completion_seq IS NOT NULL AND completion_seq <= ?",
+            (new_thread_id, src_thread_id, cutoff),
+        )
+        # Build merged extra.
+        cur = await self._db.execute(
+            "SELECT extra_json FROM thread_extra WHERE thread_id = ?",
+            (src_thread_id,),
+        )
+        row = await cur.fetchone()
+        merged_extra = json.loads(row[0]) if row else {}
+        if metadata is not None:
+            merged_extra["fork"] = json.loads(json.dumps(metadata))
+        await self._db.execute(
+            "INSERT INTO thread_extra (thread_id, extra_json, "
+            "parent_thread_id) VALUES (?, ?, ?)",
+            (new_thread_id, json.dumps(merged_extra), src_thread_id),
+        )
+```
+
+Also extend `load()` to populate `CheckpointData.parent_thread_id` from
+`thread_extra.parent_thread_id`:
+
+```python
+async def load(self, thread_id: str) -> CheckpointData | None:
+    # ... existing code that fetches messages and extra ...
+    cur = await self._db.execute(
+        "SELECT extra_json, parent_thread_id FROM thread_extra "
+        "WHERE thread_id = ?",
+        (thread_id,),
+    )
+    extra_row = await cur.fetchone()
+    parent = extra_row[1] if extra_row else None
+    # ... extra = json.loads(...) ...
+    return CheckpointData(messages=messages, extra=extra, parent_thread_id=parent)
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_sqlite_fork.py tests/checkpointer/test_sqlite.py -q`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/sqlite.py tests/checkpointer/test_sqlite_fork.py
+git commit -m "feat(sqlite): snapshot + fork with set-based selection"
+```
+
+---
+
+## Phase 5 — Postgres backend
+
+The Postgres tasks mirror SQLite with these differences:
+- SQLAlchemy model declarations in `cubepi/checkpointer/postgres/models.py`
+- Schema version bump v3 → v4 + alembic migration template
+- Use `pg_advisory_xact_lock(hashtext($thread_id))` for per-thread locking
+- Use `INSERT INTO cubepi_threads ON CONFLICT DO NOTHING` for lazy create
+- `cubepi_runs` table is `HASH (thread_id)` partitioned, FK with `ON DELETE CASCADE`
+
+> All Postgres tests run against the bundled docker fixture (existing
+> `tests/checkpointer/conftest.py` infrastructure).
+
+### Task 14: Postgres — extend models + bump schema to v4
+
+**Files:**
+- Modify: `cubepi/checkpointer/postgres/models.py`
+- Modify: `cubepi/checkpointer/postgres/alembic_helpers.py` (add migration template)
+- Test: `tests/checkpointer/test_postgres_schema.py` (new)
+
+- [ ] **Step 1: Write schema-version + table-shape tests**
+
+Create `tests/checkpointer/test_postgres_schema.py`:
+```python
+import pytest
+
+from cubepi.checkpointer.postgres.models import EXPECTED_SCHEMA_VERSION
+
+
+def test_expected_schema_version_is_4():
+    assert EXPECTED_SCHEMA_VERSION == 4
+
+
+@pytest.mark.asyncio
+async def test_cubepi_runs_table_present(pg_pool):
+    async with pg_pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT column_name, data_type FROM information_schema.columns "
+            "WHERE table_name = 'cubepi_runs' ORDER BY ordinal_position"
+        )
+        cols = {r["column_name"] for r in rows}
+        assert {
+            "thread_id",
+            "run_id",
+            "claimed_at",
+            "completed_at",
+            "completion_seq",
+        } <= cols
+
+
+@pytest.mark.asyncio
+async def test_cubepi_messages_has_run_id_column(pg_pool):
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_name = 'cubepi_messages' AND column_name = 'run_id'"
+        )
+        assert row is not None
+```
+
+(The `pg_pool` fixture is the existing one in
+`tests/checkpointer/conftest.py`.)
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_postgres_schema.py -v`
+Expected: schema version mismatch / missing column.
+
+- [ ] **Step 3: Update `cubepi/checkpointer/postgres/models.py`**
+
+- Bump `EXPECTED_SCHEMA_VERSION = 4`.
+- Add `run_id` column to `CubepiMessage`:
+  ```python
+  run_id: Mapped[str | None] = mapped_column(sa.Text, nullable=True)
+  ```
+  and add an index `Index("ix_cubepi_messages_thread_run", "thread_id", "run_id")`.
+- Add new `CubepiRun` model:
+  ```python
+  class CubepiRun(CubepiBase):
+      __tablename__ = "cubepi_runs"
+      __table_args__ = (
+          sa.Index("ix_cubepi_runs_thread_seq", "thread_id", "completion_seq"),
+          {"postgresql_partition_by": "HASH (thread_id)"},
+      )
+      thread_id: Mapped[str] = mapped_column(
+          sa.Text,
+          sa.ForeignKey("cubepi_threads.thread_id", ondelete="CASCADE"),
+          primary_key=True,
+      )
+      run_id: Mapped[str] = mapped_column(sa.Text, primary_key=True)
+      claimed_at: Mapped[_dt.datetime] = mapped_column(
+          sa.TIMESTAMP(timezone=True),
+          nullable=False,
+          server_default=sa.text("now()"),
+      )
+      completed_at: Mapped[_dt.datetime | None] = mapped_column(
+          sa.TIMESTAMP(timezone=True), nullable=True
+      )
+      completion_seq: Mapped[int | None] = mapped_column(
+          sa.BigInteger, nullable=True
+      )
+  ```
+
+- [ ] **Step 4: Update alembic helper to emit the v3→v4 migration**
+
+In `cubepi/checkpointer/postgres/alembic_helpers.py`, add a function
+`upgrade_v3_to_v4(op)` that:
+- adds `run_id TEXT NULL` to `cubepi_messages` (partitioned-table
+  alter: hold a brief access-exclusive on parent + each partition);
+- creates the index `(thread_id, run_id)`;
+- creates the partitioned `cubepi_runs` parent + N partitions (use
+  `PARTITION_COUNT` constant from `models.py`);
+- bumps `cubepi_schema_version` to 4.
+
+Provide a downgrade that drops the table + column.
+
+- [ ] **Step 5: Update `tests/checkpointer/conftest.py` to apply v4**
+
+The existing fixture creates tables via alembic / direct DDL. Wire the
+new v4 migration into the fresh-DB path so tests pick up the new
+schema. (Exact patch: find the schema-setup block and call
+`alembic_helpers.upgrade_v3_to_v4(op)` after v3.)
+
+- [ ] **Step 6: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_postgres_schema.py tests/checkpointer/test_postgres.py -q`
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```
+git add cubepi/checkpointer/postgres/ tests/checkpointer/test_postgres_schema.py tests/checkpointer/conftest.py
+git commit -m "feat(postgres): schema v3→v4 — add run_id column + cubepi_runs table"
+```
+
+---
+
+### Task 15: Postgres — `claim_run` (with lazy threads-row create)
+
+**Files:**
+- Modify: `cubepi/checkpointer/postgres/checkpointer.py`
+- Test: `tests/checkpointer/test_postgres_runs.py` (new)
+
+- [ ] **Step 1: Failing tests (mirror SQLite run tests)**
+
+Create `tests/checkpointer/test_postgres_runs.py` with the same
+scenarios as `tests/checkpointer/test_sqlite_runs.py`, plus one extra:
+
+```python
+@pytest.mark.asyncio
+async def test_claim_run_creates_threads_row_lazily(pg_pool):
+    from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
+
+    async with PostgresCheckpointer(pg_pool) as cp:
+        await cp.claim_run("new_thread", "R1")
+    async with pg_pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT thread_id FROM cubepi_threads WHERE thread_id = $1",
+            "new_thread",
+        )
+        assert row is not None
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_postgres_runs.py -v`
+Expected: method missing.
+
+- [ ] **Step 3: Implement `claim_run` with lazy threads create**
+
+Add to `PostgresCheckpointer`:
+```python
+import asyncpg
+
+async def claim_run(self, thread_id: str, run_id: str) -> None:
+    async with self._pool.acquire() as conn, conn.transaction():
+        await conn.execute(
+            "SELECT pg_advisory_xact_lock(hashtext($1))", thread_id
+        )
+        # Lazy create the threads row.
+        await conn.execute(
+            "INSERT INTO cubepi_threads (thread_id) VALUES ($1) "
+            "ON CONFLICT (thread_id) DO NOTHING",
+            thread_id,
+        )
+        try:
+            await conn.execute(
+                "INSERT INTO cubepi_runs (thread_id, run_id) "
+                "VALUES ($1, $2)",
+                thread_id, run_id,
+            )
+        except asyncpg.UniqueViolationError:
+            row = await conn.fetchrow(
+                "SELECT completed_at FROM cubepi_runs "
+                "WHERE thread_id = $1 AND run_id = $2",
+                thread_id, run_id,
+            )
+            if row is None or row["completed_at"] is None:
+                raise RunAlreadyClaimedError(
+                    f"thread={thread_id} run={run_id} in flight"
+                )
+            raise RunAlreadyCompletedError(
+                f"thread={thread_id} run={run_id} already completed"
+            )
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_postgres_runs.py -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/postgres/checkpointer.py tests/checkpointer/test_postgres_runs.py
+git commit -m "feat(postgres): claim_run with lazy threads-row create"
+```
+
+---
+
+### Task 16: Postgres — `mark_run_complete` + `load_pending`
+
+**Files:**
+- Modify: `cubepi/checkpointer/postgres/checkpointer.py`
+- Test: extend `tests/checkpointer/test_postgres_runs.py` with idempotent-retry test (mirror SQLite Task 12)
+
+- [ ] **Step 1: Add failing idempotency + load_pending tests**
+
+In `tests/checkpointer/test_postgres_runs.py`, add tests for:
+- `mark_run_complete` then second call returns success (no raise)
+- `RunNotClaimedError` when no claim exists
+- `completion_seq` strictly monotonic across runs on the same thread
+- `load_pending` returns `(HitlRequest, run_id)` tuple atomically
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_postgres_runs.py -v`
+Expected: missing methods.
+
+- [ ] **Step 3: Implement methods**
+
+Add to `PostgresCheckpointer`:
+```python
+async def mark_run_complete(self, thread_id: str, run_id: str) -> None:
+    async with self._pool.acquire() as conn, conn.transaction():
+        await conn.execute(
+            "SELECT pg_advisory_xact_lock(hashtext($1))", thread_id
+        )
+        row = await conn.fetchrow(
+            "SELECT completed_at FROM cubepi_runs "
+            "WHERE thread_id = $1 AND run_id = $2",
+            thread_id, run_id,
+        )
+        if row is None:
+            raise RunNotClaimedError(
+                f"thread={thread_id} run={run_id} has no claim row"
+            )
+        if row["completed_at"] is not None:
+            return  # idempotent
+        next_seq = await conn.fetchval(
+            "SELECT COALESCE(MAX(completion_seq), 0) + 1 "
+            "FROM cubepi_runs WHERE thread_id = $1 "
+            "AND completion_seq IS NOT NULL",
+            thread_id,
+        )
+        await conn.execute(
+            "UPDATE cubepi_runs SET completed_at = now(), "
+            "completion_seq = $3 "
+            "WHERE thread_id = $1 AND run_id = $2",
+            thread_id, run_id, next_seq,
+        )
+
+async def load_pending(
+    self, thread_id: str
+) -> tuple[HitlRequest, str | None] | None:
+    async with self._pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT pending_request, run_id FROM cubepi_threads "
+            "WHERE thread_id = $1",
+            thread_id,
+        )
+    if row is None or row["pending_request"] is None:
+        return None
+    req = HitlRequest.model_validate(row["pending_request"])
+    return req, row["run_id"]
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_postgres_runs.py -q`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/postgres/checkpointer.py tests/checkpointer/test_postgres_runs.py
+git commit -m "feat(postgres): mark_run_complete (idempotent) + load_pending"
+```
+
+---
+
+### Task 17: Postgres — `snapshot()` + `fork()` (threads row first)
+
+**Files:**
+- Modify: `cubepi/checkpointer/postgres/checkpointer.py`
+- Test: `tests/checkpointer/test_postgres_fork.py` (new)
+
+- [ ] **Step 1: Tests mirror Memory/SQLite fork suite**
+
+Create `tests/checkpointer/test_postgres_fork.py` covering the same
+scenarios; add one Postgres-specific concurrency test:
+```python
+@pytest.mark.asyncio
+async def test_fork_blocks_concurrent_appends_on_src(pg_pool):
+    """Two coroutines: fork holds advisory lock; concurrent append
+    on src serializes after fork commits. No half-copied messages."""
+    # ... use asyncio.gather to interleave; assert ordering ...
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/checkpointer/test_postgres_fork.py -v`
+Expected: missing fork method.
+
+- [ ] **Step 3: Implement `snapshot()` + `fork()` per spec §3.9 order**
+
+```python
+async def snapshot(
+    self, thread_id: str, *, after_run_id: str
+) -> list[Message]:
+    async with self._pool.acquire() as conn:
+        cutoff = await conn.fetchval(
+            "SELECT completion_seq FROM cubepi_runs "
+            "WHERE thread_id = $1 AND run_id = $2",
+            thread_id, after_run_id,
+        )
+        if cutoff is None:
+            raise RunNotCompletedError(
+                f"thread={thread_id} run={after_run_id} not completed"
+            )
+        rows = await conn.fetch(
+            "SELECT role, metadata, payload, seq FROM cubepi_messages "
+            "WHERE thread_id = $1 AND ("
+            "  run_id IS NULL OR run_id IN ("
+            "    SELECT run_id FROM cubepi_runs WHERE thread_id = $1 "
+            "    AND completion_seq IS NOT NULL AND completion_seq <= $2"
+            "  )"
+            ") ORDER BY seq",
+            thread_id, cutoff,
+        )
+        return [self._row_to_message(r) for r in rows]
+
+async def fork(
+    self,
+    src_thread_id: str,
+    new_thread_id: str,
+    *,
+    after_run_id: str,
+    metadata: JsonObject | None = None,
+) -> None:
+    async with self._pool.acquire() as conn, conn.transaction():
+        await conn.execute(
+            "SELECT pg_advisory_xact_lock(hashtext($1))", src_thread_id
+        )
+        # Cutoff + RunNotCompletedError.
+        cutoff = await conn.fetchval(
+            "SELECT completion_seq FROM cubepi_runs "
+            "WHERE thread_id = $1 AND run_id = $2",
+            src_thread_id, after_run_id,
+        )
+        if cutoff is None:
+            raise RunNotCompletedError(
+                f"thread={src_thread_id} run={after_run_id} not completed"
+            )
+        # Source extra (deep copy + merge metadata).
+        src_extra = await conn.fetchval(
+            "SELECT extra FROM cubepi_threads WHERE thread_id = $1",
+            src_thread_id,
+        )
+        if src_extra is None:
+            raise ThreadNotFoundError(f"thread={src_thread_id}")
+        merged = json.loads(json.dumps(src_extra))
+        if metadata is not None:
+            merged["fork"] = json.loads(json.dumps(metadata))
+        # INSERT thread row first (FK order).
+        try:
+            await conn.execute(
+                "INSERT INTO cubepi_threads "
+                "(thread_id, parent_thread_id, forked_at_seq, extra) "
+                "VALUES ($1, $2, NULL, $3::jsonb)",
+                new_thread_id, src_thread_id, json.dumps(merged),
+            )
+        except asyncpg.UniqueViolationError:
+            raise ThreadAlreadyExistsError(f"thread={new_thread_id}")
+        # Copy messages.
+        await conn.execute(
+            "INSERT INTO cubepi_messages "
+            "(thread_id, seq, role, run_id, metadata, payload) "
+            "SELECT $1, seq, role, run_id, metadata, payload "
+            "FROM cubepi_messages WHERE thread_id = $2 AND ("
+            "  run_id IS NULL OR run_id IN ("
+            "    SELECT run_id FROM cubepi_runs WHERE thread_id = $2 "
+            "    AND completion_seq IS NOT NULL AND completion_seq <= $3"
+            "  )"
+            ") ORDER BY seq",
+            new_thread_id, src_thread_id, cutoff,
+        )
+        # Copy runs.
+        await conn.execute(
+            "INSERT INTO cubepi_runs "
+            "(thread_id, run_id, claimed_at, completed_at, completion_seq) "
+            "SELECT $1, run_id, claimed_at, completed_at, completion_seq "
+            "FROM cubepi_runs WHERE thread_id = $2 "
+            "AND completion_seq IS NOT NULL AND completion_seq <= $3",
+            new_thread_id, src_thread_id, cutoff,
+        )
+        # Trailing forked_at_seq update.
+        await conn.execute(
+            "UPDATE cubepi_threads SET forked_at_seq = ("
+            "  SELECT MAX(seq) FROM cubepi_messages WHERE thread_id = $1"
+            ") WHERE thread_id = $1",
+            new_thread_id,
+        )
+```
+
+Also update `PostgresCheckpointer.load()` to populate
+`CheckpointData.parent_thread_id` from `cubepi_threads.parent_thread_id`.
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/checkpointer/test_postgres_fork.py tests/checkpointer/test_postgres.py -q`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/checkpointer/postgres/checkpointer.py tests/checkpointer/test_postgres_fork.py
+git commit -m "feat(postgres): snapshot + fork (threads-first, set-based)"
+```
+
+---
+
+## Phase 6 — MySQL backend
+
+MySQL mirrors Postgres with:
+- `SELECT … FOR UPDATE` on `cubepi_threads` row instead of advisory lock
+- `INSERT … ON DUPLICATE KEY UPDATE thread_id = thread_id` for lazy create
+  (NOT `INSERT IGNORE` — spec §3.9 explicit)
+- `cubepi_runs` is `KEY (thread_id)` partitioned, no FK
+- `aiomysql.IntegrityError` for PK conflict detection
+
+### Task 18: MySQL — extend models + bump schema to v4
+
+**Files:**
+- Modify: `cubepi/checkpointer/mysql/models.py`
+- Modify: `cubepi/checkpointer/mysql/alembic_helpers.py`
+- Test: `tests/checkpointer/test_mysql_schema.py` (new)
+
+Steps parallel Task 14 with MySQL syntax:
+- Bump `EXPECTED_SCHEMA_VERSION = 4`.
+- Add `run_id VARCHAR(255) NULL` to `CubepiMessage`.
+- Add `CubepiRun` model (KEY-partitioned, no FK).
+- Provide v3→v4 alembic helper template.
+
+- [ ] Steps 1–7 follow Task 14 pattern. Run `tests/checkpointer/test_mysql_*` for green.
+
+Commit: `feat(mysql): schema v3→v4 — add run_id column + cubepi_runs table`.
+
+---
+
+### Task 19: MySQL — `claim_run`, `mark_run_complete`, `load_pending`
+
+**Files:**
+- Modify: `cubepi/checkpointer/mysql/checkpointer.py`
+- Test: `tests/checkpointer/test_mysql_runs.py` (new)
+
+Mirror Tasks 15–16 with MySQL syntax. Key differences:
+
+```python
+async def claim_run(self, thread_id: str, run_id: str) -> None:
+    async with self._pool.acquire() as conn:
+        await conn.begin()
+        try:
+            async with conn.cursor() as cur:
+                await cur.execute(
+                    "INSERT INTO cubepi_threads (thread_id) VALUES (%s) "
+                    "ON DUPLICATE KEY UPDATE thread_id = thread_id",
+                    (thread_id,),
+                )
+                await cur.execute(
+                    "SELECT thread_id FROM cubepi_threads "
+                    "WHERE thread_id = %s FOR UPDATE",
+                    (thread_id,),
+                )
+                try:
+                    await cur.execute(
+                        "INSERT INTO cubepi_runs (thread_id, run_id) "
+                        "VALUES (%s, %s)",
+                        (thread_id, run_id),
+                    )
+                except aiomysql.IntegrityError:
+                    await cur.execute(
+                        "SELECT completed_at FROM cubepi_runs "
+                        "WHERE thread_id = %s AND run_id = %s",
+                        (thread_id, run_id),
+                    )
+                    row = await cur.fetchone()
+                    if row is None or row[0] is None:
+                        await conn.rollback()
+                        raise RunAlreadyClaimedError(
+                            f"thread={thread_id} run={run_id} in flight"
+                        )
+                    await conn.rollback()
+                    raise RunAlreadyCompletedError(
+                        f"thread={thread_id} run={run_id} already completed"
+                    )
+            await conn.commit()
+        except BaseException:
+            await conn.rollback()
+            raise
+```
+
+`mark_run_complete` and `load_pending` follow the SQL forms shown in
+Task 16 with MySQL placeholders.
+
+Commit: `feat(mysql): claim_run, mark_run_complete, load_pending`.
+
+---
+
+### Task 20: MySQL — `snapshot()` + `fork()`
+
+**Files:**
+- Modify: `cubepi/checkpointer/mysql/checkpointer.py`
+- Test: `tests/checkpointer/test_mysql_fork.py` (new)
+
+Mirror Task 17 with MySQL syntax. Use `SELECT … FROM cubepi_threads
+WHERE thread_id = %s FOR UPDATE` as the per-thread fence in `fork()`.
+
+Commit: `feat(mysql): snapshot + fork (threads-first, set-based)`.
+
+---
+
+## Phase 7 — Agent integration
+
+This is where the persistence primitives wire into the agent loop.
+
+### Task 21: `Agent(messages=…)` constructor pre-seed with deep copy
+
+**Files:**
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_agent_messages_kw.py` (new)
+
+- [ ] **Step 1: Failing tests for constructor + deep-copy isolation**
+
+Create `tests/agent/test_agent_messages_kw.py`:
+```python
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+from cubepi.providers.faux import FauxProvider
+
+
+def _agent(**kw):
+    return Agent(model=FauxProvider().model("faux-model"), **kw)
+
+
+def test_messages_kw_none_keeps_default():
+    a = _agent()
+    assert a.state.messages == []
+
+
+def test_messages_kw_seeds_initial_history():
+    msgs = [UserMessage(content=[TextContent(text="hi")])]
+    a = _agent(messages=msgs)
+    assert len(a.state.messages) == 1
+
+
+def test_messages_kw_conflicts_with_thread_id_checkpointer():
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+
+    msgs = [UserMessage(content=[TextContent(text="hi")])]
+    with pytest.raises(ValueError):
+        _agent(
+            messages=msgs,
+            thread_id="t",
+            checkpointer=MemoryCheckpointer(),
+        )
+
+
+def test_messages_kw_deep_copies_all_three_variants():
+    user = UserMessage(content=[TextContent(text="u")], metadata={"k": "v"})
+    assistant = AssistantMessage(
+        content=[ToolCall(id="c1", name="t", arguments={"k": [1, 2]})],
+        metadata={},
+    )
+    tool = ToolResultMessage(
+        tool_call_id="c1", tool_name="t",
+        content=[TextContent(text="r")], metadata={"x": 1},
+    )
+    a = _agent(messages=[user, assistant, tool])
+    # Mutate originals.
+    user.metadata["k"] = "MUT"
+    assistant.content[0].arguments["k"].append(99)
+    tool.metadata["x"] = 999
+    # Internal copies untouched.
+    assert a.state.messages[0].metadata["k"] == "v"
+    assert a.state.messages[1].content[0].arguments["k"] == [1, 2]
+    assert a.state.messages[2].metadata["x"] == 1
+    # Mutate agent's copies; originals untouched.
+    a.state.messages[0].metadata["k"] = "AGENT"
+    assert user.metadata["k"] == "MUT"
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_agent_messages_kw.py -v`
+Expected: `TypeError: __init__() got an unexpected keyword argument 'messages'`.
+
+- [ ] **Step 3: Add the constructor arg**
+
+In `cubepi/agent/agent.py`, locate `Agent.__init__`. Add the keyword-only
+parameter `messages: Sequence[Message] | None = None` at the end. Inside:
+
+```python
+if messages is not None:
+    if thread_id is not None and checkpointer is not None:
+        raise ValueError(
+            "Agent(messages=...) cannot be combined with "
+            "thread_id + checkpointer (pre-seed conflicts with lazy "
+            "load). Construct an ephemeral Agent without those for "
+            "fork_once-style usage."
+        )
+    seeded = [m.model_copy(deep=True) for m in messages]
+    self._state._messages = list(seeded)
+```
+
+(Make sure to import `Sequence` from `collections.abc` if not already
+imported, and `Message` from `cubepi.providers.base` likewise.)
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_agent_messages_kw.py -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py tests/agent/test_agent_messages_kw.py
+git commit -m "feat(agent): add messages=... pre-seed kw with deep-copy isolation"
+```
+
+---
+
+### Task 22: `Agent.prompt()` accepts `run_id`, returns `str`, sets `active_run_id`
+
+**Files:**
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_agent_run_id.py` (new)
+
+- [ ] **Step 1: Failing tests**
+
+Create `tests/agent/test_agent_run_id.py`:
+```python
+import uuid
+
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.providers.faux import FauxProvider
+
+
+def _agent(**kw):
+    return Agent(model=FauxProvider(text="hi").model("faux-model"), **kw)
+
+
+@pytest.mark.asyncio
+async def test_prompt_returns_supplied_run_id():
+    a = _agent()
+    got = await a.prompt("hello", run_id="R1")
+    assert got == "R1"
+
+
+@pytest.mark.asyncio
+async def test_prompt_generates_run_id_when_none():
+    a = _agent()
+    got = await a.prompt("hello")
+    assert isinstance(got, str) and len(got) >= 8
+
+
+@pytest.mark.asyncio
+async def test_prompt_sets_then_clears_active_run_id():
+    a = _agent()
+    assert a.state.active_run_id is None
+    got = await a.prompt("hello", run_id="R1")
+    assert a.state.active_run_id is None  # cleared on clean return
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_agent_run_id.py -v`
+Expected: prompt returns None or TypeError on `run_id`.
+
+- [ ] **Step 3: Modify `Agent.prompt`**
+
+In `cubepi/agent/agent.py`, edit `prompt`:
+```python
+async def prompt(
+    self,
+    message: str | Message | list[Message],
+    *,
+    run_id: str | None = None,
+) -> str:
+    if self._run_lock.locked() or self._state.is_streaming:
+        raise RuntimeError("Agent is already running")
+    effective_run_id = run_id or uuid.uuid4().hex
+    self._state.active_run_id = effective_run_id
+    try:
+        async with self._run_lock:
+            # ... existing body using `effective_run_id` for stamping ...
+            await self._run_prompt(message, run_id=effective_run_id)
+        return effective_run_id
+    finally:
+        self._state.active_run_id = None
+```
+
+(Note: the actual edit shape depends on the existing prompt() body —
+preserve everything that's there; only thread the run_id through and
+add the active_run_id set/clear in a `try/finally`. Internal helpers
+that perform `append()` will pass run_id into the Message construction
+in subsequent tasks.)
+
+Also import `uuid` at the top of the file.
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_agent_run_id.py tests/agent/ -q`
+Expected: green. (Test `tests/agent/test_agent.py` may need a small
+update if it asserted `prompt()` returns None — change to `await
+agent.prompt(...)` only without assigning, or update to assert `str`.)
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py tests/agent/test_agent_run_id.py
+git commit -m "feat(agent): prompt accepts run_id, returns it, exposes via active_run_id"
+```
+
+---
+
+### Task 23: Stamp `run_id` on every appended Message
+
+**Files:**
+- Modify: `cubepi/agent/loop.py`
+- Modify: `cubepi/agent/agent.py` (helper signatures)
+- Test: extend `tests/agent/test_agent_run_id.py`
+
+- [ ] **Step 1: Failing test asserts persisted messages carry the run_id**
+
+Append to `tests/agent/test_agent_run_id.py`:
+```python
+@pytest.mark.asyncio
+async def test_appended_messages_carry_run_id():
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=FauxProvider(text="hi").model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+    )
+    await a.prompt("hello", run_id="R1")
+    data = await cp.load("t")
+    for m in data.messages:
+        assert m.run_id == "R1"
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_agent_run_id.py::test_appended_messages_carry_run_id -v`
+Expected: `m.run_id` is None.
+
+- [ ] **Step 3: Thread run_id through the loop**
+
+In `cubepi/agent/loop.py`, locate every Message construction (`UserMessage(...)`, `AssistantMessage(...)`, `ToolResultMessage(...)`). For each one that represents a message produced THIS run, set `run_id=ctx.active_run_id` (or whatever the active variable is in that scope). The agent loop needs to plumb the active run_id from `Agent.prompt()` down to the inner loop. The cleanest way:
+
+- Add a `run_id: str` parameter to `_run_loop` / `_run_loop_inner` (and any helper that constructs Messages).
+- In `Agent.prompt()`, pass `effective_run_id` through to `_run_prompt`.
+
+Update every `UserMessage(...)`, `AssistantMessage(...)`,
+`ToolResultMessage(...)` construction site in `loop.py` to pass
+`run_id=run_id`.
+
+Also update `Agent.respond()` and `Agent.abort_pending()` paths that
+construct synthetic messages — those should also stamp the recovered
+run_id.
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/ -q`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/loop.py cubepi/agent/agent.py tests/agent/test_agent_run_id.py
+git commit -m "feat(agent): thread active run_id through loop into appended messages"
+```
+
+---
+
+### Task 24: HITL channel run_id binding enforcement at `prompt()` entry
+
+**Files:**
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_hitl_binding_enforcement.py` (new)
+
+- [ ] **Step 1: Failing tests**
+
+Create `tests/agent/test_hitl_binding_enforcement.py`:
+```python
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.agent.types import AgentTool
+from cubepi.hitl.binding import HitlBinding
+from cubepi.middleware.base import Middleware
+from cubepi.providers.faux import FauxProvider
+from pydantic import BaseModel
+
+
+class _NoArgs(BaseModel):
+    pass
+
+
+async def _noop(tool_call_id, args, *, signal=None, on_update=None):
+    raise NotImplementedError
+
+
+def _tool_with_hitl(binding):
+    return AgentTool(
+        name="ask_user",
+        description="d",
+        parameters=_NoArgs,
+        execute=_noop,
+        hitl=binding,
+    )
+
+
+def _agent(tools=None, middleware=None):
+    return Agent(
+        model=FauxProvider(text="hi").model("faux-model"),
+        tools=tools or [],
+        middleware=middleware or [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_checkpointed_hitl_with_none_run_id_raises():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=True, run_id=None))
+    a = _agent(tools=[tool])
+    with pytest.raises(ValueError, match="no run_id bound"):
+        await a.prompt("hi", run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_checkpointed_hitl_requires_explicit_run_id():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=True, run_id="R1"))
+    a = _agent(tools=[tool])
+    with pytest.raises(ValueError, match="generate-mode rejected"):
+        await a.prompt("hi", run_id=None)
+
+
+@pytest.mark.asyncio
+async def test_checkpointed_hitl_run_id_mismatch_raises():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=True, run_id="R1"))
+    a = _agent(tools=[tool])
+    with pytest.raises(ValueError, match="does not match"):
+        await a.prompt("hi", run_id="R2")
+
+
+@pytest.mark.asyncio
+async def test_checkpointed_hitl_run_id_match_succeeds():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=True, run_id="R1"))
+    a = _agent(tools=[tool])
+    got = await a.prompt("hi", run_id="R1")
+    assert got == "R1"
+
+
+@pytest.mark.asyncio
+async def test_in_memory_hitl_no_constraint():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=False, run_id=None))
+    a = _agent(tools=[tool])
+    got = await a.prompt("hi")  # generate-mode allowed
+    assert isinstance(got, str)
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_hitl_binding_enforcement.py -v`
+Expected: ValueError not raised.
+
+- [ ] **Step 3: Add the enforcement to `Agent.prompt()` start**
+
+Just before the `try:` block that sets `active_run_id`, add:
+```python
+bound: set[str] = set()
+for elem in (*self.tools, *self.middleware):
+    binding = getattr(elem, "hitl", None)
+    if binding is None or not binding.checkpointed:
+        continue
+    if binding.run_id is None:
+        raise ValueError(
+            f"Checkpointed HITL element {elem!r} has no run_id bound; "
+            "construct CheckpointedChannel(run_id=...) before passing "
+            "it to ask_user_tool/HITL middleware"
+        )
+    bound.add(binding.run_id)
+if bound:
+    if run_id is None:
+        raise ValueError(
+            f"Agent has checkpointed HITL elements bound to "
+            f"run_ids {sorted(bound)!r}; prompt(run_id=...) "
+            "must be explicitly supplied (generate-mode rejected)"
+        )
+    if any(b != run_id for b in bound):
+        raise ValueError(
+            f"prompt(run_id={run_id!r}) does not match "
+            f"HITL-bound run_ids {sorted(bound)!r}"
+        )
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_hitl_binding_enforcement.py -v`
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py tests/agent/test_hitl_binding_enforcement.py
+git commit -m "feat(agent): enforce HITL channel run_id binding at prompt() entry"
+```
+
+---
+
+### Task 25: `claim_run` pre-flight + degraded-mode capability check
+
+**Files:**
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_agent_claim_run.py` (new)
+
+- [ ] **Step 1: Failing tests**
+
+Create `tests/agent/test_agent_claim_run.py`:
+```python
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+)
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.faux import FauxProvider
+
+
+def _agent(**kw):
+    return Agent(model=FauxProvider(text="hi").model("faux-model"), **kw)
+
+
+@pytest.mark.asyncio
+async def test_prompt_calls_claim_run_before_append():
+    cp = MemoryCheckpointer()
+    a = _agent(checkpointer=cp, thread_id="t")
+    await a.prompt("hi", run_id="R1")
+    # Run row exists.
+    assert "R1" in cp._runs["t"]
+
+
+@pytest.mark.asyncio
+async def test_prompt_rejects_already_claimed_run_id():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "R1")
+    a = _agent(checkpointer=cp, thread_id="t")
+    with pytest.raises(RunAlreadyClaimedError):
+        await a.prompt("hi", run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_prompt_rejects_already_completed_run_id():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "R1")
+    await cp.mark_run_complete("t", "R1")
+    a = _agent(checkpointer=cp, thread_id="t")
+    with pytest.raises(RunAlreadyCompletedError):
+        await a.prompt("hi", run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_no_checkpointer_no_claim_call():
+    a = _agent()  # checkpointer=None
+    got = await a.prompt("hi")
+    assert isinstance(got, str)  # works fine; no claim attempted
+
+
+@pytest.mark.asyncio
+async def test_degraded_mode_v3_only_checkpointer():
+    class _V3Only:
+        async def load(self, thread_id): return None
+        async def append(self, thread_id, msgs): pass
+        async def save_extra(self, thread_id, extra): pass
+        async def save_pending_request(self, thread_id, req, *, run_id=None): pass
+        async def load_pending_request(self, thread_id): return None
+        # No claim_run / mark_run_complete.
+    a = _agent(checkpointer=_V3Only(), thread_id="t")
+    # Vanilla prompt works (degraded mode skips claim).
+    got = await a.prompt("hi")
+    assert isinstance(got, str)
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_agent_claim_run.py -v`
+Expected: claim not called / errors not surfaced.
+
+- [ ] **Step 3: Add the capability check + claim call**
+
+In `Agent.__init__` (or as a `@property`), compute:
+```python
+self._run_aware = (
+    self.checkpointer is not None
+    and hasattr(self.checkpointer, "claim_run")
+    and hasattr(self.checkpointer, "mark_run_complete")
+)
+```
+
+In `Agent.prompt()`, after the HITL binding check but BEFORE setting
+`active_run_id`, add the claim:
+```python
+if self._run_aware and self.thread_id is not None:
+    await self.checkpointer.claim_run(self.thread_id, effective_run_id)
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_agent_claim_run.py -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py tests/agent/test_agent_claim_run.py
+git commit -m "feat(agent): claim_run pre-flight + legacy degraded-mode fallback"
+```
+
+---
+
+### Task 26: `mark_run_complete` after terminal success + outcome enumeration
+
+**Files:**
+- Modify: `cubepi/agent/loop.py`
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_agent_completion.py` (new)
+
+- [ ] **Step 1: Failing tests covering every row of spec §3.6.2 table**
+
+Create `tests/agent/test_agent_completion.py`:
+```python
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.faux import FauxProvider
+
+
+def _agent(provider, **kw):
+    cp = MemoryCheckpointer()
+    a = Agent(model=provider.model("faux-model"), checkpointer=cp, thread_id="t", **kw)
+    return a, cp
+
+
+@pytest.mark.asyncio
+async def test_clean_success_marks_complete():
+    a, cp = _agent(FauxProvider(text="ok"))
+    await a.prompt("hi", run_id="R1")
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is not None
+    assert rs.completion_seq is not None
+
+
+@pytest.mark.asyncio
+async def test_hitl_suspend_does_not_mark():
+    """Provider raises HitlDetached mid-stream → loop catches → no mark."""
+    a, cp = _agent(FauxProvider(error="HitlDetached"))
+    with pytest.raises(Exception):
+        await a.prompt("hi", run_id="R1")
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_provider_error_does_not_mark():
+    a, cp = _agent(FauxProvider(error="RuntimeError"))
+    with pytest.raises(Exception):
+        await a.prompt("hi", run_id="R1")
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is None
+
+
+# Add similar tests for abort, cancellation, etc., per spec table.
+```
+
+(The exact FauxProvider injection API may differ; use whatever mechanism
+the test suite already uses to inject errors / stop_reasons. The
+assertion shape — "mark called" vs "mark not called" — is what matters.)
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_agent_completion.py -v`
+Expected: mark not called even on clean success.
+
+- [ ] **Step 3: Call `mark_run_complete` only on terminal clean exit**
+
+In `Agent.prompt()` (or wherever the loop returns cleanly), add:
+```python
+async with self._run_lock:
+    outcome = await self._run_prompt(message, run_id=effective_run_id)
+# `outcome` reports whether mark should fire. Possible values:
+#   "complete"       — clean success
+#   "suspended"      — HITL pause; respond() handles completion
+#   "incomplete"     — pre-completion invariant failed (Task 27)
+#   "abandoned"      — provider/tool error / abort / cancellation
+if outcome == "complete" and self._run_aware and self.thread_id:
+    try:
+        await self.checkpointer.mark_run_complete(
+            self.thread_id, effective_run_id
+        )
+    except Exception as exc:
+        raise CompletionMarkerFailedError(
+            thread_id=self.thread_id,
+            run_id=effective_run_id,
+            cause=exc,
+        ) from exc
+```
+
+In the agent loop, set the outcome explicitly per the spec table:
+- After clean terminal stop_reason + no pending HITL → `complete`
+- HitlDetached/HitlAborted silent catch → `suspended` (resume handles)
+- Provider/tool error → `abandoned`
+- abort_pending injected — terminal aborted → `abandoned`
+- Propagating CancelledError — re-raises, no return value
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_agent_completion.py -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/loop.py cubepi/agent/agent.py tests/agent/test_agent_completion.py
+git commit -m "feat(agent): mark_run_complete only on clean terminal outcome"
+```
+
+---
+
+### Task 27: Pre-completion tool-cycle invariant
+
+**Files:**
+- Create: `cubepi/agent/_tool_cycle.py` (helper, kept small + testable)
+- Modify: `cubepi/agent/loop.py` to call it before declaring `complete`
+- Test: `tests/agent/test_tool_cycle_invariant.py` (new)
+
+- [ ] **Step 1: Failing tests covering the four spec shapes**
+
+Create `tests/agent/test_tool_cycle_invariant.py`:
+```python
+from cubepi.agent._tool_cycle import (
+    ToolCycleViolation,
+    check_tool_cycle,
+)
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+
+
+def _asst(call_ids, run_id="R"):
+    return AssistantMessage(
+        content=[
+            ToolCall(id=cid, name="t", arguments={}) for cid in call_ids
+        ],
+        run_id=run_id,
+    )
+
+
+def _res(call_id, run_id="R"):
+    return ToolResultMessage(
+        tool_call_id=call_id,
+        tool_name="t",
+        content=[TextContent(text="r")],
+        run_id=run_id,
+    )
+
+
+def test_no_tool_calls_ok():
+    check_tool_cycle([
+        UserMessage(content=[TextContent(text="hi")], run_id="R"),
+        AssistantMessage(content=[TextContent(text="hi back")], run_id="R"),
+    ])
+
+
+def test_complete_cycle_ok():
+    check_tool_cycle([
+        _asst(["c1", "c2"]),
+        _res("c1"),
+        _res("c2"),
+        AssistantMessage(content=[TextContent(text="done")], run_id="R"),
+    ])
+
+
+def test_no_results_at_all_violation():
+    try:
+        check_tool_cycle([_asst(["c1"])])
+    except ToolCycleViolation:
+        return
+    assert False, "expected ToolCycleViolation"
+
+
+def test_intervening_user_message_violation():
+    try:
+        check_tool_cycle([
+            _asst(["c1"]),
+            UserMessage(content=[TextContent(text="hi")], run_id="R"),
+            _res("c1"),
+        ])
+    except ToolCycleViolation:
+        return
+    assert False
+
+
+def test_partial_cover_violation():
+    try:
+        check_tool_cycle([_asst(["c1", "c2"]), _res("c1")])
+    except ToolCycleViolation:
+        return
+    assert False
+
+
+def test_duplicate_ids_across_turns_violation():
+    try:
+        check_tool_cycle([
+            _asst(["c1"]),
+            _asst(["c1"]),  # second assistant reuses id
+            _res("c1"),
+        ])
+    except ToolCycleViolation:
+        return
+    assert False
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_tool_cycle_invariant.py -v`
+Expected: import error.
+
+- [ ] **Step 3: Implement `_tool_cycle.py`**
+
+Create `cubepi/agent/_tool_cycle.py`:
+```python
+"""Pre-completion tool-cycle invariant — spec §3.6.2.
+
+For each AssistantMessage with ToolCall blocks {c1..cK}, the
+K-message window immediately following MUST be all ToolResultMessages
+with tool_call_id set-equal to {c1..cK} — no other AssistantMessage
+or UserMessage may appear in that window.
+"""
+
+from __future__ import annotations
+
+from cubepi.providers.base import (
+    AssistantMessage,
+    Message,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+
+
+class ToolCycleViolation(ValueError):
+    def __init__(
+        self,
+        *,
+        kind: str,
+        assistant_index: int,
+        expected: set[str],
+        got: set[str],
+    ) -> None:
+        super().__init__(
+            f"tool-cycle violation [{kind}] at assistant index "
+            f"{assistant_index}: expected {expected}, got {got}"
+        )
+        self.kind = kind
+        self.assistant_index = assistant_index
+        self.expected = expected
+        self.got = got
+
+
+def check_tool_cycle(messages: list[Message]) -> None:
+    n = len(messages)
+    for i, m in enumerate(messages):
+        if not isinstance(m, AssistantMessage):
+            continue
+        call_ids = {
+            c.id for c in m.content if isinstance(c, ToolCall)
+        }
+        if not call_ids:
+            continue
+        k = len(call_ids)
+        window = messages[i + 1 : i + 1 + k]
+        if len(window) < k:
+            raise ToolCycleViolation(
+                kind="incomplete-window",
+                assistant_index=i,
+                expected=call_ids,
+                got=set(),
+            )
+        for w in window:
+            if not isinstance(w, ToolResultMessage):
+                raise ToolCycleViolation(
+                    kind="non-tool-result-in-window",
+                    assistant_index=i,
+                    expected=call_ids,
+                    got=set(),
+                )
+        got_ids = {w.tool_call_id for w in window}
+        if got_ids != call_ids:
+            raise ToolCycleViolation(
+                kind="set-mismatch",
+                assistant_index=i,
+                expected=call_ids,
+                got=got_ids,
+            )
+```
+
+- [ ] **Step 4: Wire into the loop's completion path**
+
+In `cubepi/agent/loop.py`, just before declaring outcome `complete` for
+a run, gather the messages tagged with this `run_id` appended since
+claim and call `check_tool_cycle(run_messages)`. On `ToolCycleViolation`,
+set the outcome to `"incomplete"` instead of `"complete"` — that flows
+into Task 26's outcome dispatcher (no mark, claim remains).
+
+- [ ] **Step 5: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_tool_cycle_invariant.py tests/agent/test_agent_completion.py -v`
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```
+git add cubepi/agent/_tool_cycle.py cubepi/agent/loop.py tests/agent/test_tool_cycle_invariant.py
+git commit -m "feat(agent): pre-completion tool-cycle strict-adjacency invariant"
+```
+
+---
+
+### Task 28: `respond()` resumes run_id from `load_pending`; does NOT call `claim_run`
+
+**Files:**
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_respond_resume_run_id.py` (new)
+
+- [ ] **Step 1: Failing test asserting single-claim invariant**
+
+Create `tests/agent/test_respond_resume_run_id.py` that:
+- Mocks/spies on `MemoryCheckpointer.claim_run` to count calls
+- Triggers a HITL pause (using cubepi's testing helpers from
+  `cubepi/hitl/testing.py`)
+- Calls `respond()` to resume
+- Asserts:
+  - `claim_run` was called exactly ONCE (during the initial prompt)
+  - Messages appended after resume carry the same `run_id`
+  - `mark_run_complete` fires on terminal exit of the resumed loop
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_respond_resume_run_id.py -v`
+Expected: `respond()` either reclaims or doesn't propagate run_id.
+
+- [ ] **Step 3: Modify `Agent.respond()`**
+
+At the start of `respond()`:
+```python
+pending = await self.checkpointer.load_pending(self.thread_id)
+if pending is None:
+    raise HitlError("no pending request")
+_req, recovered_run_id = pending
+if recovered_run_id is not None:
+    self._state.active_run_id = recovered_run_id
+```
+
+Then continue the existing flow. **Do not call `claim_run` here.** All
+subsequent append calls use `self._state.active_run_id`. At terminal
+clean exit, the same `mark_run_complete` block from Task 26 fires.
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_respond_resume_run_id.py tests/agent/ -q`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py tests/agent/test_respond_resume_run_id.py
+git commit -m "feat(agent): respond() resumes run_id via load_pending; never reclaims"
+```
+
+---
+
+## Phase 8 — Public fork API
+
+### Task 29: `Agent.fork()`
+
+**Files:**
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_agent_fork.py` (new)
+
+- [ ] **Step 1: Failing test**
+
+```python
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.faux import FauxProvider
+
+
+@pytest.mark.asyncio
+async def test_agent_fork_delegates_to_checkpointer():
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=FauxProvider(text="hi").model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.prompt("hello", run_id="R1")  # creates src + R1 marker
+    await a.fork("src", "dst", after_run_id="R1")
+    loaded = await cp.load("dst")
+    assert loaded.parent_thread_id == "src"
+
+
+@pytest.mark.asyncio
+async def test_agent_fork_no_checkpointer_raises():
+    a = Agent(model=FauxProvider(text="hi").model("faux-model"))
+    with pytest.raises(RuntimeError, match="checkpointer"):
+        await a.fork("src", "dst", after_run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_agent_fork_does_not_mutate_self_thread_id():
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=FauxProvider(text="hi").model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.prompt("hello", run_id="R1")
+    await a.fork("src", "dst", after_run_id="R1")
+    assert a.thread_id == "src"
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_agent_fork.py -v`
+Expected: `AttributeError: 'Agent' object has no attribute 'fork'`.
+
+- [ ] **Step 3: Add the method**
+
+In `cubepi/agent/agent.py`:
+```python
+async def fork(
+    self,
+    src_thread_id: str,
+    new_thread_id: str,
+    *,
+    after_run_id: str,
+    metadata: JsonObject | None = None,
+) -> None:
+    if self.checkpointer is None:
+        raise RuntimeError("fork requires a checkpointer")
+    if not self._run_aware:
+        from cubepi.checkpointer.exceptions import CheckpointerError
+        raise CheckpointerError(
+            "backend does not support fork; missing claim_run / "
+            "mark_run_complete"
+        )
+    await self.checkpointer.fork(
+        src_thread_id,
+        new_thread_id,
+        after_run_id=after_run_id,
+        metadata=metadata,
+    )
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_agent_fork.py -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py tests/agent/test_agent_fork.py
+git commit -m "feat(agent): add Agent.fork() public API"
+```
+
+---
+
+### Task 30: `ForkOnceResult` dataclass
+
+**Files:**
+- Modify: `cubepi/agent/types.py`
+
+- [ ] **Step 1: Add the dataclass**
+
+```python
+@dataclass(frozen=True)
+class ForkOnceResult:
+    text: str
+    messages: list[Message]
+    stop_reason: str
+```
+
+Add a test asserting the type imports cleanly and is frozen.
+
+- [ ] **Step 2: Commit**
+
+```
+git add cubepi/agent/types.py
+git commit -m "feat(agent): add ForkOnceResult dataclass"
+```
+
+---
+
+### Task 31: `Agent.fork_once()` — HITL ban + transient agent + tracing span
+
+**Files:**
+- Modify: `cubepi/agent/agent.py`
+- Test: `tests/agent/test_agent_fork_once.py` (new)
+
+- [ ] **Step 1: Failing tests covering all §3.8 behavior**
+
+Create `tests/agent/test_agent_fork_once.py` testing:
+- Simple text-only follow-up returns expected final text; source thread
+  unchanged
+- `RuntimeError` when no checkpointer
+- `RuntimeError` when any `tool.hitl is not None` (checkpointed OR
+  in-memory)
+- `RuntimeError` when middleware has `hitl is not None`
+- Cancellation: `asyncio.wait_for(..., timeout=0.01)` raises
+  `TimeoutError`
+- Source thread byte-identical before/after
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/agent/test_agent_fork_once.py -v`
+Expected: missing method.
+
+- [ ] **Step 3: Implement `fork_once`**
+
+```python
+async def fork_once(
+    self,
+    src_thread_id: str,
+    message: str | Message | list[Message],
+    *,
+    after_run_id: str,
+) -> ForkOnceResult:
+    if self.checkpointer is None:
+        raise RuntimeError("fork_once requires a checkpointer")
+    # HITL pre-flight.
+    hitl_offenders = [
+        elem for elem in (*self.tools, *self.middleware)
+        if getattr(elem, "hitl", None) is not None
+    ]
+    if hitl_offenders:
+        names = ", ".join(
+            getattr(e, "name", type(e).__name__) for e in hitl_offenders
+        )
+        raise RuntimeError(
+            f"fork_once() does not support HITL. Found HITL-bearing "
+            f"tools/middleware: {names}. Construct a different Agent "
+            "without these for ephemeral probes."
+        )
+    snapshot = await self.checkpointer.snapshot(
+        src_thread_id, after_run_id=after_run_id
+    )
+    # Build transient agent.
+    child = Agent(
+        model=self.model,
+        system_prompt=self.system_prompt,
+        tools=list(self.tools),
+        middleware=list(self.middleware),
+        convert_to_llm=self.convert_to_llm,
+        messages=snapshot,
+        # checkpointer=None, thread_id=None — disable persistence.
+    )
+    pre_len = len(child.state.messages)
+    fresh_run_id = uuid.uuid4().hex
+    # Tracing — see Phase 10. For now just call prompt.
+    with self._fork_once_span(
+        src_thread_id=src_thread_id, after_run_id=after_run_id
+    ):
+        await child.prompt(message, run_id=fresh_run_id)
+    new_messages = child.state.messages[pre_len:]
+    # Extract final assistant text and stop_reason.
+    final_text = ""
+    stop_reason = "stop"
+    for m in reversed(new_messages):
+        from cubepi.providers.base import AssistantMessage, TextContent
+        if isinstance(m, AssistantMessage):
+            final_text = "".join(
+                c.text for c in m.content if isinstance(c, TextContent)
+            )
+            stop_reason = m.stop_reason
+            break
+    return ForkOnceResult(
+        text=final_text, messages=new_messages, stop_reason=stop_reason
+    )
+
+def _fork_once_span(self, *, src_thread_id, after_run_id):
+    """Replaced by a real OTel span in Phase 10. Placeholder no-op."""
+    from contextlib import nullcontext
+    return nullcontext()
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/agent/test_agent_fork_once.py -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py cubepi/agent/types.py tests/agent/test_agent_fork_once.py
+git commit -m "feat(agent): add Agent.fork_once() with HITL ban + transient agent"
+```
+
+---
+
+## Phase 9 — HITL integration
+
+### Task 32: `ask_user_tool()` populates `tool.hitl` from channel
+
+**Files:**
+- Modify: `cubepi/hitl/ask_user.py`
+- Test: `tests/hitl/test_ask_user_binding.py` (new)
+
+- [ ] **Step 1: Failing test**
+
+```python
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.ask_user import ask_user_tool
+from cubepi.hitl.channel import CheckpointedChannel, InMemoryChannel
+
+
+def test_ask_user_tool_with_checkpointed_channel_sets_binding():
+    cp = MemoryCheckpointer()
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    assert tool.hitl is not None
+    assert tool.hitl.checkpointed is True
+    assert tool.hitl.run_id == "R1"
+
+
+def test_ask_user_tool_with_in_memory_channel_sets_binding():
+    ch = InMemoryChannel(thread_id="t")
+    tool = ask_user_tool(ch)
+    assert tool.hitl is not None
+    assert tool.hitl.checkpointed is False
+    assert tool.hitl.run_id is None
+```
+
+- [ ] **Step 2: Run → expect failure**
+
+Run: `uv run pytest tests/hitl/test_ask_user_binding.py -v`
+Expected: `tool.hitl is None`.
+
+- [ ] **Step 3: Patch the factory**
+
+In `cubepi/hitl/ask_user.py` (the `ask_user_tool` factory), at the
+return site:
+```python
+from cubepi.hitl.binding import HitlBinding
+from cubepi.hitl.channel import CheckpointedChannel
+
+checkpointed = isinstance(channel, CheckpointedChannel)
+binding = HitlBinding(
+    checkpointed=checkpointed,
+    run_id=getattr(channel, "_run_id", None) if checkpointed else None,
+)
+tool = AgentTool(
+    name="ask_user",
+    description=...,
+    parameters=...,
+    execute=...,
+    hitl_builtin=True,
+    hitl=binding,
+)
+return tool
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/hitl/test_ask_user_binding.py tests/hitl/ -q`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/hitl/ask_user.py tests/hitl/test_ask_user_binding.py
+git commit -m "feat(hitl): ask_user_tool sets tool.hitl HitlBinding from channel"
+```
+
+---
+
+### Task 33: `ApprovalPolicyMiddleware` populates `self.hitl`
+
+**Files:**
+- Modify: `cubepi/hitl/middleware.py`
+- Test: `tests/hitl/test_approval_policy_binding.py` (new)
+
+Same pattern as Task 32 applied to `ApprovalPolicyMiddleware.__init__`
+and (transitively via subclassing) `ConfirmToolCallMiddleware`. Add
+assertion test for both.
+
+Commit: `feat(hitl): ApprovalPolicyMiddleware populates self.hitl`.
+
+---
+
+## Phase 10 — Tracing
+
+### Task 34: `cubepi.agent.fork_once` OTel span
+
+**Files:**
+- Modify: `cubepi/agent/agent.py` (replace nullcontext placeholder)
+- Modify: `cubepi/tracing/schema.py` (add span name constant)
+- Test: `tests/tracing/test_fork_once_span.py` (new)
+
+- [ ] **Step 1: Failing test using the existing in-memory exporter**
+
+```python
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.faux import FauxProvider
+from tests.tracing.conftest import InMemoryExporter  # existing helper
+
+
+@pytest.mark.asyncio
+async def test_fork_once_emits_named_span(in_memory_exporter):
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=FauxProvider(text="hi").model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.prompt("hello", run_id="R1")
+    await a.fork_once("src", "follow up?", after_run_id="R1")
+    spans = in_memory_exporter.get_finished_spans()
+    names = [s.name for s in spans]
+    assert "cubepi.agent.fork_once" in names
+    span = next(s for s in spans if s.name == "cubepi.agent.fork_once")
+    attrs = dict(span.attributes)
+    assert attrs["cubepi.fork.src_thread_id"] == "src"
+    assert attrs["cubepi.fork.after_run_id"] == "R1"
+```
+
+(The existing in-memory exporter fixture lives in
+`tests/tracing/conftest.py`; if it doesn't, add it as a small helper
+following the OTel `InMemorySpanExporter` pattern.)
+
+- [ ] **Step 2: Run → expect failure**
+
+Expected: no span named `cubepi.agent.fork_once`.
+
+- [ ] **Step 3: Replace `_fork_once_span` placeholder with a real span**
+
+```python
+def _fork_once_span(self, *, src_thread_id, after_run_id):
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        from contextlib import nullcontext
+        return nullcontext()
+    tracer = trace.get_tracer("cubepi.agent")
+    return tracer.start_as_current_span(
+        "cubepi.agent.fork_once",
+        attributes={
+            "cubepi.fork.src_thread_id": src_thread_id,
+            "cubepi.fork.after_run_id": after_run_id,
+        },
+    )
+```
+
+- [ ] **Step 4: Run tests → expect pass**
+
+Run: `uv run pytest tests/tracing/test_fork_once_span.py -v`
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add cubepi/agent/agent.py tests/tracing/test_fork_once_span.py
+git commit -m "feat(tracing): emit cubepi.agent.fork_once span"
+```
+
+---
+
+## Phase 11 — Documentation
+
+### Task 35: User-facing fork guide
+
+**Files:**
+- Create: `website/docs/guides/checkpointing/forking.md`
+
+Write a guide covering:
+- What a fork is + persistent vs ephemeral
+- The cubebox copy-button UX
+- `Agent.prompt()` accept-or-generate `run_id`
+- `Agent.fork(after_run_id=…)`
+- `Agent.fork_once()` + isolation contract (only checkpointer writes
+  isolated; tools may have side effects; HITL banned)
+- HITL binding requirement: build `CheckpointedChannel(run_id=…)` with
+  the same value as `Agent.prompt(run_id=…)`
+- Schema v3→v4 migration note pointing to alembic helper
+- Legacy data behavior (NULL run_id messages remain readable; mixed
+  threads forkable; all-legacy threads not forkable)
+- Known limitation: cross-process interleaved runs on the same thread
+  produce row-correct but semantically dangling forks
+
+Cross-link from `website/docs/guides/checkpointing/postgres.md`,
+`mysql.md`, `sqlite.md` (each gets a short "fork" subsection pointing
+to the main guide).
+
+Commit: `docs(guides): add conversation-fork guide`.
+
+---
+
+### Task 36: Migration notes in per-backend docs
+
+**Files:**
+- Modify: `website/docs/guides/checkpointing/postgres.md`
+- Modify: `website/docs/guides/checkpointing/mysql.md`
+- Modify: `website/docs/guides/checkpointing/sqlite.md` (if exists)
+
+Each gets a "Schema v3 → v4 migration" subsection. For PG/MySQL,
+include the alembic helper invocation. For SQLite, point at the
+auto-migration in `__aenter__`.
+
+Commit: `docs(guides): backend-specific v3→v4 migration notes`.
+
+---
+
+### Task 37: API reference + CHANGELOG
+
+**Files:**
+- Modify: `website/docs/api/cubepi-agent.mdx` (add new Agent methods)
+- Modify: `website/docs/api/cubepi-checkpointer.mdx` (add new Protocol methods, errors)
+- Modify: `CHANGELOG.md`
+
+CHANGELOG entry:
+```markdown
+## 0.8.0 — TBD
+
+### Added
+- `Agent.fork(src, new, *, after_run_id, metadata=None)` — physical-copy fork at a completed-run boundary.
+- `Agent.fork_once(src, message, *, after_run_id) -> ForkOnceResult` — single-turn ephemeral continuation.
+- `Agent.prompt(message, *, run_id=None) -> str` now accept-or-generates the run_id and returns it.
+- `Agent.state.active_run_id` exposes the in-flight run_id.
+- `Agent(messages=...)` constructor arg for ephemeral pre-seeded history.
+- `Checkpointer.snapshot`, `fork`, `claim_run`, `mark_run_complete`, `load_pending` Protocol methods.
+- `cubepi_runs` table per backend (PG/MySQL schema v3 → v4).
+- `Message.run_id: str | None` field on all three Message variants.
+- `HitlBinding` attribute on `AgentTool` / `Middleware`; `ask_user_tool` and `ApprovalPolicyMiddleware` populate it.
+
+### Breaking
+- `Agent.prompt()` return type changed from `None` to `str`. Callers ignoring the return value keep working.
+- `Checkpointer` Protocol gained 5 new methods. Third-party v3-only checkpointers continue to work for vanilla `prompt()` via degraded mode; fork APIs raise `CheckpointerError` on such backends.
+
+### Migration
+- Postgres / MySQL: run the new alembic helper (see backend guides).
+- SQLite: auto-migration at connect time.
+- Legacy `run_id=NULL` messages remain readable; threads with only such messages are not forkable.
+```
+
+Commit: `docs: API ref + CHANGELOG for fork feature`.
+
+---
+
+## Phase 12 — End-to-end tests
+
+### Task 38: Cross-backend happy path
+
+**Files:**
+- Create: `tests/e2e/test_fork_e2e.py`
+
+- [ ] **Step 1: Write parameterized test across all four backends**
+
+```python
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.providers.faux import FauxProvider
+
+BACKENDS = ["memory", "sqlite", "postgres", "mysql"]
+
+
+@pytest.fixture(params=BACKENDS)
+async def checkpointer(request, tmp_path, pg_pool, mysql_pool):
+    # Build the appropriate checkpointer per param.
+    ...
+
+
+@pytest.mark.asyncio
+async def test_fork_e2e_happy_path(checkpointer):
+    cp = checkpointer
+    a = Agent(
+        model=FauxProvider(text="ok").model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    r1 = await a.prompt("first", run_id="R1")
+    assert r1 == "R1"
+    r2 = await a.prompt("second", run_id="R2")
+    assert r2 == "R2"
+    await a.fork("src", "dst", after_run_id="R1", metadata={"label": "branch"})
+    loaded = await cp.load("dst")
+    assert loaded.parent_thread_id == "src"
+    assert loaded.extra["fork"] == {"label": "branch"}
+    # dst contains R1's messages only, not R2's.
+    run_ids = {m.run_id for m in loaded.messages if m.run_id}
+    assert run_ids == {"R1"}
+```
+
+- [ ] **Step 2: Run on all backends**
+
+Run: `uv run pytest tests/e2e/test_fork_e2e.py -v`
+Expected: 4 backends × 1 test = 4 passes (skip PG / MySQL if test
+infra isn't available in CI for those — gate appropriately).
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/e2e/test_fork_e2e.py
+git commit -m "test(e2e): cross-backend fork happy path"
+```
+
+---
+
+### Task 39: HITL pause+resume+fork chain
+
+**Files:**
+- Create: `tests/e2e/test_fork_hitl_e2e.py`
+
+- [ ] **Step 1: Test**
+
+```python
+@pytest.mark.asyncio
+async def test_fork_after_hitl_resume(memory_checkpointer):
+    """prompt pauses for HITL → respond resumes → marker written →
+    fork succeeds and copies the resumed run."""
+    ...
+```
+
+Use `cubepi/hitl/testing.py` helpers to script the HITL response.
+
+- [ ] **Step 2: Commit**
+
+```
+git add tests/e2e/test_fork_hitl_e2e.py
+git commit -m "test(e2e): HITL pause+resume followed by fork"
+```
+
+---
+
+### Task 40: Concurrent fork race on Postgres
+
+**Files:**
+- Create: `tests/e2e/test_fork_concurrency_pg.py`
+
+- [ ] **Step 1: Test**
+
+Two concurrent forks of the same source thread (different
+`new_thread_id`s); both succeed; outputs consistent (one fork's
+messages are a prefix of the other's iff completion order is observed).
+
+Also: concurrent claim of the same run_id from two coroutines via two
+PostgresCheckpointer instances pointing at the same DB → exactly one
+succeeds, the other raises `RunAlreadyClaimedError` with zero messages
+appended.
+
+- [ ] **Step 2: Commit**
+
+```
+git add tests/e2e/test_fork_concurrency_pg.py
+git commit -m "test(e2e): concurrent fork + claim races on Postgres"
+```
+
+---
+
+## Final checklist
+
+- [ ] **All tests pass**
+
+Run: `uv run pytest tests/ -q`
+Expected: full suite green.
+
+- [ ] **Type check clean**
+
+Run: `uv run mypy cubepi`
+Expected: no errors.
+
+- [ ] **Lint clean**
+
+Run: `uv run ruff check cubepi/ tests/ && uv run ruff format --check cubepi/ tests/`
+Expected: no errors.
+
+- [ ] **Coverage on new code**
+
+Run: `uv run pytest tests/ --cov=cubepi --cov-report=term-missing`
+Spot-check: `cubepi/agent/_tool_cycle.py`, `cubepi/checkpointer/memory.py`,
+`cubepi/checkpointer/sqlite.py`, `cubepi/hitl/binding.py` are all
+≥ 90 %.
+
+- [ ] **Spec coverage walk**
+
+Open `dev/specs/2026-06-05-conversation-fork.md` side-by-side and
+confirm each section maps to a task:
+- §3.1 storage → Phase 3–6
+- §3.2 set-based selection → Tasks 9, 13, 17, 20
+- §3.3 atomicity → Tasks 7, 10–13, 14–17, 18–20
+- §3.4 copy table → Tasks 9, 13, 17, 20
+- §3.5 tracing → Task 34
+- §3.6 run lifecycle → Tasks 22–28
+- §3.6.3.1 HITL binding → Tasks 4, 24, 32, 33
+- §3.7 API surface → Tasks 1, 2, 4, 5, 6, 21, 22, 29, 30, 31
+- §3.8 fork_once → Tasks 31, 34
+- §3.9 per-backend → Phases 3–6
+- §3.10 errors → Task 1
+- §4 migration → Tasks 14, 18, 36, 37
+- §5 testing → tests in every task + Phase 12
+
+- [ ] **PR description draft**
+
+Once everything is green, draft the PR body covering:
+- One-paragraph summary
+- Schema changes (PG/MySQL v3→v4; SQLite ALTER)
+- Public API changes + return-type change on `Agent.prompt()`
+- Migration story for third-party checkpointers (legacy degraded mode)
+- Link to `dev/specs/2026-06-05-conversation-fork.md`
+- Link to this plan
+
+Open the PR. Drive the codex PR review loop per CLAUDE.md §5 (poll
+~2 min, fix, reply `@codex review again` until clean).

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -3623,10 +3623,19 @@ git commit -m "feat(agent): mark_run_complete only on clean terminal outcome"
 
 Create `tests/agent/test_tool_cycle_invariant.py`:
 ```python
+import asyncio
+
+import pytest
+
 from cubepi.agent._tool_cycle import (
     ToolCycleViolation,
     check_tool_cycle,
 )
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.ask_user import ask_user_tool
+from cubepi.hitl.channel import CheckpointedChannel
+from cubepi.middleware.base import TurnAction
 from cubepi.providers.base import (
     AssistantMessage,
     TextContent,
@@ -3634,6 +3643,7 @@ from cubepi.providers.base import (
     ToolResultMessage,
     UserMessage,
 )
+from cubepi.providers.faux import FauxProvider
 
 
 def _asst(call_ids, run_id="R"):
@@ -3873,13 +3883,6 @@ async def test_incomplete_tool_cycle_does_not_mark():
     leaves an unresolved tool_call. _dispatch_outcome filters
     state.messages by run_id and demotes 'complete' to 'incomplete'
     via check_tool_cycle. Marker not written."""
-    from cubepi.checkpointer.memory import MemoryCheckpointer
-    from cubepi.middleware.base import TurnAction
-    from cubepi.providers.base import (
-        AssistantMessage, ToolCall,
-    )
-    from cubepi.providers.faux import FauxProvider
-
     p = FauxProvider()
     p.set_responses([
         AssistantMessage(
@@ -3910,15 +3913,6 @@ async def test_tool_cycle_invariant_spans_hitl_resume():
     state.messages by m.run_id == 'R1' — sees the unresolved c1 →
     outcome demoted from 'complete' to 'incomplete' → marker NOT
     written."""
-    import asyncio
-
-    from cubepi.checkpointer.memory import MemoryCheckpointer
-    from cubepi.hitl.ask_user import ask_user_tool
-    from cubepi.hitl.channel import CheckpointedChannel
-    from cubepi.providers.base import (
-        AssistantMessage, TextContent, ToolCall,
-    )
-
     cp = MemoryCheckpointer()
     p = FauxProvider()
     p.set_responses([
@@ -3939,8 +3933,6 @@ async def test_tool_cycle_invariant_spans_hitl_resume():
             stop_reason="tool_use",
         ),
     ])
-
-    from cubepi.middleware.base import TurnAction
 
     async def _stop_after(response, ctx, *, signal=None):
         # Stop after the second assistant turn so the orphan tool_call

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -4039,11 +4039,12 @@ if recovered_run_id is not None:
     self._state.active_run_id = recovered_run_id
 self._state.last_outcome = None
 try:
-    # ... existing respond() body — re-enter the agent loop via
-    # _run_hitl_resume(...) (which receives set_outcome=
-    # self._outcome_sink() from Task 26's plumbing, so the loop's
-    # exit-path catches populate state.last_outcome) ...
-    await self._run_hitl_resume(...)
+    # `_run_hitl_resume(self)` (no args; takes everything from
+    # self._state) re-enters the agent loop. It calls
+    # run_agent_loop_resume(set_outcome=self._outcome_sink(), …)
+    # internally — the loop's exit-path catches populate
+    # self._state.last_outcome.
+    await self._run_hitl_resume()
 except BaseException:
     # Leave active_run_id SET on raise (spec §3.7).
     raise
@@ -4059,28 +4060,108 @@ else:
 Task 23). At terminal clean exit, `_dispatch_outcome` (from Task 26)
 fires `mark_run_complete`.
 
-Add tests asserting:
+Add tests in `tests/agent/test_respond_resume_run_id.py`:
 
 ```python
+import asyncio
+
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.ask_user import ask_user_tool
+from cubepi.hitl.channel import CheckpointedChannel
+from cubepi.providers.base import AssistantMessage, TextContent, ToolCall
+from cubepi.providers.faux import FauxProvider
+
+
+def _pause_then_finish_provider() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses([
+        # Turn 1: ask_user → pause.
+        AssistantMessage(
+            content=[ToolCall(
+                id="tc-1", name="ask_user",
+                arguments={"questions": [{"key": "ans", "prompt": "?"}]},
+            )],
+            stop_reason="tool_use",
+        ),
+        # Turn 2 (resume): final assistant.
+        AssistantMessage(
+            content=[TextContent(text="done")],
+            stop_reason="end_turn",
+        ),
+    ])
+    return p
+
+
+async def _drive_pause(cp, model_factory):
+    """Helper: start a prompt that pauses for ask_user. Returns
+    (agent, task) — caller awaits task after detach/abort/respond."""
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    a = Agent(
+        model=model_factory(),
+        tools=[tool],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch,
+    )
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    while (await cp.load_pending("t")) is None:
+        await asyncio.sleep(0.01)
+    return a, task
+
+
 @pytest.mark.asyncio
 async def test_respond_clears_active_run_id_on_clean_resume():
-    # Mirror tests/hitl/test_agent_respond.py setup: provider script
-    # ask_user → final assistant; CheckpointedChannel; pause; resume
-    # via respond(question_id=qid, answer="yes").
-    ...
-    assert agent.state.active_run_id is None
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+    a, task = await _drive_pause(cp, lambda: p.model("faux-model"))
+    await a.detach()
+    await task
+    # Resume with a fresh Agent on a fresh channel.
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=p.model("faux-model"),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+    pending = await cp.load_pending("t")
+    qid = pending[0].question_id
+    await a2.respond(question_id=qid, answer="yes")
+    assert a2.state.active_run_id is None
 
 
 @pytest.mark.asyncio
 async def test_respond_resume_writes_marker():
     """Cross-reference: Task 26's
     test_hitl_detached_outcome_suspended_no_mark stops at the
-    suspended assertion. This test reaches the resume path and
-    asserts cp._runs[t][R1].completed_at IS NOT None after
-    respond()."""
-    # Same setup as test_hitl_detached_outcome_suspended_no_mark
-    # from Task 26, then continue with respond and assert the marker.
-    ...
+    suspended-state assertion. This test continues to the resume
+    path and asserts cp._runs[t][R1].completed_at IS NOT None
+    after respond()."""
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+    a, task = await _drive_pause(cp, lambda: p.model("faux-model"))
+    await a.detach()
+    await task
+    assert cp._runs["t"]["R1"].completed_at is None  # not yet marked
+
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=p.model("faux-model"),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+    pending = await cp.load_pending("t")
+    qid = pending[0].question_id
+    await a2.respond(question_id=qid, answer="yes")
     assert cp._runs["t"]["R1"].completed_at is not None
 ```
 

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -3243,7 +3243,6 @@ Create `tests/agent/test_agent_completion.py`:
 
 ```python
 import asyncio
-import contextlib
 
 import pytest
 
@@ -4094,10 +4093,49 @@ async def respond(
             # Spec §3.7: leave active_run_id SET on raise.
             raise
         else:
-            outcome = self._state.last_outcome or "abandoned"
-            await self._dispatch_outcome(outcome, recovered_run_id)
-            # Clear on successful resume completion.
+            # Legacy guard: pending rows written by pre-spec code
+            # may carry run_id=None. Skip dispatch entirely — the
+            # caller didn't opt into run tracking for this run.
+            if recovered_run_id is not None:
+                outcome = self._state.last_outcome or "abandoned"
+                await self._dispatch_outcome(outcome, recovered_run_id)
+            # Clear on successful resume completion (legacy or not).
             self._state.active_run_id = None
+```
+
+Add a regression test mirroring the legacy case:
+
+```python
+@pytest.mark.asyncio
+async def test_respond_resume_with_legacy_pending_does_not_crash():
+    """A pre-spec pending row was written without run_id. respond()
+    must resume cleanly: no claim, no mark, no crash."""
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+    a, task = await _drive_pause(cp, lambda: p.model("faux-model"))
+    await a.detach()
+    await task
+    # Forge legacy state: clear the pending row's run_id (simulating
+    # the pre-spec on-disk shape).
+    pending_req = (await cp.load_pending("t"))[0]
+    await cp.save_pending_request("t", pending_req, run_id=None)
+
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id=None)
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=p.model("faux-model"),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+    pending = await cp.load_pending("t")
+    qid = pending[0].question_id
+    # Must not raise.
+    await a2.respond(question_id=qid, answer="yes")
+    # No marker (run_id was None on resume) — but the messages are
+    # persisted and the thread is in a coherent state.
+    assert "R1" not in cp._runs.get("t", {})
 ```
 
 **Do not call `claim_run` here.** All subsequent append calls use

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -55,25 +55,71 @@ Expected: all green (existing tests, no impl changes yet).
 
 ### Fixture conventions for the rest of the plan
 
-These names appear in test snippets throughout the plan. They map to
-existing fixtures in `tests/checkpointer/conftest.py`:
+These names appear in test snippets throughout the plan.
 
-| Plan name | Real fixture | Returns |
+| Plan name | Maps to | Returns |
 |---|---|---|
-| Postgres DB | `clean_db` | DSN string |
-| MySQL DB | `clean_mysql_db` | DSN string |
-| In-memory tracing exporter | (none — see Task 34) | spec adds one |
+| Postgres DSN (raw, empty DB) | `clean_db` (existing) | DSN string |
+| MySQL DSN (raw, empty DB) | `clean_mysql_db` (existing) | DSN string |
+| Postgres DSN with v4 schema | `pg_v4_dsn` (NEW — Task 14) | DSN string |
+| MySQL DSN with v4 schema | `mysql_v4_dsn` (NEW — Task 18) | DSN string |
+| In-memory tracing exporter | `in_memory_exporter` (NEW — Task 34) | OTel exporter |
 | MemoryCheckpointer | (no fixture — instantiate inline `MemoryCheckpointer()`) | — |
+
+**Schema setup matters.** `clean_db` / `clean_mysql_db` create empty
+databases. `PostgresCheckpointer.__aenter__` runs schema-version
+verification and raises `CubepiSchemaUninitialized` against an empty
+DB. Tests that exercise a real checkpointer instance MUST use the
+v4-applied fixtures (`pg_v4_dsn` / `mysql_v4_dsn`), which Tasks 14 and
+18 create by extending the existing `_setup_schema(dsn)` helper at
+`tests/checkpointer/test_postgres.py:177` (PG) and the equivalent
+pattern in `test_mysql.py` (MySQL).
 
 Both SQL checkpointers' constructors take a DSN string (PG signature:
 `PostgresCheckpointer(dsn, *, min_pool_size=1, max_pool_size=10)` at
 `cubepi/checkpointer/postgres/checkpointer.py:62`; MySQL similar).
 Test snippets MUST construct them via `async with
-PostgresCheckpointer(clean_db) as cp:` — NOT by passing a pool object.
+PostgresCheckpointer(pg_v4_dsn) as cp:` — NOT by passing a pool object,
+and NOT by passing raw `clean_db` if exercising the checkpointer.
 
-Task 34 (tracing) is responsible for creating the `in_memory_exporter`
-fixture in `tests/tracing/conftest.py` if it doesn't already exist
-there (verify with `ls tests/tracing/` at task start).
+### FauxProvider construction
+
+`cubepi/providers/faux.py:156` defines:
+```python
+class FauxProvider(BaseProvider):
+    def __init__(self, *, tokens_per_second=None, ..., provider_id=""): ...
+    def set_responses(self, responses: list[AssistantMessage | FauxResponseFactory]): ...
+```
+
+It has **no `text=` / `error=` / `tool_error=` / `abort_mid_stream=` /
+`sleep_seconds=` kwargs**. To produce a single "ok" reply, every test
+file uses this helper:
+
+```python
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_faux() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses([
+        AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")
+    ])
+    return p
+```
+
+Plan snippets that say `_ok_faux()` rely on this local helper —
+define it at the top of each test file (or share via
+`tests/agent/_helpers.py`).
+
+To inject provider-side errors / slow streams, subclass
+`FauxProvider` and override `stream_message`:
+
+```python
+class _RaisingProvider(FauxProvider):
+    async def stream_message(self, *args, **kwargs):
+        raise RuntimeError("provider down")
+```
 
 ---
 
@@ -1812,8 +1858,8 @@ def test_expected_schema_version_is_4():
 
 
 @pytest.mark.asyncio
-async def test_cubepi_runs_table_present(clean_db):
-    async with PostgresCheckpointer(clean_db) as cp:
+async def test_cubepi_runs_table_present(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
         rows = await cp._pool.fetch(
             "SELECT column_name, data_type FROM information_schema.columns "
             "WHERE table_name = 'cubepi_runs' ORDER BY ordinal_position"
@@ -1829,8 +1875,8 @@ async def test_cubepi_runs_table_present(clean_db):
 
 
 @pytest.mark.asyncio
-async def test_cubepi_messages_has_run_id_column(clean_db):
-    async with PostgresCheckpointer(clean_db) as cp:
+async def test_cubepi_messages_has_run_id_column(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
         row = await cp._pool.fetchrow(
             "SELECT data_type FROM information_schema.columns "
             "WHERE table_name = 'cubepi_messages' AND column_name = 'run_id'"
@@ -1894,12 +1940,52 @@ In `cubepi/checkpointer/postgres/alembic_helpers.py`, add a function
 
 Provide a downgrade that drops the table + column.
 
-- [ ] **Step 5: Update `tests/checkpointer/conftest.py` to apply v4**
+- [ ] **Step 5: Extend `_setup_schema` to v4 + add `pg_v4_dsn` fixture**
 
-The existing fixture creates tables via alembic / direct DDL. Wire the
-new v4 migration into the fresh-DB path so tests pick up the new
-schema. (Exact patch: find the schema-setup block and call
-`alembic_helpers.upgrade_v3_to_v4(op)` after v3.)
+In `tests/checkpointer/test_postgres.py`, the existing `_setup_schema`
+helper (`test_postgres.py:177`) builds the v3 schema. Extend it to
+also apply the v4 changes from Task 14:
+- `ALTER TABLE cubepi_messages ADD COLUMN run_id TEXT NULL`
+- `CREATE INDEX ix_cubepi_messages_thread_run ON cubepi_messages (thread_id, run_id)`
+- Create the partitioned `cubepi_runs` table + partitions (mirror
+  `create_message_partitions_op` from `alembic_helpers.py`)
+- Bump `cubepi_schema_version` from 3 to 4
+
+Move `_setup_schema` from `test_postgres.py` into
+`tests/checkpointer/conftest.py` so other test modules can reuse it.
+Add a fixture there:
+```python
+@pytest_asyncio.fixture
+async def pg_v4_dsn(clean_db: str):
+    await _setup_schema(clean_db)
+    yield clean_db
+```
+
+PG tests that exercise a PostgresCheckpointer instance MUST use
+`pg_v4_dsn` instead of raw `clean_db`. Tests that only assert
+information_schema shape can also use `pg_v4_dsn` (the schema is
+already applied; opening the checkpointer is optional).
+
+Update the table-shape tests at the top of Task 14 to use
+`pg_v4_dsn`:
+```python
+async def test_cubepi_runs_table_present(pg_v4_dsn):
+    conn = await asyncpg.connect(pg_v4_dsn)
+    try:
+        rows = await conn.fetch(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'cubepi_runs'"
+        )
+        cols = {r["column_name"] for r in rows}
+        assert {
+            "thread_id", "run_id", "claimed_at",
+            "completed_at", "completion_seq",
+        } <= cols
+    finally:
+        await conn.close()
+```
+
+(No `PostgresCheckpointer` needed here — we're only inspecting schema.)
 
 - [ ] **Step 6: Run tests → expect pass**
 
@@ -1936,13 +2022,13 @@ Postgres-specific tests:
 
 ```python
 @pytest.mark.asyncio
-async def test_append_persists_run_id_into_column(clean_db):
+async def test_append_persists_run_id_into_column(pg_v4_dsn):
     """Regression for plan-review CRITICAL: append() MUST write
     Message.run_id into cubepi_messages.run_id."""
     from cubepi.providers.base import TextContent, UserMessage
     from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
 
-    async with PostgresCheckpointer(clean_db) as cp:
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
         await cp.claim_run("t", "R1")
         msg = UserMessage(content=[TextContent(text="hi")], run_id="R1")
         await cp.append("t", [msg])
@@ -1954,12 +2040,12 @@ async def test_append_persists_run_id_into_column(clean_db):
 
 
 @pytest.mark.asyncio
-async def test_append_rejects_completed_run_id(clean_db):
+async def test_append_rejects_completed_run_id(pg_v4_dsn):
     from cubepi.checkpointer.exceptions import RunAlreadyCompletedError
     from cubepi.providers.base import TextContent, UserMessage
     from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
 
-    async with PostgresCheckpointer(clean_db) as cp:
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
         await cp.claim_run("t", "R1")
         await cp.mark_run_complete("t", "R1")
         msg = UserMessage(content=[TextContent(text="late")], run_id="R1")
@@ -1968,10 +2054,10 @@ async def test_append_rejects_completed_run_id(clean_db):
 
 
 @pytest.mark.asyncio
-async def test_claim_run_creates_threads_row_lazily(clean_db):
+async def test_claim_run_creates_threads_row_lazily(pg_v4_dsn):
     from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
 
-    async with PostgresCheckpointer(clean_db) as cp:
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
         await cp.claim_run("new_thread", "R1")
         row = await cp._pool.fetchrow(
             "SELECT thread_id FROM cubepi_threads WHERE thread_id = $1",
@@ -2168,7 +2254,7 @@ Create `tests/checkpointer/test_postgres_fork.py` covering the same
 scenarios; add one Postgres-specific concurrency test:
 ```python
 @pytest.mark.asyncio
-async def test_fork_blocks_concurrent_appends_on_src(clean_db):
+async def test_fork_blocks_concurrent_appends_on_src(pg_v4_dsn):
     """Two coroutines: fork holds advisory lock; concurrent append
     on src serializes after fork commits. No half-copied messages."""
     # ... use asyncio.gather to interleave; assert ordering ...
@@ -2327,15 +2413,28 @@ MySQL mirrors Postgres with:
 **Files:**
 - Modify: `cubepi/checkpointer/mysql/models.py`
 - Modify: `cubepi/checkpointer/mysql/alembic_helpers.py`
+- Modify: `tests/checkpointer/conftest.py` (add `mysql_v4_dsn` fixture)
 - Test: `tests/checkpointer/test_mysql_schema.py` (new)
 
 Steps parallel Task 14 with MySQL syntax:
 - Bump `EXPECTED_SCHEMA_VERSION = 4`.
-- Add `run_id VARCHAR(255) NULL` to `CubepiMessage`.
-- Add `CubepiRun` model (KEY-partitioned, no FK).
-- Provide v3→v4 alembic helper template.
+- Add `run_id VARCHAR(255) NULL` to `CubepiMessage` + composite index.
+- Add `CubepiRun` model (KEY-partitioned by thread_id, no FK).
+- Extend `_setup_schema(dsn)` in `test_mysql.py` (mirror of the
+  Postgres helper at `test_postgres.py:177`) to apply the v4 DDL.
+  Move it to `conftest.py` and expose a `mysql_v4_dsn` fixture:
+  ```python
+  @pytest_asyncio.fixture
+  async def mysql_v4_dsn(clean_mysql_db: str):
+      await _setup_mysql_schema(clean_mysql_db)
+      yield clean_mysql_db
+  ```
+- Provide v3→v4 alembic helper template (no PARTITION BY in
+  SQLAlchemy declarative; emit raw DDL).
 
-- [ ] Steps 1–7 follow Task 14 pattern. Run `tests/checkpointer/test_mysql_*` for green.
+- [ ] Steps 1–7 follow Task 14 pattern. All test snippets use
+  `mysql_v4_dsn` (not raw `clean_mysql_db`) when constructing a
+  `MySQLCheckpointer`. Run `tests/checkpointer/test_mysql_*` for green.
 
 Commit: `feat(mysql): schema v3→v4 — add run_id column + cubepi_runs table`.
 
@@ -2571,7 +2670,7 @@ from cubepi.providers.faux import FauxProvider
 
 
 def _agent(**kw):
-    return Agent(model=FauxProvider(text="hi").model("faux-model"), **kw)
+    return Agent(model=_ok_faux().model("faux-model"), **kw)
 
 
 @pytest.mark.asyncio
@@ -2598,8 +2697,11 @@ async def test_prompt_sets_then_clears_active_run_id_on_clean_return():
 
 @pytest.mark.asyncio
 async def test_prompt_leaves_active_run_id_set_on_raise():
-    # Use a provider that will raise inside the loop.
-    a = Agent(model=FauxProvider(error="RuntimeError").model("faux-model"))
+    # FauxProvider has no `error=` kwarg — subclass to raise inside the loop.
+    class _RaisingProvider(FauxProvider):
+        async def stream_message(self, *args, **kwargs):
+            raise RuntimeError("provider down")
+    a = Agent(model=_RaisingProvider().model("faux-model"))
     with pytest.raises(Exception):
         await a.prompt("hello", run_id="R1")
     # Spec §3.7: left set so except-block readers can recover it.
@@ -2694,7 +2796,7 @@ async def test_appended_messages_carry_run_id():
 
     cp = MemoryCheckpointer()
     a = Agent(
-        model=FauxProvider(text="hi").model("faux-model"),
+        model=_ok_faux().model("faux-model"),
         checkpointer=cp,
         thread_id="t",
     )
@@ -2702,6 +2804,26 @@ async def test_appended_messages_carry_run_id():
     data = await cp.load("t")
     for m in data.messages:
         assert m.run_id == "R1"
+
+
+@pytest.mark.asyncio
+async def test_appending_message_with_mismatched_run_id_raises():
+    """Caller pre-stamps a Message with a different run_id than the
+    active one. _process_event must reject rather than silently stamp."""
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+    from cubepi.providers.base import TextContent, UserMessage
+
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+    )
+    bad_msg = UserMessage(
+        content=[TextContent(text="hi")], run_id="WRONG"
+    )
+    with pytest.raises(ValueError, match="does not match active run_id"):
+        await a.prompt(bad_msg, run_id="R1")
 ```
 
 - [ ] **Step 2: Run → expect failure**
@@ -2714,14 +2836,23 @@ Expected: `m.run_id` is None.
 In `cubepi/agent/agent.py`, locate `_process_event(self, event)` and
 the `MessageEndEvent` branch. Stamp `run_id` from
 `self._state.active_run_id` onto the message BEFORE it's appended /
-mirrored into state:
+mirrored into state. **Validate any caller-supplied `run_id` matches**
+the active run — silent mismatch would split a run's identity in two
+and corrupt fork selection:
 
 ```python
 elif isinstance(event, MessageEndEvent):
     msg = event.message
-    if self._state.active_run_id is not None and msg.run_id is None:
-        msg = msg.model_copy(update={"run_id": self._state.active_run_id})
-        event = event.model_copy(update={"message": msg})
+    active = self._state.active_run_id
+    if active is not None:
+        if msg.run_id is None:
+            msg = msg.model_copy(update={"run_id": active})
+            event = event.model_copy(update={"message": msg})
+        elif msg.run_id != active:
+            raise ValueError(
+                f"message.run_id={msg.run_id!r} does not match "
+                f"active run_id={active!r}"
+            )
     # ... existing append + state-mirror code, now operating on the
     # stamped `msg` / `event` ...
 ```
@@ -2803,7 +2934,7 @@ def _tool_with_hitl(binding):
 
 def _agent(tools=None, middleware=None):
     return Agent(
-        model=FauxProvider(text="hi").model("faux-model"),
+        model=_ok_faux().model("faux-model"),
         tools=tools or [],
         middleware=middleware or [],
     )
@@ -2924,7 +3055,7 @@ from cubepi.providers.faux import FauxProvider
 
 
 def _agent(**kw):
-    return Agent(model=FauxProvider(text="hi").model("faux-model"), **kw)
+    return Agent(model=_ok_faux().model("faux-model"), **kw)
 
 
 @pytest.mark.asyncio
@@ -3042,6 +3173,28 @@ from cubepi.checkpointer.memory import MemoryCheckpointer
 from cubepi.providers.faux import FauxProvider
 
 
+**FauxProvider API.** `FauxProvider` (`cubepi/providers/faux.py:156`)
+has no `text=` / `error=` / `tool_error=` / `abort_mid_stream=` /
+`sleep_seconds=` kwargs. Its real API: construct empty, then call
+`set_responses([...])` with a list of `AssistantMessage` instances
+(or `FauxResponseFactory` callables). To simulate provider failures
+or sleep behavior, subclass `FauxProvider` inside this test file.
+
+```python
+from cubepi.checkpointer.exceptions import CompletionMarkerFailedError
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_provider() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses([
+        AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")
+    ])
+    return p
+
+
 def _agent(provider, **kw):
     cp = MemoryCheckpointer()
     a = Agent(model=provider.model("faux-model"), checkpointer=cp, thread_id="t", **kw)
@@ -3050,7 +3203,7 @@ def _agent(provider, **kw):
 
 @pytest.mark.asyncio
 async def test_clean_success_marks_complete():
-    a, cp = _agent(FauxProvider(text="ok"))
+    a, cp = _agent(_ok_provider())
     await a.prompt("hi", run_id="R1")
     rs = cp._runs["t"]["R1"]
     assert rs.completed_at is not None
@@ -3058,18 +3211,11 @@ async def test_clean_success_marks_complete():
 
 
 @pytest.mark.asyncio
-async def test_hitl_suspend_does_not_mark():
-    """Provider raises HitlDetached mid-stream → loop catches → no mark."""
-    a, cp = _agent(FauxProvider(error="HitlDetached"))
-    with pytest.raises(Exception):
-        await a.prompt("hi", run_id="R1")
-    rs = cp._runs["t"]["R1"]
-    assert rs.completed_at is None
-
-
-@pytest.mark.asyncio
 async def test_provider_error_does_not_mark():
-    a, cp = _agent(FauxProvider(error="RuntimeError"))
+    class _RaisingProvider(FauxProvider):
+        async def stream_message(self, *args, **kwargs):
+            raise RuntimeError("provider down")
+    a, cp = _agent(_RaisingProvider())
     with pytest.raises(Exception):
         await a.prompt("hi", run_id="R1")
     rs = cp._runs["t"]["R1"]
@@ -3077,49 +3223,62 @@ async def test_provider_error_does_not_mark():
 
 
 @pytest.mark.asyncio
-async def test_tool_exception_does_not_mark():
-    a, cp = _agent(FauxProvider(tool_error="RuntimeError"))
-    with pytest.raises(Exception):
-        await a.prompt("hi", run_id="R1")
-    rs = cp._runs["t"]["R1"]
-    assert rs.completed_at is None
+async def test_hitl_detached_outcome_suspended_no_mark():
+    """HitlDetached raised inside the loop → caught at loop.py:196 →
+    outcome 'suspended', no mark. respond() resume completes."""
+    from cubepi.hitl.testing import ScriptedHitlChannel
+    # Drive HITL via cubepi.hitl.testing.ScriptedHitlChannel which
+    # supports detach + reconnect; assert cp._runs[...].completed_at
+    # IS None after the detach, then after respond() IS NOT None.
+    # ... full setup mirrors tests/hitl/test_detach.py existing
+    # pattern (read that file before writing the test) ...
 
 
 @pytest.mark.asyncio
-async def test_abort_during_streaming_does_not_mark():
-    a, cp = _agent(FauxProvider(text="ok", abort_mid_stream=True))
-    # Caller cancels mid-stream via agent.abort().
-    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
-    await asyncio.sleep(0)  # let the streaming start
-    a.abort()
-    with contextlib.suppress(Exception):
-        await task
-    rs = cp._runs["t"]["R1"]
-    assert rs.completed_at is None
-
-
-@pytest.mark.asyncio
-async def test_abort_pending_does_not_mark():
-    """abort_pending injects synthetic deny + terminal aborted assistant
-    (agent.py:582-595). Outcome is "abandoned", marker not written."""
-    # Setup an agent suspended at HITL, then call abort_pending.
-    # ... use cubepi.hitl.testing scaffolding ...
-    rs = cp._runs["t"]["R1"]
-    assert rs.completed_at is None
+async def test_hitl_aborted_via_abort_pending_does_not_mark():
+    """abort_pending raises HitlAborted in the loop → caught at
+    loop.py:418 → outcome 'abandoned' (NOT 'suspended'). The
+    synthetic deny + terminal aborted assistant are appended by
+    agent.py:582-595 — assert they're present and that
+    cp._runs[...].completed_at is None."""
+    # ... setup pauses on HITL, then awaits agent.abort_pending(reason="x") ...
 
 
 @pytest.mark.asyncio
 async def test_incomplete_tool_cycle_does_not_mark():
     """after_model_response(decision='stop') on a tool-use response
     triggers Task 27's invariant. Outcome 'incomplete', no marker."""
-    # ... see Task 27 fixture; reuse it here ...
+    from cubepi.providers.base import ToolCall
+    from cubepi.agent.types import TurnAction
+
+    p = FauxProvider()
+    p.set_responses([
+        AssistantMessage(
+            content=[ToolCall(id="c1", name="t", arguments={})],
+            stop_reason="tool_use",
+        ),
+    ])
+    async def _stop_after(ctx):
+        return TurnAction(decision="stop")
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=p.model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+        after_model_response=_stop_after,
+    )
+    await a.prompt("hi", run_id="R1")
     rs = cp._runs["t"]["R1"]
     assert rs.completed_at is None
 
 
 @pytest.mark.asyncio
 async def test_propagating_cancel_does_not_mark():
-    a, cp = _agent(FauxProvider(text="ok", sleep_seconds=10))
+    class _SlowProvider(FauxProvider):
+        async def stream_message(self, *args, **kwargs):
+            await asyncio.sleep(10)
+            return  # unreachable
+    a, cp = _agent(_SlowProvider())
     task = asyncio.create_task(a.prompt("hi", run_id="R1"))
     await asyncio.sleep(0.01)
     task.cancel()
@@ -3131,29 +3290,23 @@ async def test_propagating_cancel_does_not_mark():
 
 @pytest.mark.asyncio
 async def test_completion_marker_failed_carries_run_id_when_generated():
-    """When prompt(run_id=None) generates a run_id and mark_run_complete
-    fails, the exception carries the generated run_id and
-    active_run_id is left set."""
+    """prompt(run_id=None) generates; mark_run_complete fails;
+    exception carries the generated run_id; active_run_id is left set."""
     class _BrokenMark(MemoryCheckpointer):
         async def mark_run_complete(self, thread_id, run_id):
             raise RuntimeError("db down")
 
     cp = _BrokenMark()
     a = Agent(
-        model=FauxProvider(text="ok").model("faux-model"),
+        model=_ok_provider().model("faux-model"),
         checkpointer=cp,
         thread_id="t",
     )
     with pytest.raises(CompletionMarkerFailedError) as exc_info:
         await a.prompt("hi")  # run_id=None → generate
-    assert exc_info.value.run_id == a.state.active_run_id
     assert exc_info.value.run_id is not None
+    assert exc_info.value.run_id == a.state.active_run_id
 ```
-
-(`FauxProvider`'s `tool_error` / `abort_mid_stream` / `sleep_seconds`
-keyword args are illustrative — use whatever the test suite's
-FauxProvider already supports; if it doesn't expose the needed knob,
-add a tiny subclass inside this test file.)
 
 (The exact FauxProvider injection API may differ; use whatever mechanism
 the test suite already uses to inject errors / stop_reasons. The
@@ -3174,17 +3327,35 @@ from typing import Literal
 RunOutcome = Literal["complete", "suspended", "incomplete", "abandoned"]
 ```
 
-Modify `cubepi/agent/loop.py`:
-- Change `run_agent_loop`, `_run_loop`, `_run_loop_inner` return type
-  from `None` (or `list[Message]`) to `RunOutcome`. Each existing exit
-  path returns the appropriate literal:
+Modify `cubepi/agent/loop.py`. **The existing public helpers
+`run_agent_loop`, `run_agent_loop_continue`, and `run_agent_loop_resume`
+return `list[Message]` and have callers in `tests/agent/test_loop.py`
+that assert on the list.** To avoid breaking them, change the return
+type to `tuple[list[Message], RunOutcome]` rather than replacing it.
+
+- `run_agent_loop`, `run_agent_loop_continue`, `run_agent_loop_resume`,
+  `_run_loop`, `_run_loop_inner` return
+  `tuple[list[Message], RunOutcome]`. Existing exit paths
+  (currently `return new_messages`) become
+  `return new_messages, <outcome>`. The literals:
   - After clean `AgentEndEvent` with terminal stop_reason and no
-    pending HITL → `return "complete"`
-  - After the `HitlDetached` / `HitlAborted` `except` blocks at
-    `loop.py:196` and `loop.py:418` (which currently `return` silently)
-    → `return "suspended"`
+    pending HITL → `return new_messages, "complete"`
+  - The existing combined `except (HitlDetached, HitlAborted)` blocks
+    at `loop.py:196` and `loop.py:418` must be **split by exception
+    type**:
+    ```python
+    except HitlDetached:
+        return new_messages, "suspended"
+    except HitlAborted:
+        return new_messages, "abandoned"
+    ```
+    `HitlDetached` means "channel detached, the run can still be
+    resumed via respond()" — completion deferred to resume.
+    `HitlAborted` means "abort_pending was called; the synthetic deny
+    and terminal aborted assistant have already been appended by
+    `agent.py:582-595`" — terminal abandonment, no marker.
   - After the early-exit branch on `stop_reason in ("error", "aborted")`
-    at `loop.py:485` → `return "abandoned"`
+    at `loop.py:485` → `return new_messages, "abandoned"`
   - When `check_tool_cycle(...)` (from Task 27) raises
     `ToolCycleViolation` immediately before declaring `complete`,
     catch it and `return "incomplete"` instead
@@ -3194,20 +3365,26 @@ Modify `cubepi/agent/loop.py`:
   must also forward the outcome.
 
 Modify `cubepi/agent/agent.py`:
-- `_run_prompt` and `_run_hitl_resume` return `RunOutcome`.
+- `_run_prompt` and `_run_hitl_resume` return
+  `tuple[list[Message], RunOutcome]`.
 - In `Agent.prompt()` (replacing the placeholder line `await
   self._run_prompt(...)`):
   ```python
-  outcome: RunOutcome = await self._run_prompt(
+  _new_messages, outcome = await self._run_prompt(
       message, run_id=effective_run_id
   )
   await self._dispatch_outcome(outcome, effective_run_id)
   ```
 - In `Agent.respond()`:
   ```python
-  outcome: RunOutcome = await self._run_hitl_resume(...)
+  _new_messages, outcome = await self._run_hitl_resume(...)
   await self._dispatch_outcome(outcome, recovered_run_id)
   ```
+
+**Update `tests/agent/test_loop.py`** to expect tuples. Existing
+assertions of the form `result = await run_agent_loop(...)` become
+`messages, _outcome = await run_agent_loop(...)`. Mention this
+explicitly in the task body so the implementer doesn't skip it.
 - New private helper `_dispatch_outcome`:
   ```python
   async def _dispatch_outcome(
@@ -3354,12 +3531,19 @@ def test_duplicate_ids_across_turns_violation():
     assert False
 
 
-def test_extra_results_with_same_id_violation():
-    """Multiset check: assistant emits one c1; window has two
-    tool_results both with c1. Set-equality would pass; multiset
-    correctly rejects."""
+def test_multiset_mismatch_within_window_violation():
+    """Assistant emits {c1, c2}; window has [c1, c1] — set-equality
+    would have failed, but the bug is multiset-specific: window length
+    matches K=2, and only the multiset check catches that c2 is missing
+    while c1 is duplicated. (A trailing extra tool_result AFTER the
+    K-window is a separate concern handled by the NEXT assistant turn's
+    adjacency check; it's not what this test covers.)"""
     try:
-        check_tool_cycle([_asst(["c1"]), _res("c1"), _res("c1")])
+        check_tool_cycle([
+            _asst(["c1", "c2"]),
+            _res("c1"),
+            _res("c1"),  # duplicate of c1; c2 missing
+        ])
     except ToolCycleViolation:
         return
     assert False
@@ -3498,7 +3682,11 @@ Expected: `respond()` either reclaims or doesn't propagate run_id.
 
 - [ ] **Step 3: Modify `Agent.respond()`**
 
-At the start of `respond()`:
+At the start of `respond()` (after the existing locking / state
+guards), recover the run_id from pending state and apply the same
+lifecycle pattern as `prompt()` — set on entry, clear on clean return,
+leave set on raise:
+
 ```python
 pending = await self.checkpointer.load_pending(self.thread_id)
 if pending is None:
@@ -3506,11 +3694,32 @@ if pending is None:
 _req, recovered_run_id = pending
 if recovered_run_id is not None:
     self._state.active_run_id = recovered_run_id
+try:
+    # ... existing respond() body, which will:
+    # - re-enter the agent loop
+    # - eventually call _dispatch_outcome (Task 26) which writes the
+    #   marker on outcome == "complete"
+    ...
+except BaseException:
+    # Leave active_run_id SET on raise (spec §3.7).
+    raise
+else:
+    # Clear on successful resume completion.
+    self._state.active_run_id = None
 ```
 
-Then continue the existing flow. **Do not call `claim_run` here.** All
-subsequent append calls use `self._state.active_run_id`. At terminal
-clean exit, the same `mark_run_complete` block from Task 26 fires.
+**Do not call `claim_run` here.** All subsequent append calls use
+`self._state.active_run_id` (the same chokepoint as prompt — see
+Task 23). At terminal clean exit, `_dispatch_outcome` from Task 26
+fires `mark_run_complete`.
+
+Add a test asserting:
+```python
+@pytest.mark.asyncio
+async def test_respond_clears_active_run_id_on_clean_resume():
+    # ... drive a HITL pause then resume to clean completion ...
+    assert agent.state.active_run_id is None
+```
 
 - [ ] **Step 4: Run tests → expect pass**
 
@@ -3548,7 +3757,7 @@ from cubepi.providers.faux import FauxProvider
 async def test_agent_fork_delegates_to_checkpointer():
     cp = MemoryCheckpointer()
     a = Agent(
-        model=FauxProvider(text="hi").model("faux-model"),
+        model=_ok_faux().model("faux-model"),
         checkpointer=cp,
         thread_id="src",
     )
@@ -3560,7 +3769,7 @@ async def test_agent_fork_delegates_to_checkpointer():
 
 @pytest.mark.asyncio
 async def test_agent_fork_no_checkpointer_raises():
-    a = Agent(model=FauxProvider(text="hi").model("faux-model"))
+    a = Agent(model=_ok_faux().model("faux-model"))
     with pytest.raises(RuntimeError, match="checkpointer"):
         await a.fork("src", "dst", after_run_id="R1")
 
@@ -3569,7 +3778,7 @@ async def test_agent_fork_no_checkpointer_raises():
 async def test_agent_fork_does_not_mutate_self_thread_id():
     cp = MemoryCheckpointer()
     a = Agent(
-        model=FauxProvider(text="hi").model("faux-model"),
+        model=_ok_faux().model("faux-model"),
         checkpointer=cp,
         thread_id="src",
     )
@@ -3663,6 +3872,9 @@ Create `tests/agent/test_agent_fork_once.py` testing:
 - Simple text-only follow-up returns expected final text; source thread
   unchanged
 - `RuntimeError` when no checkpointer
+- `CheckpointerError` when checkpointer is a v3-only stub lacking
+  `snapshot` / `claim_run` / `mark_run_complete` (degraded-mode test
+  mirroring Task 25's coverage but for fork_once)
 - `RuntimeError` when any `tool.hitl is not None` (checkpointed OR
   in-memory)
 - `RuntimeError` when middleware has `hitl is not None`
@@ -3687,6 +3899,13 @@ async def fork_once(
 ) -> ForkOnceResult:
     if self.checkpointer is None:
         raise RuntimeError("fork_once requires a checkpointer")
+    # Degraded-mode guard — same shape as Agent.fork (Task 29).
+    if not self._run_aware or not hasattr(self.checkpointer, "snapshot"):
+        from cubepi.checkpointer.exceptions import CheckpointerError
+        raise CheckpointerError(
+            "backend does not support fork_once; missing snapshot / "
+            "claim_run / mark_run_complete"
+        )
     # HITL pre-flight. Real attributes: self._state.tools, self._middleware.
     hitl_offenders = [
         elem for elem in (*self._state.tools, *self._middleware)
@@ -3910,7 +4129,7 @@ from cubepi.providers.faux import FauxProvider
 async def test_fork_once_emits_named_span(in_memory_exporter):
     cp = MemoryCheckpointer()
     a = Agent(
-        model=FauxProvider(text="hi").model("faux-model"),
+        model=_ok_faux().model("faux-model"),
         checkpointer=cp,
         thread_id="src",
     )
@@ -4063,10 +4282,8 @@ BACKENDS = ["memory", "sqlite", "postgres", "mysql"]
 
 
 @pytest.fixture(params=BACKENDS)
-async def checkpointer(request, tmp_path, clean_db, clean_mysql_db):
-    # Build the appropriate checkpointer per param. clean_db /
-    # clean_mysql_db are DSN strings; PG and MySQL constructors open
-    # their own pools on __aenter__.
+async def checkpointer(request, tmp_path, pg_v4_dsn, mysql_v4_dsn):
+    # Use v4-applied DSN fixtures; constructors open their own pools.
     if request.param == "memory":
         from cubepi.checkpointer.memory import MemoryCheckpointer
         yield MemoryCheckpointer()
@@ -4076,11 +4293,11 @@ async def checkpointer(request, tmp_path, clean_db, clean_mysql_db):
             yield cp
     elif request.param == "postgres":
         from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
-        async with PostgresCheckpointer(clean_db) as cp:
+        async with PostgresCheckpointer(pg_v4_dsn) as cp:
             yield cp
     elif request.param == "mysql":
         from cubepi.checkpointer.mysql.checkpointer import MySQLCheckpointer
-        async with MySQLCheckpointer(clean_mysql_db) as cp:
+        async with MySQLCheckpointer(mysql_v4_dsn) as cp:
             yield cp
 
 
@@ -4088,7 +4305,7 @@ async def checkpointer(request, tmp_path, clean_db, clean_mysql_db):
 async def test_fork_e2e_happy_path(checkpointer):
     cp = checkpointer
     a = Agent(
-        model=FauxProvider(text="ok").model("faux-model"),
+        model=_ok_faux().model("faux-model"),
         checkpointer=cp,
         thread_id="src",
     )

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -53,6 +53,28 @@ uv run pytest tests/ -x -q
 ```
 Expected: all green (existing tests, no impl changes yet).
 
+### Fixture conventions for the rest of the plan
+
+These names appear in test snippets throughout the plan. They map to
+existing fixtures in `tests/checkpointer/conftest.py`:
+
+| Plan name | Real fixture | Returns |
+|---|---|---|
+| Postgres DB | `clean_db` | DSN string |
+| MySQL DB | `clean_mysql_db` | DSN string |
+| In-memory tracing exporter | (none — see Task 34) | spec adds one |
+| MemoryCheckpointer | (no fixture — instantiate inline `MemoryCheckpointer()`) | — |
+
+Both SQL checkpointers' constructors take a DSN string (PG signature:
+`PostgresCheckpointer(dsn, *, min_pool_size=1, max_pool_size=10)` at
+`cubepi/checkpointer/postgres/checkpointer.py:62`; MySQL similar).
+Test snippets MUST construct them via `async with
+PostgresCheckpointer(clean_db) as cp:` — NOT by passing a pool object.
+
+Task 34 (tracing) is responsible for creating the `in_memory_exporter`
+fixture in `tests/tracing/conftest.py` if it doesn't already exist
+there (verify with `ls tests/tracing/` at task start).
+
 ---
 
 ## Phase 1 — Foundation types
@@ -1790,9 +1812,9 @@ def test_expected_schema_version_is_4():
 
 
 @pytest.mark.asyncio
-async def test_cubepi_runs_table_present(pg_pool):
-    async with pg_pool.acquire() as conn:
-        rows = await conn.fetch(
+async def test_cubepi_runs_table_present(clean_db):
+    async with PostgresCheckpointer(clean_db) as cp:
+        rows = await cp._pool.fetch(
             "SELECT column_name, data_type FROM information_schema.columns "
             "WHERE table_name = 'cubepi_runs' ORDER BY ordinal_position"
         )
@@ -1807,17 +1829,17 @@ async def test_cubepi_runs_table_present(pg_pool):
 
 
 @pytest.mark.asyncio
-async def test_cubepi_messages_has_run_id_column(pg_pool):
-    async with pg_pool.acquire() as conn:
-        row = await conn.fetchrow(
+async def test_cubepi_messages_has_run_id_column(clean_db):
+    async with PostgresCheckpointer(clean_db) as cp:
+        row = await cp._pool.fetchrow(
             "SELECT data_type FROM information_schema.columns "
             "WHERE table_name = 'cubepi_messages' AND column_name = 'run_id'"
         )
         assert row is not None
 ```
 
-(The `pg_pool` fixture is the existing one in
-`tests/checkpointer/conftest.py`.)
+(`clean_db` fixture from `tests/checkpointer/conftest.py` yields a DSN
+string; `PostgresCheckpointer(dsn)` opens its own pool on `__aenter__`.)
 
 - [ ] **Step 2: Run → expect failure**
 
@@ -1893,26 +1915,65 @@ git commit -m "feat(postgres): schema v3→v4 — add run_id column + cubepi_run
 
 ---
 
-### Task 15: Postgres — `claim_run` (with lazy threads-row create)
+### Task 15: Postgres — `claim_run` + persist `Message.run_id` in `append()`
 
 **Files:**
 - Modify: `cubepi/checkpointer/postgres/checkpointer.py`
 - Test: `tests/checkpointer/test_postgres_runs.py` (new)
 
-- [ ] **Step 1: Failing tests (mirror SQLite run tests)**
+**CRITICAL:** Task 14 added the `run_id` column to `cubepi_messages`,
+but the existing `PostgresCheckpointer.append()` SQL
+(`postgres/checkpointer.py:201`) writes only `(thread_id, seq, role,
+metadata, payload)` — it must be extended to write `run_id` too, or
+fork's set-based selection will treat every new message as legacy
+(`run_id IS NULL`).
+
+- [ ] **Step 1: Failing tests (mirror SQLite run tests) + run_id persistence**
 
 Create `tests/checkpointer/test_postgres_runs.py` with the same
-scenarios as `tests/checkpointer/test_sqlite_runs.py`, plus one extra:
+scenarios as `tests/checkpointer/test_sqlite_runs.py`, plus these
+Postgres-specific tests:
 
 ```python
 @pytest.mark.asyncio
-async def test_claim_run_creates_threads_row_lazily(pg_pool):
+async def test_append_persists_run_id_into_column(clean_db):
+    """Regression for plan-review CRITICAL: append() MUST write
+    Message.run_id into cubepi_messages.run_id."""
+    from cubepi.providers.base import TextContent, UserMessage
     from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
 
-    async with PostgresCheckpointer(pg_pool) as cp:
+    async with PostgresCheckpointer(clean_db) as cp:
+        await cp.claim_run("t", "R1")
+        msg = UserMessage(content=[TextContent(text="hi")], run_id="R1")
+        await cp.append("t", [msg])
+        row = await cp._pool.fetchrow(
+            "SELECT run_id FROM cubepi_messages WHERE thread_id = $1",
+            "t",
+        )
+        assert row["run_id"] == "R1"
+
+
+@pytest.mark.asyncio
+async def test_append_rejects_completed_run_id(clean_db):
+    from cubepi.checkpointer.exceptions import RunAlreadyCompletedError
+    from cubepi.providers.base import TextContent, UserMessage
+    from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
+
+    async with PostgresCheckpointer(clean_db) as cp:
+        await cp.claim_run("t", "R1")
+        await cp.mark_run_complete("t", "R1")
+        msg = UserMessage(content=[TextContent(text="late")], run_id="R1")
+        with pytest.raises(RunAlreadyCompletedError):
+            await cp.append("t", [msg])
+
+
+@pytest.mark.asyncio
+async def test_claim_run_creates_threads_row_lazily(clean_db):
+    from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
+
+    async with PostgresCheckpointer(clean_db) as cp:
         await cp.claim_run("new_thread", "R1")
-    async with pg_pool.acquire() as conn:
-        row = await conn.fetchrow(
+        row = await cp._pool.fetchrow(
             "SELECT thread_id FROM cubepi_threads WHERE thread_id = $1",
             "new_thread",
         )
@@ -1924,7 +1985,45 @@ async def test_claim_run_creates_threads_row_lazily(pg_pool):
 Run: `uv run pytest tests/checkpointer/test_postgres_runs.py -v`
 Expected: method missing.
 
-- [ ] **Step 3: Implement `claim_run` with lazy threads create**
+- [ ] **Step 3a: Update `append()` to write `run_id` and reject completed run_ids**
+
+In `cubepi/checkpointer/postgres/checkpointer.py:201` (the existing
+`INSERT INTO cubepi_messages` statement inside `append()`), extend the
+column list and parameter tuple:
+
+```python
+# Before any insert, defend against append-on-completed.
+run_ids = {m.run_id for m in messages if m.run_id is not None}
+if run_ids:
+    completed = await conn.fetch(
+        "SELECT run_id FROM cubepi_runs WHERE thread_id = $1 "
+        "AND run_id = ANY($2::text[]) AND completed_at IS NOT NULL",
+        thread_id, list(run_ids),
+    )
+    if completed:
+        bad = ", ".join(r["run_id"] for r in completed)
+        raise RunAlreadyCompletedError(
+            f"append on completed run thread={thread_id} runs={bad}"
+        )
+
+for i, msg in enumerate(messages):
+    seq = last_seq + i + 1
+    await conn.execute(
+        "INSERT INTO cubepi_messages "
+        "(thread_id, seq, role, run_id, metadata, payload) "
+        "VALUES ($1, $2, $3, $4, $5, $6)",
+        thread_id, seq, _role_of(msg),
+        getattr(msg, "run_id", None),
+        json.dumps(msg.metadata),
+        msgpack.packb(msg.model_dump(), use_bin_type=True),
+    )
+```
+
+Both `tests/checkpointer/test_postgres_runs.py::
+test_append_persists_run_id_into_column` and
+`::test_append_rejects_completed_run_id` exercise this.
+
+- [ ] **Step 3b: Implement `claim_run` with lazy threads create**
 
 Add to `PostgresCheckpointer`:
 ```python
@@ -2069,7 +2168,7 @@ Create `tests/checkpointer/test_postgres_fork.py` covering the same
 scenarios; add one Postgres-specific concurrency test:
 ```python
 @pytest.mark.asyncio
-async def test_fork_blocks_concurrent_appends_on_src(pg_pool):
+async def test_fork_blocks_concurrent_appends_on_src(clean_db):
     """Two coroutines: fork holds advisory lock; concurrent append
     on src serializes after fork commits. No half-copied messages."""
     # ... use asyncio.gather to interleave; assert ordering ...
@@ -2087,6 +2186,14 @@ async def snapshot(
     self, thread_id: str, *, after_run_id: str
 ) -> list[Message]:
     async with self._pool.acquire() as conn:
+        # Spec §3.10: ThreadNotFoundError takes precedence over
+        # RunNotCompletedError. Validate the source thread first.
+        thread_exists = await conn.fetchval(
+            "SELECT 1 FROM cubepi_threads WHERE thread_id = $1",
+            thread_id,
+        )
+        if not thread_exists:
+            raise ThreadNotFoundError(f"thread={thread_id}")
         cutoff = await conn.fetchval(
             "SELECT completion_seq FROM cubepi_runs "
             "WHERE thread_id = $1 AND run_id = $2",
@@ -2106,7 +2213,15 @@ async def snapshot(
             ") ORDER BY seq",
             thread_id, cutoff,
         )
-        return [self._row_to_message(r) for r in rows]
+        # Decode using the existing pattern from load() in this file
+        # (msgpack unpack + role-to-class). Inline here rather than
+        # invent a `_row_to_message` helper that doesn't exist.
+        result: list[Message] = []
+        for r in rows:
+            cls = _ROLE_TO_CLS[r["role"]]
+            data = msgpack.unpackb(r["payload"], raw=False)
+            result.append(cls.model_validate(data))
+        return result
 
 async def fork(
     self,
@@ -2120,6 +2235,13 @@ async def fork(
         await conn.execute(
             "SELECT pg_advisory_xact_lock(hashtext($1))", src_thread_id
         )
+        # Source existence FIRST (spec §3.10 error precedence).
+        src_extra = await conn.fetchval(
+            "SELECT extra FROM cubepi_threads WHERE thread_id = $1",
+            src_thread_id,
+        )
+        if src_extra is None:
+            raise ThreadNotFoundError(f"thread={src_thread_id}")
         # Cutoff + RunNotCompletedError.
         cutoff = await conn.fetchval(
             "SELECT completion_seq FROM cubepi_runs "
@@ -2130,13 +2252,6 @@ async def fork(
             raise RunNotCompletedError(
                 f"thread={src_thread_id} run={after_run_id} not completed"
             )
-        # Source extra (deep copy + merge metadata).
-        src_extra = await conn.fetchval(
-            "SELECT extra FROM cubepi_threads WHERE thread_id = $1",
-            src_thread_id,
-        )
-        if src_extra is None:
-            raise ThreadNotFoundError(f"thread={src_thread_id}")
         merged = json.loads(json.dumps(src_extra))
         if metadata is not None:
             merged["fork"] = json.loads(json.dumps(metadata))
@@ -2226,11 +2341,19 @@ Commit: `feat(mysql): schema v3→v4 — add run_id column + cubepi_runs table`.
 
 ---
 
-### Task 19: MySQL — `claim_run`, `mark_run_complete`, `load_pending`
+### Task 19: MySQL — `claim_run`, `mark_run_complete`, `load_pending` + persist `Message.run_id`
 
 **Files:**
 - Modify: `cubepi/checkpointer/mysql/checkpointer.py`
 - Test: `tests/checkpointer/test_mysql_runs.py` (new)
+
+**CRITICAL — same as Task 15:** Existing
+`MySQLCheckpointer.append()` SQL at
+`mysql/checkpointer.py:241` writes `(thread_id, seq, role, metadata,
+payload)` without `run_id`. Extend it. Add corresponding test
+asserting `cubepi_messages.run_id` is populated, mirroring the
+Postgres Task 15 Step 1 tests (`test_append_persists_run_id_into_column`,
+`test_append_rejects_completed_run_id`).
 
 Mirror Tasks 15–16 with MySQL syntax. Key differences:
 
@@ -2381,12 +2504,18 @@ def test_messages_kw_deep_copies_all_three_variants():
 Run: `uv run pytest tests/agent/test_agent_messages_kw.py -v`
 Expected: `TypeError: __init__() got an unexpected keyword argument 'messages'`.
 
-- [ ] **Step 3: Add the constructor arg**
+- [ ] **Step 3: Add the constructor arg + retain the model reference**
 
 In `cubepi/agent/agent.py`, locate `Agent.__init__`. Add the keyword-only
-parameter `messages: Sequence[Message] | None = None` at the end. Inside:
+parameter `messages: Sequence[Message] | None = None` at the end. Inside,
+add the messages-handling block AND a one-line retention of the original
+`model` argument (needed by `fork_once()` in Task 31):
 
 ```python
+# Retain the original `model` argument so fork_once() can construct
+# a transient Agent reusing the same model.
+self._model = model
+
 if messages is not None:
     if thread_id is not None and checkpointer is not None:
         raise ValueError(
@@ -2396,11 +2525,18 @@ if messages is not None:
             "fork_once-style usage."
         )
     seeded = [m.model_copy(deep=True) for m in messages]
-    self._state._messages = list(seeded)
+    # AgentState exposes `messages` as a property — use the public
+    # setter (which delegates to `_messages`); don't poke `_messages`
+    # directly. The setter is at agent.py:117 today.
+    self._state.messages = list(seeded)
 ```
 
 (Make sure to import `Sequence` from `collections.abc` if not already
 imported, and `Message` from `cubepi.providers.base` likewise.)
+
+**Note:** the spec §3.7a forbids touching private attributes from
+fork_once. Going through the public `messages` setter on AgentState is
+the supported path; do not reach into `_messages` directly.
 
 - [ ] **Step 4: Run tests → expect pass**
 
@@ -2453,11 +2589,21 @@ async def test_prompt_generates_run_id_when_none():
 
 
 @pytest.mark.asyncio
-async def test_prompt_sets_then_clears_active_run_id():
+async def test_prompt_sets_then_clears_active_run_id_on_clean_return():
     a = _agent()
     assert a.state.active_run_id is None
-    got = await a.prompt("hello", run_id="R1")
+    await a.prompt("hello", run_id="R1")
     assert a.state.active_run_id is None  # cleared on clean return
+
+
+@pytest.mark.asyncio
+async def test_prompt_leaves_active_run_id_set_on_raise():
+    # Use a provider that will raise inside the loop.
+    a = Agent(model=FauxProvider(error="RuntimeError").model("faux-model"))
+    with pytest.raises(Exception):
+        await a.prompt("hello", run_id="R1")
+    # Spec §3.7: left set so except-block readers can recover it.
+    assert a.state.active_run_id == "R1"
 ```
 
 - [ ] **Step 2: Run → expect failure**
@@ -2481,18 +2627,28 @@ async def prompt(
     self._state.active_run_id = effective_run_id
     try:
         async with self._run_lock:
-            # ... existing body using `effective_run_id` for stamping ...
+            # ... existing body, with run_id threaded through ...
             await self._run_prompt(message, run_id=effective_run_id)
-        return effective_run_id
-    finally:
+    except BaseException:
+        # Spec §3.7: leave active_run_id SET on failure so except-block
+        # readers can recover it. CompletionMarkerFailedError.run_id is
+        # still the recommended source in handlers (see Task 26).
+        raise
+    else:
         self._state.active_run_id = None
+        return effective_run_id
 ```
 
 (Note: the actual edit shape depends on the existing prompt() body —
 preserve everything that's there; only thread the run_id through and
-add the active_run_id set/clear in a `try/finally`. Internal helpers
-that perform `append()` will pass run_id into the Message construction
-in subsequent tasks.)
+add the active_run_id set + try/except/else clear pattern. Internal
+helpers that perform `append()` will pass run_id into the Message
+construction in subsequent tasks.)
+
+**Per spec §3.7 — do NOT clear `active_run_id` in `finally`.** Clearing
+in `finally` would wipe the value before `except` handlers can read
+it, defeating the recovery contract for `CompletionMarkerFailedError`
+and any other post-claim failure mode.
 
 Also import `uuid` at the top of the file.
 
@@ -2512,12 +2668,21 @@ git commit -m "feat(agent): prompt accepts run_id, returns it, exposes via activ
 
 ---
 
-### Task 23: Stamp `run_id` on every appended Message
+### Task 23: Stamp `run_id` on every appended Message via `Agent._process_event`
 
 **Files:**
-- Modify: `cubepi/agent/loop.py`
-- Modify: `cubepi/agent/agent.py` (helper signatures)
+- Modify: `cubepi/agent/agent.py` (central stamping point)
 - Test: extend `tests/agent/test_agent_run_id.py`
+
+**Why `_process_event` is the right location.** `cubepi/agent/loop.py`
+does NOT directly construct most of the Message objects that get
+persisted — the loop emits events, and `Agent._process_event`
+(`cubepi/agent/agent.py:~329`) is the single dispatch site where
+`MessageEndEvent` triggers the actual `checkpointer.append([msg])`
+call. The same `_process_event` is also called by `abort_pending()`
+when it injects synthetic deny + terminal aborted messages, and by
+`respond()` resume path. Stamping at this single chokepoint covers
+every append.
 
 - [ ] **Step 1: Failing test asserts persisted messages carry the run_id**
 
@@ -2544,20 +2709,45 @@ async def test_appended_messages_carry_run_id():
 Run: `uv run pytest tests/agent/test_agent_run_id.py::test_appended_messages_carry_run_id -v`
 Expected: `m.run_id` is None.
 
-- [ ] **Step 3: Thread run_id through the loop**
+- [ ] **Step 3: Stamp in `Agent._process_event` (single chokepoint)**
 
-In `cubepi/agent/loop.py`, locate every Message construction (`UserMessage(...)`, `AssistantMessage(...)`, `ToolResultMessage(...)`). For each one that represents a message produced THIS run, set `run_id=ctx.active_run_id` (or whatever the active variable is in that scope). The agent loop needs to plumb the active run_id from `Agent.prompt()` down to the inner loop. The cleanest way:
+In `cubepi/agent/agent.py`, locate `_process_event(self, event)` and
+the `MessageEndEvent` branch. Stamp `run_id` from
+`self._state.active_run_id` onto the message BEFORE it's appended /
+mirrored into state:
 
-- Add a `run_id: str` parameter to `_run_loop` / `_run_loop_inner` (and any helper that constructs Messages).
-- In `Agent.prompt()`, pass `effective_run_id` through to `_run_prompt`.
+```python
+elif isinstance(event, MessageEndEvent):
+    msg = event.message
+    if self._state.active_run_id is not None and msg.run_id is None:
+        msg = msg.model_copy(update={"run_id": self._state.active_run_id})
+        event = event.model_copy(update={"message": msg})
+    # ... existing append + state-mirror code, now operating on the
+    # stamped `msg` / `event` ...
+```
 
-Update every `UserMessage(...)`, `AssistantMessage(...)`,
-`ToolResultMessage(...)` construction site in `loop.py` to pass
-`run_id=run_id`.
+This is the single dispatch site every appended message flows through
+(loop streaming, abort_pending's synthetic deny + terminal aborted at
+`agent.py:582-595`, respond resume). One edit covers all paths.
 
-Also update `Agent.respond()` and `Agent.abort_pending()` paths that
-construct synthetic messages — those should also stamp the recovered
-run_id.
+Also stamp the input message constructed from a `str` argument inside
+`Agent.prompt()` before passing to `_run_prompt` (locate the
+`UserMessage(content=[TextContent(text=message)])` construction):
+
+```python
+if isinstance(message, str):
+    message = UserMessage(
+        content=[TextContent(text=message)],
+        run_id=effective_run_id,
+    )
+```
+
+If `message` is already a `Message` / `list[Message]`, leave caller's
+value alone — `_process_event` will stamp at append time as a
+backstop.
+
+Loop.py and tools.py: NO changes required for this task — they emit
+events that flow through `_process_event` and inherit the stamping.
 
 - [ ] **Step 4: Run tests → expect pass**
 
@@ -2666,10 +2856,14 @@ Expected: ValueError not raised.
 
 - [ ] **Step 3: Add the enforcement to `Agent.prompt()` start**
 
+The real `Agent` attribute names are `self._state.tools` (a public
+property over `_tools`) and `self._middleware` (raw list saved at
+`agent.py:169`). Use those, not `self.tools` / `self.middleware`.
+
 Just before the `try:` block that sets `active_run_id`, add:
 ```python
 bound: set[str] = set()
-for elem in (*self.tools, *self.middleware):
+for elem in (*self._state.tools, *self._middleware):
     binding = getattr(elem, "hitl", None)
     if binding is None or not binding.checkpointed:
         continue
@@ -2823,9 +3017,19 @@ git commit -m "feat(agent): claim_run pre-flight + legacy degraded-mode fallback
 ### Task 26: `mark_run_complete` after terminal success + outcome enumeration
 
 **Files:**
-- Modify: `cubepi/agent/loop.py`
-- Modify: `cubepi/agent/agent.py`
+- Create: `cubepi/agent/_outcome.py` (the `RunOutcome` literal + helpers)
+- Modify: `cubepi/agent/loop.py` — `run_agent_loop`, `_run_loop`,
+  `_run_loop_inner` to RETURN a `RunOutcome` instead of `None`
+- Modify: `cubepi/agent/agent.py` — `_run_prompt` and `_run_hitl_resume`
+  to propagate the outcome; `prompt()` and `respond()` dispatch on it
 - Test: `tests/agent/test_agent_completion.py` (new)
+
+**Why this is a deliberate refactor, not a drop-in change.** The current
+`run_agent_loop`, `_run_loop`, and `_run_loop_inner` return `None` (or
+a `list[Message]`). The loop catches `HitlDetached` / `HitlAborted`
+silently (`loop.py:196` and `loop.py:418`) and returns normally. There
+is no first-class "what happened" return value today. This task
+introduces one.
 
 - [ ] **Step 1: Failing tests covering every row of spec §3.6.2 table**
 
@@ -2872,8 +3076,84 @@ async def test_provider_error_does_not_mark():
     assert rs.completed_at is None
 
 
-# Add similar tests for abort, cancellation, etc., per spec table.
+@pytest.mark.asyncio
+async def test_tool_exception_does_not_mark():
+    a, cp = _agent(FauxProvider(tool_error="RuntimeError"))
+    with pytest.raises(Exception):
+        await a.prompt("hi", run_id="R1")
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_abort_during_streaming_does_not_mark():
+    a, cp = _agent(FauxProvider(text="ok", abort_mid_stream=True))
+    # Caller cancels mid-stream via agent.abort().
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    await asyncio.sleep(0)  # let the streaming start
+    a.abort()
+    with contextlib.suppress(Exception):
+        await task
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_abort_pending_does_not_mark():
+    """abort_pending injects synthetic deny + terminal aborted assistant
+    (agent.py:582-595). Outcome is "abandoned", marker not written."""
+    # Setup an agent suspended at HITL, then call abort_pending.
+    # ... use cubepi.hitl.testing scaffolding ...
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_incomplete_tool_cycle_does_not_mark():
+    """after_model_response(decision='stop') on a tool-use response
+    triggers Task 27's invariant. Outcome 'incomplete', no marker."""
+    # ... see Task 27 fixture; reuse it here ...
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_propagating_cancel_does_not_mark():
+    a, cp = _agent(FauxProvider(text="ok", sleep_seconds=10))
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    rs = cp._runs["t"]["R1"]
+    assert rs.completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_completion_marker_failed_carries_run_id_when_generated():
+    """When prompt(run_id=None) generates a run_id and mark_run_complete
+    fails, the exception carries the generated run_id and
+    active_run_id is left set."""
+    class _BrokenMark(MemoryCheckpointer):
+        async def mark_run_complete(self, thread_id, run_id):
+            raise RuntimeError("db down")
+
+    cp = _BrokenMark()
+    a = Agent(
+        model=FauxProvider(text="ok").model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+    )
+    with pytest.raises(CompletionMarkerFailedError) as exc_info:
+        await a.prompt("hi")  # run_id=None → generate
+    assert exc_info.value.run_id == a.state.active_run_id
+    assert exc_info.value.run_id is not None
 ```
+
+(`FauxProvider`'s `tool_error` / `abort_mid_stream` / `sleep_seconds`
+keyword args are illustrative — use whatever the test suite's
+FauxProvider already supports; if it doesn't expose the needed knob,
+add a tiny subclass inside this test file.)
 
 (The exact FauxProvider injection API may differ; use whatever mechanism
 the test suite already uses to inject errors / stop_reasons. The
@@ -2884,36 +3164,83 @@ assertion shape — "mark called" vs "mark not called" — is what matters.)
 Run: `uv run pytest tests/agent/test_agent_completion.py -v`
 Expected: mark not called even on clean success.
 
-- [ ] **Step 3: Call `mark_run_complete` only on terminal clean exit**
+- [ ] **Step 3: Introduce `RunOutcome` and propagate it**
 
-In `Agent.prompt()` (or wherever the loop returns cleanly), add:
+Create `cubepi/agent/_outcome.py`:
 ```python
-async with self._run_lock:
-    outcome = await self._run_prompt(message, run_id=effective_run_id)
-# `outcome` reports whether mark should fire. Possible values:
-#   "complete"       — clean success
-#   "suspended"      — HITL pause; respond() handles completion
-#   "incomplete"     — pre-completion invariant failed (Task 27)
-#   "abandoned"      — provider/tool error / abort / cancellation
-if outcome == "complete" and self._run_aware and self.thread_id:
-    try:
-        await self.checkpointer.mark_run_complete(
-            self.thread_id, effective_run_id
-        )
-    except Exception as exc:
-        raise CompletionMarkerFailedError(
-            thread_id=self.thread_id,
-            run_id=effective_run_id,
-            cause=exc,
-        ) from exc
+from __future__ import annotations
+from typing import Literal
+
+RunOutcome = Literal["complete", "suspended", "incomplete", "abandoned"]
 ```
 
-In the agent loop, set the outcome explicitly per the spec table:
-- After clean terminal stop_reason + no pending HITL → `complete`
-- HitlDetached/HitlAborted silent catch → `suspended` (resume handles)
-- Provider/tool error → `abandoned`
-- abort_pending injected — terminal aborted → `abandoned`
-- Propagating CancelledError — re-raises, no return value
+Modify `cubepi/agent/loop.py`:
+- Change `run_agent_loop`, `_run_loop`, `_run_loop_inner` return type
+  from `None` (or `list[Message]`) to `RunOutcome`. Each existing exit
+  path returns the appropriate literal:
+  - After clean `AgentEndEvent` with terminal stop_reason and no
+    pending HITL → `return "complete"`
+  - After the `HitlDetached` / `HitlAborted` `except` blocks at
+    `loop.py:196` and `loop.py:418` (which currently `return` silently)
+    → `return "suspended"`
+  - After the early-exit branch on `stop_reason in ("error", "aborted")`
+    at `loop.py:485` → `return "abandoned"`
+  - When `check_tool_cycle(...)` (from Task 27) raises
+    `ToolCycleViolation` immediately before declaring `complete`,
+    catch it and `return "incomplete"` instead
+  - On propagating `asyncio.CancelledError` → DO NOT catch; the
+    function never returns; `prompt()`'s outer try/except handles it
+- Run `_run_loop_inner`'s `_run_with_lifecycle` (if it wraps anything)
+  must also forward the outcome.
+
+Modify `cubepi/agent/agent.py`:
+- `_run_prompt` and `_run_hitl_resume` return `RunOutcome`.
+- In `Agent.prompt()` (replacing the placeholder line `await
+  self._run_prompt(...)`):
+  ```python
+  outcome: RunOutcome = await self._run_prompt(
+      message, run_id=effective_run_id
+  )
+  await self._dispatch_outcome(outcome, effective_run_id)
+  ```
+- In `Agent.respond()`:
+  ```python
+  outcome: RunOutcome = await self._run_hitl_resume(...)
+  await self._dispatch_outcome(outcome, recovered_run_id)
+  ```
+- New private helper `_dispatch_outcome`:
+  ```python
+  async def _dispatch_outcome(
+      self, outcome: RunOutcome, run_id: str
+  ) -> None:
+      if outcome != "complete":
+          return
+      if not (self._run_aware and self.thread_id):
+          return
+      try:
+          await self.checkpointer.mark_run_complete(
+              self.thread_id, run_id
+          )
+      except Exception as exc:
+          raise CompletionMarkerFailedError(
+              thread_id=self.thread_id,
+              run_id=run_id,
+              cause=exc,
+          ) from exc
+  ```
+
+Mapping from spec §3.6.2 outcome table to literal:
+
+| §3.6.2 row | Returned outcome | Marker called? |
+|---|---|---|
+| Clean success | `"complete"` | yes |
+| HITL suspended (normal pause) | `"suspended"` | no |
+| HITL detached (silent catch) | `"suspended"` | no — respond() resumes |
+| HITL aborted (abort_pending) | `"abandoned"` | no |
+| Incomplete tool cycle (Task 27) | `"incomplete"` | no |
+| Provider / tool error | `"abandoned"` | no |
+| Abort during streaming | `"abandoned"` | no |
+| Propagating cancellation | (raises, no return) | no |
 
 - [ ] **Step 4: Run tests → expect pass**
 
@@ -3025,6 +3352,17 @@ def test_duplicate_ids_across_turns_violation():
     except ToolCycleViolation:
         return
     assert False
+
+
+def test_extra_results_with_same_id_violation():
+    """Multiset check: assistant emits one c1; window has two
+    tool_results both with c1. Set-equality would pass; multiset
+    correctly rejects."""
+    try:
+        check_tool_cycle([_asst(["c1"]), _res("c1"), _res("c1")])
+    except ToolCycleViolation:
+        return
+    assert False
 ```
 
 - [ ] **Step 2: Run → expect failure**
@@ -3038,20 +3376,22 @@ Create `cubepi/agent/_tool_cycle.py`:
 ```python
 """Pre-completion tool-cycle invariant — spec §3.6.2.
 
-For each AssistantMessage with ToolCall blocks {c1..cK}, the
-K-message window immediately following MUST be all ToolResultMessages
-with tool_call_id set-equal to {c1..cK} — no other AssistantMessage
-or UserMessage may appear in that window.
+For each AssistantMessage with ToolCall blocks {c1..cK}, the K-message
+window immediately following MUST be all ToolResultMessages whose
+tool_call_id MULTISET equals {c1..cK} — no extras, no missing, no
+duplicates beyond what the assistant emitted, and no other
+AssistantMessage or UserMessage may appear in that window.
 """
 
 from __future__ import annotations
+
+from collections import Counter
 
 from cubepi.providers.base import (
     AssistantMessage,
     Message,
     ToolCall,
     ToolResultMessage,
-    UserMessage,
 )
 
 
@@ -3061,12 +3401,13 @@ class ToolCycleViolation(ValueError):
         *,
         kind: str,
         assistant_index: int,
-        expected: set[str],
-        got: set[str],
+        expected: Counter,
+        got: Counter,
     ) -> None:
         super().__init__(
             f"tool-cycle violation [{kind}] at assistant index "
-            f"{assistant_index}: expected {expected}, got {got}"
+            f"{assistant_index}: expected {dict(expected)}, "
+            f"got {dict(got)}"
         )
         self.kind = kind
         self.assistant_index = assistant_index
@@ -3075,39 +3416,38 @@ class ToolCycleViolation(ValueError):
 
 
 def check_tool_cycle(messages: list[Message]) -> None:
-    n = len(messages)
     for i, m in enumerate(messages):
         if not isinstance(m, AssistantMessage):
             continue
-        call_ids = {
-            c.id for c in m.content if isinstance(c, ToolCall)
-        }
+        call_ids = [c.id for c in m.content if isinstance(c, ToolCall)]
         if not call_ids:
             continue
+        expected = Counter(call_ids)
         k = len(call_ids)
         window = messages[i + 1 : i + 1 + k]
         if len(window) < k:
             raise ToolCycleViolation(
                 kind="incomplete-window",
                 assistant_index=i,
-                expected=call_ids,
-                got=set(),
+                expected=expected,
+                got=Counter(),
             )
         for w in window:
             if not isinstance(w, ToolResultMessage):
                 raise ToolCycleViolation(
                     kind="non-tool-result-in-window",
                     assistant_index=i,
-                    expected=call_ids,
-                    got=set(),
+                    expected=expected,
+                    got=Counter(),
                 )
-        got_ids = {w.tool_call_id for w in window}
-        if got_ids != call_ids:
+        got = Counter(w.tool_call_id for w in window)
+        # Multiset equality — catches duplicates the spec rejects.
+        if got != expected:
             raise ToolCycleViolation(
-                kind="set-mismatch",
+                kind="multiset-mismatch",
                 assistant_index=i,
-                expected=call_ids,
-                got=got_ids,
+                expected=expected,
+                got=got,
             )
 ```
 
@@ -3347,9 +3687,9 @@ async def fork_once(
 ) -> ForkOnceResult:
     if self.checkpointer is None:
         raise RuntimeError("fork_once requires a checkpointer")
-    # HITL pre-flight.
+    # HITL pre-flight. Real attributes: self._state.tools, self._middleware.
     hitl_offenders = [
-        elem for elem in (*self.tools, *self.middleware)
+        elem for elem in (*self._state.tools, *self._middleware)
         if getattr(elem, "hitl", None) is not None
     ]
     if hitl_offenders:
@@ -3364,12 +3704,17 @@ async def fork_once(
     snapshot = await self.checkpointer.snapshot(
         src_thread_id, after_run_id=after_run_id
     )
-    # Build transient agent.
+    # Build transient agent. The constructor takes the original `model`
+    # arg (a BoundModel-like with `.provider` + `.spec`). Task 22 must
+    # also have stored the constructor's `model` argument on
+    # `self._model` (or equivalent retention) so fork_once can reuse it.
+    # If that retention isn't already present, add it as a one-line
+    # `self._model = model` in __init__ as part of this task.
     child = Agent(
-        model=self.model,
-        system_prompt=self.system_prompt,
-        tools=list(self.tools),
-        middleware=list(self.middleware),
+        model=self._model,
+        system_prompt=self._state.system_prompt,
+        tools=list(self._state.tools),
+        middleware=list(self._middleware),
         convert_to_llm=self.convert_to_llm,
         messages=snapshot,
         # checkpointer=None, thread_id=None — disable persistence.
@@ -3516,15 +3861,49 @@ Commit: `feat(hitl): ApprovalPolicyMiddleware populates self.hitl`.
 - Modify: `cubepi/tracing/schema.py` (add span name constant)
 - Test: `tests/tracing/test_fork_once_span.py` (new)
 
-- [ ] **Step 1: Failing test using the existing in-memory exporter**
+- [ ] **Step 1: Create `tests/tracing/conftest.py` with an in-memory exporter fixture if missing**
+
+First check: `ls tests/tracing/`. If `conftest.py` exists with an
+`in_memory_exporter` fixture already, skip. Otherwise create:
 
 ```python
+# tests/tracing/conftest.py
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry import trace
+
+
+@pytest.fixture
+def in_memory_exporter():
+    """Configure the global tracer provider with an in-memory exporter
+    for the duration of one test. Returns the exporter so tests can
+    call get_finished_spans()."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
+```
+
+If `tests/tracing/` doesn't exist as a directory yet, create it with an
+empty `__init__.py` first.
+
+- [ ] **Step 2: Failing test using the in-memory exporter**
+
+```python
+# tests/tracing/test_fork_once_span.py
 import pytest
 
 from cubepi.agent.agent import Agent
 from cubepi.checkpointer.memory import MemoryCheckpointer
 from cubepi.providers.faux import FauxProvider
-from tests.tracing.conftest import InMemoryExporter  # existing helper
 
 
 @pytest.mark.asyncio
@@ -3546,15 +3925,12 @@ async def test_fork_once_emits_named_span(in_memory_exporter):
     assert attrs["cubepi.fork.after_run_id"] == "R1"
 ```
 
-(The existing in-memory exporter fixture lives in
-`tests/tracing/conftest.py`; if it doesn't, add it as a small helper
-following the OTel `InMemorySpanExporter` pattern.)
+- [ ] **Step 3: Run → expect failure**
 
-- [ ] **Step 2: Run → expect failure**
-
+Run: `uv run pytest tests/tracing/test_fork_once_span.py -v`
 Expected: no span named `cubepi.agent.fork_once`.
 
-- [ ] **Step 3: Replace `_fork_once_span` placeholder with a real span**
+- [ ] **Step 4: Replace `_fork_once_span` placeholder with a real span**
 
 ```python
 def _fork_once_span(self, *, src_thread_id, after_run_id):
@@ -3573,15 +3949,15 @@ def _fork_once_span(self, *, src_thread_id, after_run_id):
     )
 ```
 
-- [ ] **Step 4: Run tests → expect pass**
+- [ ] **Step 5: Run tests → expect pass**
 
 Run: `uv run pytest tests/tracing/test_fork_once_span.py -v`
 Expected: green.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```
-git add cubepi/agent/agent.py tests/tracing/test_fork_once_span.py
+git add cubepi/agent/agent.py tests/tracing/conftest.py tests/tracing/__init__.py tests/tracing/test_fork_once_span.py
 git commit -m "feat(tracing): emit cubepi.agent.fork_once span"
 ```
 
@@ -3687,9 +4063,25 @@ BACKENDS = ["memory", "sqlite", "postgres", "mysql"]
 
 
 @pytest.fixture(params=BACKENDS)
-async def checkpointer(request, tmp_path, pg_pool, mysql_pool):
-    # Build the appropriate checkpointer per param.
-    ...
+async def checkpointer(request, tmp_path, clean_db, clean_mysql_db):
+    # Build the appropriate checkpointer per param. clean_db /
+    # clean_mysql_db are DSN strings; PG and MySQL constructors open
+    # their own pools on __aenter__.
+    if request.param == "memory":
+        from cubepi.checkpointer.memory import MemoryCheckpointer
+        yield MemoryCheckpointer()
+    elif request.param == "sqlite":
+        from cubepi.checkpointer.sqlite import SQLiteCheckpointer
+        async with SQLiteCheckpointer(str(tmp_path / "x.db")) as cp:
+            yield cp
+    elif request.param == "postgres":
+        from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
+        async with PostgresCheckpointer(clean_db) as cp:
+            yield cp
+    elif request.param == "mysql":
+        from cubepi.checkpointer.mysql.checkpointer import MySQLCheckpointer
+        async with MySQLCheckpointer(clean_mysql_db) as cp:
+            yield cp
 
 
 @pytest.mark.asyncio
@@ -3737,7 +4129,9 @@ git commit -m "test(e2e): cross-backend fork happy path"
 
 ```python
 @pytest.mark.asyncio
-async def test_fork_after_hitl_resume(memory_checkpointer):
+async def test_fork_after_hitl_resume():
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+    cp = MemoryCheckpointer()
     """prompt pauses for HITL → respond resumes → marker written →
     fork succeeds and copies the resumed run."""
     ...

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -2719,30 +2719,23 @@ async def test_prompt_sets_then_clears_active_run_id_on_clean_return():
 
 @pytest.mark.asyncio
 async def test_prompt_leaves_active_run_id_set_on_raise(monkeypatch):
-    """Spec §3.7 + Task 22 require active_run_id to be LEFT SET on any
-    failure post-claim. Use a propagating failure mode — provider
-    exceptions are CAUGHT by Agent._run_with_lifecycle (agent.py:645)
-    and converted to a synthetic error message, so they do NOT
-    propagate. The cleanest synthesized-after-the-fact path is a
-    CompletionMarkerFailedError raised by _dispatch_outcome (Task 26).
-    """
-    from cubepi.checkpointer.exceptions import CompletionMarkerFailedError
-    from cubepi.checkpointer.memory import MemoryCheckpointer
+    """Spec §3.7 + Task 22: active_run_id must be LEFT SET on any
+    propagating failure after claim. Provider exceptions are caught
+    by Agent._run_with_lifecycle and synthesized into error messages
+    — they do NOT propagate. To exercise the propagation path at
+    THIS task (before Task 26 introduces CompletionMarkerFailedError),
+    monkeypatch self._run_prompt to raise after entry."""
+    a = Agent(model=_ok_faux().model("faux-model"))
 
-    class _BrokenMark(MemoryCheckpointer):
-        async def mark_run_complete(self, thread_id, run_id):
-            raise RuntimeError("db down")
+    async def _boom(*args, **kwargs):
+        # Raises AFTER prompt() sets active_run_id and BEFORE the
+        # `else:` clear runs.
+        raise RuntimeError("boom")
 
-    cp = _BrokenMark()
-    a = Agent(
-        model=_ok_faux().model("faux-model"),
-        checkpointer=cp,
-        thread_id="t",
-    )
-    with pytest.raises(CompletionMarkerFailedError):
+    monkeypatch.setattr(a, "_run_prompt", _boom)
+    with pytest.raises(RuntimeError, match="boom"):
         await a.prompt("hello", run_id="R1")
-    # Spec §3.7: active_run_id stays set so the except-block reader
-    # can still recover it (exc.run_id is the recommended source).
+    # Spec §3.7: left set so except-block readers can recover it.
     assert a.state.active_run_id == "R1"
 ```
 
@@ -3238,23 +3231,23 @@ introduces one.
 
 - [ ] **Step 1: Failing tests covering every row of spec §3.6.2 table**
 
+**FauxProvider API reminder.** `FauxProvider`
+(`cubepi/providers/faux.py:156`) has no `text=` / `error=` /
+`tool_error=` / `abort_mid_stream=` / `sleep_seconds=` kwargs. Its
+real API: construct empty, then call `set_responses([...])` with a
+list of `AssistantMessage` instances (or `FauxResponseFactory`
+callables). To simulate provider failures, subclass `FauxProvider`
+inside the test file.
+
 Create `tests/agent/test_agent_completion.py`:
+
 ```python
+import asyncio
+import contextlib
+
 import pytest
 
 from cubepi.agent.agent import Agent
-from cubepi.checkpointer.memory import MemoryCheckpointer
-from cubepi.providers.faux import FauxProvider
-
-
-**FauxProvider API.** `FauxProvider` (`cubepi/providers/faux.py:156`)
-has no `text=` / `error=` / `tool_error=` / `abort_mid_stream=` /
-`sleep_seconds=` kwargs. Its real API: construct empty, then call
-`set_responses([...])` with a list of `AssistantMessage` instances
-(or `FauxResponseFactory` callables). To simulate provider failures
-or sleep behavior, subclass `FauxProvider` inside this test file.
-
-```python
 from cubepi.checkpointer.exceptions import CompletionMarkerFailedError
 from cubepi.checkpointer.memory import MemoryCheckpointer
 from cubepi.providers.base import AssistantMessage, TextContent
@@ -3323,7 +3316,7 @@ async def test_hitl_detached_outcome_suspended_no_mark():
         # Turn 1: ask_user tool_call.
         AssistantMessage(
             content=[ToolCall(id="tc-1", name="ask_user",
-                              arguments={"question": "?"})],
+                              arguments={"questions": [{"key": "ans", "prompt": "?"}]})],
             stop_reason="tool_use",
         ),
         # Turn 2 (after respond appends the answer as tool_result):
@@ -3349,7 +3342,9 @@ async def test_hitl_detached_outcome_suspended_no_mark():
         if (await cp.load_pending("t")) is not None:
             break
         await asyncio.sleep(0.01)
-    ch.detach()
+    # CheckpointedChannel has no .detach(); the Agent does
+    # (agent.py:405). a.detach() raises HitlDetached in the loop.
+    await a.detach()
     await task  # returns normally; state.last_outcome == "suspended"
     assert cp._runs["t"]["R1"].completed_at is None
 
@@ -3387,7 +3382,7 @@ async def test_hitl_aborted_via_abort_pending_does_not_mark():
     p.set_responses([
         AssistantMessage(
             content=[ToolCall(id="tc-1", name="ask_user",
-                              arguments={"question": "?"})],
+                              arguments={"questions": [{"key": "ans", "prompt": "?"}]})],
             stop_reason="tool_use",
         ),
     ])
@@ -3933,7 +3928,7 @@ async def test_tool_cycle_invariant_spans_hitl_resume():
         # Turn 1: ask_user → pause.
         AssistantMessage(
             content=[ToolCall(id="ask-1", name="ask_user",
-                              arguments={"question": "?"})],
+                              arguments={"questions": [{"key": "ans", "prompt": "?"}]})],
             stop_reason="tool_use",
         ),
         # Turn 2 (resume): assistant with an unresolved tool_call
@@ -3972,7 +3967,10 @@ async def test_tool_cycle_invariant_spans_hitl_resume():
     task = asyncio.create_task(a.prompt("hi", run_id="R1"))
     while (await cp.load_pending("t")) is None:
         await asyncio.sleep(0.01)
-    await task  # detach not needed; first prompt() returns suspended
+    # prompt() blocks until detach / abort / answer. Detach to
+    # surface HitlDetached → loop returns with last_outcome="suspended".
+    await a.detach()
+    await task
 
     # Resume with a fresh Agent. The second turn emits orphan-1;
     # the after_model_response hook stops the loop. Pre-completion

--- a/dev/plans/2026-06-05-conversation-fork.md
+++ b/dev/plans/2026-06-05-conversation-fork.md
@@ -2718,15 +2718,31 @@ async def test_prompt_sets_then_clears_active_run_id_on_clean_return():
 
 
 @pytest.mark.asyncio
-async def test_prompt_leaves_active_run_id_set_on_raise():
-    # FauxProvider has no `error=` kwarg — subclass to raise inside the loop.
-    class _RaisingProvider(FauxProvider):
-        async def stream(self, *args, **kwargs):
-            raise RuntimeError("provider down")
-    a = Agent(model=_RaisingProvider().model("faux-model"))
-    with pytest.raises(Exception):
+async def test_prompt_leaves_active_run_id_set_on_raise(monkeypatch):
+    """Spec §3.7 + Task 22 require active_run_id to be LEFT SET on any
+    failure post-claim. Use a propagating failure mode — provider
+    exceptions are CAUGHT by Agent._run_with_lifecycle (agent.py:645)
+    and converted to a synthetic error message, so they do NOT
+    propagate. The cleanest synthesized-after-the-fact path is a
+    CompletionMarkerFailedError raised by _dispatch_outcome (Task 26).
+    """
+    from cubepi.checkpointer.exceptions import CompletionMarkerFailedError
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+
+    class _BrokenMark(MemoryCheckpointer):
+        async def mark_run_complete(self, thread_id, run_id):
+            raise RuntimeError("db down")
+
+    cp = _BrokenMark()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+    )
+    with pytest.raises(CompletionMarkerFailedError):
         await a.prompt("hello", run_id="R1")
-    # Spec §3.7: left set so except-block readers can recover it.
+    # Spec §3.7: active_run_id stays set so the except-block reader
+    # can still recover it (exc.run_id is the recommended source).
     assert a.state.active_run_id == "R1"
 ```
 
@@ -3292,66 +3308,103 @@ async def test_provider_error_does_not_mark():
 
 @pytest.mark.asyncio
 async def test_hitl_detached_outcome_suspended_no_mark():
-    """Detach the channel mid-pause → loop catch sets
-    state.last_outcome="suspended" → no mark. After respond(), marker
-    IS written.
-
-    Implementation note: BEFORE writing this test, open
-    `tests/hitl/test_agent_respond.py` and mirror its full setup —
-    Provider that emits an ask_user tool_call, CheckpointedChannel
-    construction, `Agent.prompt()` awaited inside an asyncio.Task
-    that detaches the channel mid-flight, then `Agent.respond()`
-    on a fresh Agent constructed from the same checkpointer/thread_id.
+    """Provider returns an ask_user tool_call → loop pauses → channel
+    detach → loop catch sets state.last_outcome="suspended" → no mark.
+    Then respond() resumes; provider finishes; marker IS written.
     """
     from cubepi.checkpointer.memory import MemoryCheckpointer
     from cubepi.hitl.ask_user import ask_user_tool
     from cubepi.hitl.channel import CheckpointedChannel
+    from cubepi.providers.base import AssistantMessage, TextContent, ToolCall
 
     cp = MemoryCheckpointer()
-    # ... mirror tests/hitl/test_agent_respond.py setup ...
-    # Step 1: scripted FauxProvider that returns an ask_user tool_call
-    #         on first stream() invocation, then a final assistant on
-    #         the second (after the answer is appended).
-    # Step 2: ch = CheckpointedChannel(checkpointer=cp, thread_id="t",
-    #                                  run_id="R1")
-    #         tool = ask_user_tool(ch)
-    #         a = Agent(model=..., tools=[tool], checkpointer=cp,
-    #                   thread_id="t")
-    # Step 3: task = asyncio.create_task(a.prompt("hi", run_id="R1"))
-    # Step 4: await pending = wait for pending_request row
-    # Step 5: ch.detach() / channel HitlDetached path
-    # Step 6: await task  # returns; state.last_outcome == "suspended"
-
+    p = FauxProvider()
+    p.set_responses([
+        # Turn 1: ask_user tool_call.
+        AssistantMessage(
+            content=[ToolCall(id="tc-1", name="ask_user",
+                              arguments={"question": "?"})],
+            stop_reason="tool_use",
+        ),
+        # Turn 2 (after respond appends the answer as tool_result):
+        # final assistant.
+        AssistantMessage(
+            content=[TextContent(text="done")], stop_reason="end_turn"
+        ),
+    ])
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    a = Agent(
+        model=p.model("faux-model"),
+        tools=[tool],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch,
+    )
+    # Drive the run inside a Task so we can detach mid-pause.
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    # Wait until pending_request row exists (loop has reached the
+    # ask_user pause).
+    while True:
+        if (await cp.load_pending("t")) is not None:
+            break
+        await asyncio.sleep(0.01)
+    ch.detach()
+    await task  # returns normally; state.last_outcome == "suspended"
     assert cp._runs["t"]["R1"].completed_at is None
 
-    # Resume with a fresh Agent + answer.
+    # Resume with a fresh Agent on a fresh channel; provide answer.
     ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
     tool2 = ask_user_tool(ch2)
-    a2 = Agent(model=..., tools=[tool2], checkpointer=cp, thread_id="t")
-    # Find the pending question_id from cp.load_pending("t")
+    a2 = Agent(
+        model=p.model("faux-model"),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
     pending = await cp.load_pending("t")
     qid = pending[0].question_id
-    await a2.respond(qid, "yes")
+    # respond() is keyword-only — see agent.py:431.
+    await a2.respond(question_id=qid, answer="yes")
     assert cp._runs["t"]["R1"].completed_at is not None
 
 
 @pytest.mark.asyncio
 async def test_hitl_aborted_via_abort_pending_does_not_mark():
-    """abort_pending raises HitlAborted → loop catch sets
+    """Provider returns an ask_user tool_call → loop pauses →
+    abort_pending raises HitlAborted in the loop → catch sets
     state.last_outcome="abandoned" (NOT "suspended"). agent.py:582-595
     appends the synthetic deny + terminal aborted assistant.
-
-    Mirror tests/hitl/test_agent_abort_pending.py for the
-    abort_pending plumbing.
     """
     from cubepi.checkpointer.memory import MemoryCheckpointer
     from cubepi.hitl.ask_user import ask_user_tool
     from cubepi.hitl.channel import CheckpointedChannel
+    from cubepi.providers.base import AssistantMessage, ToolCall
 
     cp = MemoryCheckpointer()
-    # ... mirror tests/hitl/test_agent_abort_pending.py setup ...
-    # Construct as in the detached test, then instead of detach +
-    # respond, call await a.abort_pending(reason="user cancelled").
+    p = FauxProvider()
+    p.set_responses([
+        AssistantMessage(
+            content=[ToolCall(id="tc-1", name="ask_user",
+                              arguments={"question": "?"})],
+            stop_reason="tool_use",
+        ),
+    ])
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    a = Agent(
+        model=p.model("faux-model"),
+        tools=[tool],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch,
+    )
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    while (await cp.load_pending("t")) is None:
+        await asyncio.sleep(0.01)
+    await a.abort_pending(reason="user cancelled")
+    await task
 
     rs = cp._runs["t"]["R1"]
     assert rs.completed_at is None
@@ -3859,24 +3912,86 @@ Add a resume-path test to Task 26 (or as an extra in
 ```python
 @pytest.mark.asyncio
 async def test_tool_cycle_invariant_spans_hitl_resume():
-    """Pause mid-tool-use; resume; if resume returns without
-    resolving the tool_use (e.g., an after_model_response middleware
-    rewrites the assistant to drop the unresolved tool_use), mark
-    must NOT be written even though respond's last-segment messages
-    look 'clean' on their own.
+    """Pause mid-tool-use (ask_user). Resume; provider then emits an
+    assistant carrying an UNRELATED unresolved tool_call (no matching
+    ToolResultMessage will follow). The invariant filters
+    state.messages by m.run_id == 'R1' — sees the unresolved c1 →
+    outcome demoted from 'complete' to 'incomplete' → marker NOT
+    written."""
+    import asyncio
 
-    Setup mirror: tests/hitl/test_agent_respond.py for the pause +
-    respond plumbing. Provider script: turn 1 = assistant with
-    ask_user tool_call → pause. Resume: turn 2 = assistant with an
-    unrelated unresolved tool_call (e.g., name='lookup', id='c1', no
-    matching ToolResultMessage). The invariant filters state.messages
-    by m.run_id=='R1' — sees the unresolved c1 → outcome demoted to
-    'incomplete' → marker NOT written.
-    """
     from cubepi.checkpointer.memory import MemoryCheckpointer
+    from cubepi.hitl.ask_user import ask_user_tool
+    from cubepi.hitl.channel import CheckpointedChannel
+    from cubepi.providers.base import (
+        AssistantMessage, TextContent, ToolCall,
+    )
+
     cp = MemoryCheckpointer()
-    # ... full setup omitted; pattern is identical to
-    # test_hitl_detached_outcome_suspended_no_mark in Task 26 ...
+    p = FauxProvider()
+    p.set_responses([
+        # Turn 1: ask_user → pause.
+        AssistantMessage(
+            content=[ToolCall(id="ask-1", name="ask_user",
+                              arguments={"question": "?"})],
+            stop_reason="tool_use",
+        ),
+        # Turn 2 (resume): assistant with an unresolved tool_call
+        # that NO ToolResultMessage will satisfy. The agent loop's
+        # after_model_response forces a stop on this turn so the
+        # call never gets executed.
+        AssistantMessage(
+            content=[
+                ToolCall(id="orphan-1", name="lookup", arguments={}),
+            ],
+            stop_reason="tool_use",
+        ),
+    ])
+
+    from cubepi.middleware.base import TurnAction
+
+    async def _stop_after(response, ctx, *, signal=None):
+        # Stop after the second assistant turn so the orphan tool_call
+        # is NEVER executed.
+        if any(
+            getattr(c, "id", None) == "orphan-1" for c in response.content
+        ):
+            return TurnAction(decision="stop")
+        return None
+
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    a = Agent(
+        model=p.model("faux-model"),
+        tools=[tool],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch,
+        after_model_response=_stop_after,
+    )
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    while (await cp.load_pending("t")) is None:
+        await asyncio.sleep(0.01)
+    await task  # detach not needed; first prompt() returns suspended
+
+    # Resume with a fresh Agent. The second turn emits orphan-1;
+    # the after_model_response hook stops the loop. Pre-completion
+    # invariant scans state.messages filtered by run_id=='R1' and
+    # finds the unresolved orphan-1 → outcome 'incomplete' → no mark.
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=p.model("faux-model"),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+        after_model_response=_stop_after,
+    )
+    pending = await cp.load_pending("t")
+    qid = pending[0].question_id
+    await a2.respond(question_id=qid, answer="yes")
+
     assert cp._runs["t"]["R1"].completed_at is None
 ```
 

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -149,15 +149,37 @@ unfinished run we have no right to copy. The set-based selection
 solves this by construction: only messages tagged with a *completed*
 run_id (or NULL for legacy) are eligible.
 
-This selection is also robust to:
+This selection is **row-correct** in the presence of:
 
-- **Interleaved runs**: each run's messages are addressed by tag, not
-  by position. Gaps in seq are fine.
 - **In-flight runs**: their messages have a `run_id` whose row has
   `completion_seq IS NULL` → excluded.
 - **Mixed legacy + post-upgrade threads**: NULL-run_id messages are
   preserved as a chronological prefix, post-upgrade completed runs
   appear after.
+
+#### What "row-correct" does NOT cover: context consistency under interleaved runs
+
+If two runs A and B run concurrently on the same thread, the agent
+loop's lazy load (`load(thread_id)`) at the start of B will pick up
+A's in-flight messages as context. If B then completes and A doesn't,
+`fork(after_run_id=B)` copies B's messages but EXCLUDES A's — yet B's
+outputs were conditioned on A's context. The fork is row-correct (no
+orphan tool_use, no half-truncated run) but **semantically dangling**:
+B's assistant reply may refer to information that no longer exists in
+the forked thread's history.
+
+The spec **does not solve this** at the cubepi layer. It is left as a
+host responsibility:
+
+- **Recommended pattern**: one active run per thread (cubebox's actual
+  pattern — RunManager serializes per conversation; `Agent.prompt()`
+  inside a single Agent instance is also single-flight via the
+  existing `_run_lock`).
+- **If hosts want multi-process / multi-Agent prompts on the same
+  thread**: they must accept that fork can produce semantically
+  dangling artifacts when runs overlap. This is documented as a
+  known limitation; a future spec may add a per-thread run lease
+  if a real workload needs the stronger guarantee.
 
 #### Why a run is the right unit
 
@@ -175,14 +197,17 @@ This selection is also robust to:
   one-line operation backed by the same `run_id` column the fork uses
   for lookup.
 
-#### Recommendation (not enforced): one active run per thread
+#### Single-flight per Agent instance (existing, enforced)
 
-For UX clarity and predictable ordering, hosts SHOULD serialize runs
-per thread (cubebox naturally does — one conversation = one in-flight
-prompt at a time). The spec does NOT enforce this — the set-based fork
-selection means interleaved runs are *correct*, just unusual. A future
-spec may add a "one active run per thread" lease if a real workload
-needs the stronger guarantee.
+`Agent.prompt()` is single-flight on its own instance — the existing
+`_run_lock` (see `cubepi/agent/agent.py:204`) guards `prompt()` and
+`respond()` so two coroutines on the SAME Agent object serialize.
+`Agent.state.active_run_id` is therefore safe from clobbering under
+single-instance concurrency.
+
+The unguarded case (and the context-consistency caveat above) is
+**multiple Agent instances or multiple processes** on the same thread.
+Spec does not protect that case.
 
 ### 3.3 Atomicity and concurrency
 
@@ -376,22 +401,33 @@ The recommended retry pattern: "retry `mark_run_complete()`, not the
 whole `prompt()`" — re-running `prompt(run_id=R)` raises
 `RunAlreadyClaimedError` because R's claim row already exists.
 
-Trigger conditions for the agent loop to call `mark_run_complete()`:
+#### Trigger conditions for `mark_run_complete()` — enumerated by loop outcome
 
-- The loop exits cleanly with a terminal stop_reason
-  (`end_turn` / `tool_use_completed`-then-`end_turn` / any
-  non-suspended terminal state)
-- AND no pending HITL request remains for this run
+The current `cubepi/agent/loop.py` is **not** a "return-means-success"
+machine. It catches provider/tool exceptions, appends a synthetic
+assistant message with `stop_reason="error"` or `"aborted"`, and
+returns normally (see `loop.py:485` early-exit branch). A naive
+"call mark_run_complete after `_run_prompt()` returns"
+implementation would mark FAILED runs complete. To prevent that, the
+spec enumerates each loop outcome:
 
-If `prompt()` returns / raises because of:
+| Loop outcome | Detection signal | `mark_run_complete()` called? |
+|---|---|---|
+| **Clean success** | Final `AssistantMessage` has `stop_reason in {"end_turn", "stop", "tool_use", …}` (any non-error / non-aborted stop_reason) AND `error_message is None` AND no pending HITL on the thread | **YES** |
+| **HITL suspended** | `pending_request` row written this run; `prompt()` returns with the agent in suspended state | NO — `respond()` writes the marker on resume's clean exit |
+| **Provider / tool error** | Final assistant message has `stop_reason="error"` OR `error_message is not None` (set on the message by the loop's exception handler) | NO — claim row remains; future `delete_run()` cleans up |
+| **Abort** (`agent.abort()` or `agent.abort_pending()`) | Final assistant message has `stop_reason="aborted"` | NO — claim row remains |
+| **Cancellation** (`asyncio.CancelledError`, `HitlDetached`, `HitlAborted`) | Exception propagates out of `prompt()`; no `AgentEndEvent` emitted | NO — claim row remains; `active_run_id` left set (§3.7) |
 
-- **HITL pause** (`pending_request` set) → completion NOT written;
-  resumed by `respond()` (§3.6.3). Claim row remains (`completed_at
-  IS NULL`) so concurrent attempts to reuse the run_id correctly
-  hit `RunAlreadyClaimedError`.
-- **Exception / abort / cancellation** → completion NOT written;
-  claim row remains. `fork(after_run_id=R)` raises
-  `RunNotCompletedError`. The future `delete_run(R)` can clean up.
+The agent loop's existing `if message.stop_reason in ("error",
+"aborted"): … return early` branch (`loop.py:485`) is the natural
+gating point. After it, on the success path, the loop calls
+`mark_run_complete()` once before final cleanup.
+
+Tests MUST cover each row of this table independently (provider
+exception, tool exception, abort, abort_pending, cancel,
+HitlDetached) and assert the cubepi_runs row's `completed_at IS
+NULL` for every non-success outcome.
 
 #### 3.6.3 HITL pause / resume continuity
 
@@ -416,6 +452,39 @@ HITL-bearing run calls `claim_run()` exactly once across all
 `prompt()` + N × `respond()` invocations.
 
 `Agent.respond()` signature does **not** change.
+
+#### 3.6.3.1 HITL channel run_id binding constraint
+
+`cubepi.hitl.channel.CheckpointedChannel.__init__` takes `run_id` as a
+constructor argument (`self._run_id`) and never updates it per call.
+The value is written to `pending_request.run_id` whenever the channel
+pauses for HITL. This pre-dates the spec and is preserved.
+
+The spec **adds a constraint** to make the channel's bound run_id
+agree with the agent's active run_id, so HITL recovery on resume
+finds the right value:
+
+- When the agent has both a `checkpointer` AND any tool/middleware
+  with `requires_hitl=True` (§3.8.2) bound that holds a
+  `CheckpointedChannel`, `Agent.prompt(run_id=...)` MUST be
+  host-supplied (NOT generate-mode) and MUST equal the channel's
+  `_run_id`. Mismatch / `None` raises `ValueError` at the start of
+  `prompt()`, before `claim_run()`.
+
+- This is the existing cubebox pattern: `RunManager` generates a
+  `uuid7()` run_id per request, constructs
+  `CheckpointedChannel(checkpointer=cp, thread_id=conv_id,
+  run_id=run_id)`, then calls `Agent.prompt(run_id=run_id)`. Same
+  value in both places, no change needed at the host.
+
+- For non-HITL agents (no `requires_hitl=True` element), `Agent.prompt`
+  accepts `run_id=None` and generates; no channel binding to worry
+  about.
+
+This avoids the alternative of refactoring `CheckpointedChannel` to
+take run_id at call time (a backward-incompatible HITL API change
+beyond this spec's scope) while still making the binding semantics
+unambiguous.
 
 **Protocol change required to support this.** Today,
 `Checkpointer.load_pending_request(thread_id) -> HitlRequest | None`
@@ -584,9 +653,16 @@ class Checkpointer(Protocol):
         BEFORE `Agent.prompt()` returns. NOT coupled to the final
         append — see §3.6.2.
 
+        **Idempotent on already-completed rows.** If the row exists
+        and already has `completed_at IS NOT NULL`, the call returns
+        successfully (no-op) — does NOT raise
+        `RunAlreadyCompletedError`. This makes the
+        `CompletionMarkerFailedError` recovery story honest: a retry
+        after the DB committed but the ack was lost succeeds cleanly.
+
         Raises `RunNotClaimedError` if no row exists for
-        `(thread_id, run_id)`, or `RunAlreadyCompletedError` if the
-        row's `completed_at` is already non-NULL.
+        `(thread_id, run_id)` (genuine logic bug — claim_run never
+        ran or its row was lost).
         """
 
     async def load_pending(
@@ -632,9 +708,12 @@ class RunAlreadyClaimedError(CheckpointerError):
 
 
 class RunAlreadyCompletedError(CheckpointerError):
-    """claim_run() or mark_run_complete() called but the cubepi_runs
-    row already has completed_at IS NOT NULL. Runs are append-only;
-    start a new run with a different run_id."""
+    """claim_run() called but the cubepi_runs row already has
+    completed_at IS NOT NULL. Runs are append-only; start a new run
+    with a different run_id.
+
+    NOT raised by mark_run_complete() — that path is idempotent on
+    already-completed rows (see §3.6.2 retry semantics)."""
 
 
 class CompletionMarkerFailedError(CheckpointerError):
@@ -669,9 +748,19 @@ class AgentState:
 ```
 
 Set to the claimed run_id at the start of `prompt()` (after a
-successful `claim_run()`), cleared back to `None` when the prompt
-returns or raises. Observable to listeners / debugging without
-needing the prompt() return value.
+successful `claim_run()`). Cleared back to `None` ONLY on clean
+return; on exception it is left set so callers reading
+`agent.state.active_run_id` from the except block can still recover
+it. For the specific `CompletionMarkerFailedError` case the run_id is
+ALSO carried on the exception (`exc.run_id`) — that is the
+recommended source of truth in `except` blocks because it survives
+any subsequent `prompt()` invocation that would otherwise overwrite
+`active_run_id`. `active_run_id` is also cleared back to None on
+successful resume completion via `respond()`.
+
+The single-flight `_run_lock` (see `cubepi/agent/agent.py:204`)
+prevents two concurrent `prompt()` / `respond()` calls on the same
+Agent instance from racing on `active_run_id`.
 
 ```python
 class Agent(Generic[TMessage]):
@@ -923,13 +1012,15 @@ idiom in `cubepi/checkpointer/mysql/checkpointer.py`.
 `mark_run_complete()`:
 
 - Take per-thread advisory lock / `FOR UPDATE`.
+- `SELECT completed_at FROM cubepi_runs WHERE thread_id=? AND run_id=?`.
+  - No row → `RunNotClaimedError`.
+  - Existing row with `completed_at IS NOT NULL` → **idempotent
+    success**, commit, return.
+  - Existing row with `completed_at IS NULL` → proceed to UPDATE.
 - `next_seq = (SELECT COALESCE(MAX(completion_seq), 0) + 1 FROM
   cubepi_runs WHERE thread_id = ? AND completion_seq IS NOT NULL)`.
 - `UPDATE cubepi_runs SET completed_at = now(), completion_seq =
-  $next_seq WHERE thread_id = ? AND run_id = ? AND completed_at IS
-  NULL`.
-- If 0 rows updated: SELECT to distinguish
-  `RunNotClaimedError` vs `RunAlreadyCompletedError`.
+  $next_seq WHERE thread_id = ? AND run_id = ?`.
 - Commit.
 
 `append()` (existing) is unchanged in surface but must persist
@@ -999,12 +1090,14 @@ Schema additions at connect time using the existing PRAGMA-probe +
 `mark_run_complete()`:
 
 - `BEGIN IMMEDIATE`.
+- `SELECT completed_at FROM runs WHERE thread_id=? AND run_id=?`.
+  - No row → `RunNotClaimedError`.
+  - `completed_at IS NOT NULL` → idempotent success, commit, return.
+  - `completed_at IS NULL` → proceed.
 - `next_seq = (SELECT COALESCE(MAX(completion_seq), 0) + 1 FROM
   runs WHERE thread_id=? AND completion_seq IS NOT NULL)`.
 - `UPDATE runs SET completed_at = julianday('now'), completion_seq =
-  $next_seq WHERE thread_id=? AND run_id=? AND completed_at IS NULL`.
-- If 0 rows updated: SELECT to distinguish
-  `RunNotClaimedError` vs `RunAlreadyCompletedError`.
+  $next_seq WHERE thread_id=? AND run_id=?`.
 - Commit.
 
 `append()` is also wrapped in `BEGIN IMMEDIATE` (uniform writer
@@ -1060,7 +1153,7 @@ No `forked_at_seq` column added — SQLite has no per-thread seq.
 
 - `state = runs[thread_id].get(run_id)`.
 - If missing → `RunNotClaimedError`.
-- If `state.completed_at is not None` → `RunAlreadyCompletedError`.
+- If `state.completed_at is not None` → **idempotent success**, return.
 - Else allocate `next_seq = max((s.completion_seq for s in
   runs[thread_id].values() if s.completion_seq is not None),
   default=0) + 1`; update state's completed_at + completion_seq.
@@ -1088,6 +1181,7 @@ No `forked_at_seq` field — Memory has no seq.
 | `prompt(run_id=R)` and `R` is currently claimed (completed_at IS NULL) on the thread | `RunAlreadyClaimedError(thread_id=..., run_id=R)` |
 | `prompt(run_id=R)` and `R` has completed_at IS NOT NULL on the thread | `RunAlreadyCompletedError(thread_id=..., run_id=R)` |
 | `mark_run_complete()` called without a prior `claim_run()` | `RunNotClaimedError(thread_id=..., run_id=...)` — indicates an agent-loop logic bug |
+| `mark_run_complete()` called on a row that already has `completed_at IS NOT NULL` | **success (no-op)** — idempotent; supports retry-after-lost-ack from `CompletionMarkerFailedError` |
 | `mark_run_complete()` fails AFTER the run's final append succeeded | `CompletionMarkerFailedError(thread_id=..., run_id=..., cause=...)` — `run_id` is recoverable even when `prompt(run_id=None)` was used |
 | `Agent.fork_once()` child run errors | propagates (same surface as `Agent.prompt()`) |
 | `Agent.fork_once()` is cancelled mid-turn | `asyncio.CancelledError` re-raises after transient agent abort completes (best-effort; see §3.8 step 6) |
@@ -1096,15 +1190,38 @@ No `forked_at_seq` field — Memory has no seq.
 
 ## 4. Migration / Compatibility
 
-- **Protocol change**: `Checkpointer.snapshot`, `Checkpointer.fork`,
-  `Checkpointer.claim_run`, `Checkpointer.mark_run_complete`,
-  `Checkpointer.load_pending` are new methods on the
-  `runtime_checkable` Protocol. Existing user-implemented
-  checkpointers keep type-checking; they only fail when the new
-  methods are actually called.
+- **Protocol change — full impact disclosure.** This is a v4
+  Checkpointer contract change, not just a "fork API addition".
+  Five new Protocol methods: `snapshot`, `fork`, `claim_run`,
+  `mark_run_complete`, `load_pending`. Existing third-party
+  checkpointers that implement only the v3 surface (`load`, `append`,
+  `save_extra`, `save_pending_request`, `load_pending_request`) will
+  fail **ordinary `Agent.prompt()` calls** once `claim_run()` is
+  invoked at the start of every run — not just fork API calls.
+
+  Mitigation: `Agent.prompt()` checks `hasattr(self.checkpointer,
+  "claim_run")` at the start. If the method is absent, `prompt()`
+  runs in **legacy degraded mode**:
+
+  - No `claim_run()` / `mark_run_complete()` call.
+  - `Message.run_id` is still stamped on appended messages (purely
+    informational — no marker exists to anchor it).
+  - `Agent.fork()` / `Agent.fork_once()` on this checkpointer raises
+    `CheckpointerError("backend does not support fork; missing
+    claim_run / mark_run_complete")`.
+
+  This keeps existing third-party Protocol-only impls working for
+  vanilla `prompt()` while making the missing fork capability an
+  explicit error rather than a silent corruption path. First-party
+  backends (Memory, SQLite, Postgres, MySQL) always implement the
+  new methods after this spec lands; the degraded mode is purely a
+  third-party compatibility shim.
+
   `Checkpointer.load_pending_request` is kept as a thin alias for
-  `load_pending()` returning only the request part — existing callers
-  unchanged.
+  `load_pending()` returning only the request part — existing
+  callers unchanged. The matching backend-specific
+  `load_pending_run_id()` methods are deprecated in favor of
+  `load_pending()` but left in place for one release.
 - **`Agent.prompt()` signature**: adds an optional keyword `run_id`
   and changes return type from `None` to `str`. Returning a value that
   the caller previously ignored is **not** a breaking change for
@@ -1230,6 +1347,31 @@ No `forked_at_seq` field — Memory has no seq.
     `claim_run()` or `mark_run_complete()` call is made (assert via
     spying on a checkpointer instance that would have been used by
     the parent — and observe no calls from the transient agent).
+  - **`mark_run_complete()` idempotency** (regression test for v2 R7
+    HIGH #3): call mark_run_complete twice on the same
+    `(thread_id, run_id)`; second call returns success (no raise),
+    `completion_seq` unchanged from the first call.
+  - **HITL channel run_id binding** (regression test for v2 R7 HIGH
+    #2): construct Agent with a `requires_hitl=True` tool whose
+    `CheckpointedChannel(run_id="R1")` is bound at construction.
+    Then call `Agent.prompt(message, run_id=None)` → raises
+    `ValueError` (generate-mode rejected). Then call
+    `Agent.prompt(message, run_id="R2")` (mismatch) → raises
+    `ValueError`. Then `Agent.prompt(message, run_id="R1")` →
+    succeeds. Non-HITL agents accept `run_id=None` unchanged.
+  - **Loop-outcome completion enumeration** (regression test for v2
+    R7 HIGH #5): exercise each row of the §3.6.2 table — clean
+    success, HITL pause, provider exception, tool exception, abort,
+    cancellation, HitlDetached — and assert
+    `cubepi_runs.completed_at IS NULL` for every non-success outcome
+    and `IS NOT NULL` for the success outcome.
+  - **Legacy-degraded mode** (regression test for v2 R7 HIGH #4):
+    construct an Agent with a checkpointer that implements only the
+    v3 surface (no `claim_run` / `mark_run_complete`). Vanilla
+    `Agent.prompt(msg)` succeeds (no claim attempted; messages
+    stamped with run_id but no marker written). Calling
+    `Agent.fork(...)` or `Agent.fork_once(...)` raises
+    `CheckpointerError` explaining the missing methods.
   - SQLite cross-connection: two `SQLiteCheckpointer` instances on
     the same DB file, one `fork()` and one `mark_run_complete()`
     from different processes serialize via `BEGIN IMMEDIATE`

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -817,18 +817,33 @@ two additive changes (alembic migration in cubebox / cubepi-using apps):
   - PRIMARY KEY `(thread_id, run_id)`
   - INDEX `(thread_id, completion_seq)` for fork's set-selection query
   - Postgres: `HASH (thread_id)` partitioned to match
-    `cubepi_messages`; FK to `cubepi_threads(thread_id)`
-  - MySQL: `KEY (thread_id)` partitioned (no FK, consistent with
-    `cubepi_messages`)
+    `cubepi_messages`;
+    **`FOREIGN KEY (thread_id) REFERENCES cubepi_threads(thread_id)
+    ON DELETE CASCADE`** so thread deletion cleans up runs (mirrors
+    `cubepi_messages`).
+  - MySQL: `KEY (thread_id)` partitioned, **no FK** (consistent with
+    `cubepi_messages` — MySQL forbids FKs on partitioned tables).
+    Hosts that delete threads MUST also DELETE the matching
+    `cubepi_runs` rows in the same transaction, the same as they
+    already do for `cubepi_messages`. Document this in the MySQL
+    backend guide.
 
-`fork()` in one transaction:
+`fork()` in one transaction. **The thread row is created BEFORE
+the message INSERT because `cubepi_messages.thread_id` FKs to
+`cubepi_threads(thread_id)`. `forked_at_seq` is populated in a
+trailing UPDATE since its value isn't known until messages have
+been copied.**
 
 1. Advisory lock / `FOR UPDATE` on the source thread.
 2. `SELECT completion_seq AS cutoff FROM cubepi_runs WHERE
    thread_id = $src AND run_id = $after_run_id AND completion_seq IS
    NOT NULL` → if no row, `RunNotCompletedError`.
-3. Copy messages (compute `$last_copied_seq` in the same statement
-   via RETURNING or follow-up):
+3. `INSERT INTO cubepi_threads (thread_id, parent_thread_id,
+   forked_at_seq, extra, …)
+   VALUES ($new, $src, NULL, $merged_extra, …)` —
+   `ThreadAlreadyExistsError` on PK violation. `forked_at_seq` is
+   NULL for now; populated in step 6.
+4. Copy messages:
    ```sql
    INSERT INTO cubepi_messages (thread_id, seq, role, run_id,
                                 metadata, payload)
@@ -846,12 +861,6 @@ two additive changes (alembic migration in cubebox / cubepi-using apps):
      )
    ORDER BY seq;
    ```
-4. `INSERT INTO cubepi_threads (thread_id, parent_thread_id,
-   forked_at_seq, extra, …)
-   VALUES ($new, $src, $last_copied_seq, $merged_extra, …)` —
-   `ThreadAlreadyExistsError` on PK violation.
-   `$last_copied_seq = (SELECT MAX(seq) FROM cubepi_messages WHERE
-   thread_id = $new)`.
 5. `INSERT INTO cubepi_runs (thread_id, run_id, claimed_at,
    completed_at, completion_seq)
    SELECT $new, run_id, claimed_at, completed_at, completion_seq
@@ -859,16 +868,34 @@ two additive changes (alembic migration in cubebox / cubepi-using apps):
    WHERE thread_id = $src
      AND completion_seq IS NOT NULL
      AND completion_seq <= $cutoff`.
-6. Commit.
+6. `UPDATE cubepi_threads SET forked_at_seq = (SELECT MAX(seq)
+   FROM cubepi_messages WHERE thread_id = $new) WHERE thread_id =
+   $new`. The MAX subquery returns NULL for an empty-prefix fork
+   (e.g., fork of a thread with only legacy NULL-run messages where
+   the chosen run_id excluded everything) — NULL is the correct
+   value in that edge case.
+7. Commit.
 
-`claim_run()`:
+`claim_run()`. **Must lazily ensure the `cubepi_threads` row exists
+before inserting into `cubepi_runs`, because `cubepi_runs.thread_id`
+FKs to it. This mirrors the existing `append()` lazy-creation
+pattern: a brand-new thread's first writer creates the threads row
+with defaults.**
 
 - Take per-thread advisory lock / `FOR UPDATE`.
+- `INSERT INTO cubepi_threads (thread_id) VALUES (?)
+  ON CONFLICT (thread_id) DO NOTHING` — idempotently ensures the
+  thread row exists with defaults (`parent_thread_id=NULL`,
+  `forked_at_seq=NULL`, `extra='{}'`).
 - `INSERT INTO cubepi_runs (thread_id, run_id) VALUES (?, ?)` →
   on PK conflict, `SELECT completed_at FROM cubepi_runs WHERE
   thread_id = ? AND run_id = ?` → if NULL,
   `RunAlreadyClaimedError`; else `RunAlreadyCompletedError`.
 - Commit.
+
+(MySQL equivalent: `INSERT IGNORE INTO cubepi_threads`. The same
+lazy-create lives in `append()` today; spec just promotes the
+pattern to `claim_run()`.)
 
 `mark_run_complete()`:
 

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -231,7 +231,7 @@ world the copy will see:
 
 | Field / row | Copied? | Notes |
 |---|---|---|
-| `cubepi_messages` rows where `run_id IS NULL` OR `run_id IN {completed runs of src with completed_at <= after_run_id.completed_at}` | yes | physical copy; PG/MySQL preserve source `seq` values for the copied range. SQLite copies the JSON payloads under fresh global `id`s (its `messages.id` is a global auto-increment, not a per-thread seq). Memory copies in-list order. Each copied row keeps its original `run_id` value (or NULL). Source seq order is preserved across the copy. |
+| `cubepi_messages` rows where `run_id IS NULL` OR `run_id IN {completed runs of src with completion_seq IS NOT NULL AND completion_seq <= after_run_id.completion_seq}` | yes | physical copy; PG/MySQL preserve source `seq` values for the copied range. SQLite copies the JSON payloads under fresh global `id`s (its `messages.id` is a global auto-increment, not a per-thread seq). Memory copies in-list order. Each copied row keeps its original `run_id` value (or NULL). Source seq order is preserved across the copy. |
 | `cubepi_runs` rows for the copied runs | yes | so the new thread can be further forked / deleted by run |
 | `extra` | yes | deep copy of the source JSON object |
 | `parent_thread_id` | written (new) | set to `src_thread_id` on the new thread row |
@@ -470,7 +470,9 @@ completed runs):
   - Includes ALL legacy NULL-run_id messages (the chronological
     prefix the user has been chatting on top of)
   - PLUS messages of every completed run with
-    `completed_at <= R.completed_at`
+    `completion_seq <= R.completion_seq` (see §3.2 — `completion_seq`
+    is the per-thread monotonic ordering key; `completed_at` is
+    audit-only)
   - Source seq order preserved across the copy
 - `delete_run(thread_id, R)` removes only R's messages (those with
   `run_id = R`); the legacy NULL prefix is untouched. To clear the
@@ -1136,13 +1138,20 @@ No `forked_at_seq` field — Memory has no seq.
   - `prompt()` accept-or-generate: caller-supplied run_id is used
     verbatim; None generates a uuid; return value matches what was
     persisted on appended messages
-  - `prompt()` raises `RunAlreadyCompletedError` if caller passes a
-    run_id that already has a completion marker
-  - completion marker written atomically with the final append (test:
-    crash between final append and marker write is structurally
-    impossible — they're one transaction)
-  - HITL pause does NOT write a completion marker; `respond()` resume
-    DOES write it once the resumed loop completes
+  - `prompt(run_id=R)` raises `RunAlreadyClaimedError` if R is
+    currently claimed (completed_at IS NULL) on the thread; raises
+    `RunAlreadyCompletedError` if R is already completed
+  - `mark_run_complete()` is called AFTER the final append, NOT
+    atomically with it. Inject a checkpointer that raises on
+    `mark_run_complete()` and assert: messages of the run are
+    persisted; the `cubepi_runs` row exists with `completed_at IS
+    NULL`; `Agent.prompt()` raises
+    `CompletionMarkerFailedError(run_id=…)`. Retrying
+    `checkpointer.mark_run_complete(thread_id, exc.run_id)` succeeds
+    and the run becomes forkable.
+  - HITL pause does NOT call `mark_run_complete()`; `cubepi_runs`
+    row remains with `completed_at IS NULL`. `respond()` calls
+    `mark_run_complete()` once the resumed loop completes terminally.
   - fork happy path: source has 3 completed runs A, B, C →
     `fork(after_run_id=B)` produces a thread with messages of A+B
     (in source order), `runs` rows for A+B, and no

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -1,0 +1,425 @@
+# Conversation Fork — `Agent.fork()` + `Agent.fork_once()`
+
+- **Date**: 2026-06-05
+- **Status**: Draft
+- **Branch / worktree**: `2026-06-05-conversation-fork` in `.worktrees/2026-06-05-conversation-fork`
+- **Drives**: cubebox "copy this conversation from message N" UI button; future
+  A/B exploration / reflection-runner side experiments.
+
+## 1. Motivation
+
+Two related needs are unaddressed today:
+
+1. **Persistent fork.** Cubebox wants a per-assistant-message button that
+   spawns a new conversation, pre-populated with all prior messages from a
+   chosen point. The user keeps both conversations and can continue them
+   independently (compare answers, try a different next question, save a
+   branch before risky edits, etc.).
+2. **One-shot off-thread prompt.** Application code wants to ask the model a
+   follow-up question from the context of an existing thread without
+   polluting that thread's persisted history. Reflection-runner-style
+   probes, automated evaluation harnesses, scratch "what if I asked X
+   instead?" queries.
+
+The Postgres and MySQL checkpointer schemas reserved `parent_thread_id` and
+`forked_at_seq` columns for this exact eventuality (see
+`website/docs/migration/from-langgraph.md` and
+`website/docs/guides/checkpointing/postgres.md`), but no API exists yet.
+The Memory and SQLite backends have no fork hooks at all.
+
+This spec adds the missing API across all four backends and exposes it on
+`Agent` as `fork()` (persistent) and `fork_once()` (ephemeral one-shot).
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- A `Checkpointer.fork()` operation that physically copies a prefix of a
+  thread's messages under a caller-supplied new `thread_id`, records
+  lineage, and is atomic.
+- A `Checkpointer.snapshot()` operation that returns the same prefix as
+  `list[Message]` without writing anything — the shared primitive both
+  `fork()` and `fork_once()` build on.
+- `Agent.fork()` — thin wrapper over `Checkpointer.fork()`.
+- `Agent.fork_once()` — in-memory single-turn continuation from a snapshot
+  prefix; not persisted; emits its own tracing span.
+- Implementations across Memory, SQLite, Postgres, MySQL.
+- Boundary validation that rejects cuts that would orphan a `tool_call`
+  from its `tool_result`.
+- User-facing docs page under `website/docs/guides/checkpointing/`.
+
+**Non-goals**
+
+- Copy-on-write / logical pointer storage (deliberately rejected — see §3.1).
+- Forking subagent state, MCP session state, or external resources spun up
+  during the parent run.
+- Mutating the source thread (this is purely a read operation on the source).
+- A `fork_into_agent()` convenience that hands back a ready-to-use `Agent`
+  instance bound to the new thread. Caller decides what to do with the new
+  `thread_id`; constructing the next `Agent` is one line of user code and
+  keeping `Agent` state machinery out of `fork()` avoids confusing
+  "which agent instance owns which thread" questions.
+- Resuming a `fork_once()` session. By construction it is single-turn,
+  in-memory, and discarded.
+- Multi-turn ephemeral sessions. If they become a real need later they can
+  ship as a separate `EphemeralAgent` handle returned from a future call;
+  YAGNI for now.
+- A `cubepi fork` CLI subcommand. Not needed by the cubebox driving use
+  case; can be added later if it earns its keep.
+
+## 3. Design
+
+### 3.1 Storage semantics: physical copy
+
+`fork()` physically copies the prefix `[0..message_count)` of source-thread
+messages into the new thread, then records lineage metadata
+(`parent_thread_id`, `forked_at_seq`) on the new thread row. The new
+thread is fully independent — subsequent reads on either thread are
+single-thread operations.
+
+Considered and rejected: **logical pointer / copy-on-write** (store only
+parent reference + new tail in the child). Reasons:
+
+- All four backends are designed to keep a single thread's reads local.
+  Postgres uses `HASH (thread_id)` partitioning on `cubepi_messages`;
+  MySQL uses `KEY` partitioning by `thread_id`. COW reads would have to
+  span parent and child partitions, defeating that invariant.
+- The source thread is mutable in real cubepi usage: `agent.respond()`,
+  HITL deny appends synthetic messages, future compaction may rewrite
+  history. Under COW the child silently drifts when the parent changes;
+  under physical copy the child is frozen at fork time.
+- Deletion semantics: with physical copy the parent and child are
+  independently deletable. Under COW, deleting the parent either breaks
+  the child (FK violation) or wipes it (CASCADE) — neither is
+  expressible cleanly across the four backends.
+- The `parent_thread_id` + `forked_at_seq` columns retain value as pure
+  lineage metadata (UI family tree, audit, debugging) under physical
+  copy. They keep the cost of a few bytes per fork, not the cost of a
+  recursive read.
+- LangGraph's `copy_thread` uses physical copy for the same reasons.
+
+Space cost (long conversations forked many times) is acknowledged. If a
+real workload hits it we add a GC / compaction job later — that is much
+cheaper to layer on physical copy than to retrofit COW.
+
+### 3.2 Cut point: `message_count`, not `seq`
+
+The user-facing cut is **`message_count`: include the first N messages**.
+`message_count=None` copies everything currently in the thread.
+
+`seq` is intentionally NOT exposed to callers:
+
+- Cubepi's `Message` types (`UserMessage`, `AssistantMessage`,
+  `ToolResultMessage`) carry no `seq` field. Only the
+  Postgres/MySQL storage layer assigns seqs.
+- Cubebox renders messages from `Checkpointer.load()` and identifies the
+  click target by list index. "First N messages" lines up trivially with
+  that.
+- Memory and SQLite backends have no native seq column; `message_count`
+  reduces to "len of the first N elements" there.
+
+Storage-level `forked_at_seq` is still written for Postgres/MySQL
+(it equals the seq of the last copied message — for the in-memory and
+SQLite backends it equals `message_count` because seq == index+1 there).
+It is metadata; callers do not pass or read it directly.
+
+### 3.3 Boundary validation
+
+Cubepi's message protocol requires every `AssistantMessage` that emits
+`ToolCall` blocks to be followed (eventually) by `ToolResultMessage`s
+for every call before the next assistant turn. Forking mid-tool-call
+would leave the new thread in a state the provider rejects on the next
+`prompt()` call ("`tool_use` block without matching `tool_result`").
+
+`snapshot()` and `fork()` both validate the cut: if message
+`message_count - 1` is an `AssistantMessage` with unresolved
+`ToolCall`s (i.e. one of its tool_call_ids has no corresponding
+`ToolResultMessage` in the prefix), they raise `ForkBoundaryError`.
+The error message lists the unresolved `tool_call_id`s so the caller
+can re-pick a later message_count.
+
+### 3.4 Atomicity
+
+`fork()` is atomic per backend:
+
+- **Memory**: holds `asyncio.Lock`; copies under the lock.
+- **SQLite**: single `BEGIN…COMMIT`.
+- **Postgres**: single transaction; thread row INSERT + messages
+  `INSERT…SELECT WHERE thread_id=$1 AND seq <= $2`. Per-thread advisory
+  lock on the source thread (the same lock `append()` already uses for
+  monotonic seq allocation) prevents racing appends from being included
+  half-and-half.
+- **MySQL**: single transaction; thread row INSERT + `INSERT…SELECT`.
+  Uses the same locking discipline already in `append()`.
+
+If the new thread already exists, `fork()` raises
+`ThreadAlreadyExistsError` and writes nothing.
+
+If the source thread does not exist, `fork()` raises `ThreadNotFoundError`.
+
+### 3.5 What gets copied
+
+| Field | Copied? | Notes |
+|---|---|---|
+| `messages` `[0..message_count)` | yes | physical copy; new thread's seqs equal the copied parent seqs |
+| `extra` | yes | deep copy of the source JSON object |
+| `parent_thread_id` | written (new) | set to `src_thread_id` on new row |
+| `forked_at_seq` | written (new) | the seq of message `message_count - 1` (Postgres/MySQL); equals `message_count` for Memory/SQLite |
+| `extra['fork']` | written (new) | `= metadata` argument when caller supplies it |
+| `pending_request` | **no** | new thread starts clean; HITL is run-state, not history |
+| `run_id` | **no** | host-side run identifier; new thread has none |
+| `created_at` / `updated_at` | new | server-default to fork time |
+
+### 3.6 Tracing for `fork_once()`
+
+`fork_once()` runs an in-memory `Agent` instance that is never persisted.
+It emits its own root span (it does **not** nest under the source
+thread's last run span — those spans are completed and unrelated):
+
+- Span name: `cubepi.agent.fork_once`
+- Attributes:
+  - `cubepi.fork.src_thread_id`
+  - `cubepi.fork.src_message_count`
+  - `cubepi.fork.src_seq` (the storage seq of the last copied message,
+    when the source backend has one)
+  - `cubepi.model.id`, etc. — the standard cubepi tracing attributes
+- The in-process child `Agent` it runs subscribes to the standard
+  tracing middleware if the host has one bound; child events nest under
+  this span as normal.
+- The persistent `fork()` does not need a special span; existing
+  checkpointer instrumentation (if any) covers it.
+
+### 3.7 API
+
+#### `cubepi.checkpointer.base`
+
+```python
+@runtime_checkable
+class Checkpointer(Protocol):
+    # existing: load, append, save_extra, save_pending_request, load_pending_request
+
+    async def snapshot(
+        self,
+        thread_id: str,
+        *,
+        message_count: int | None = None,
+    ) -> list[Message]:
+        """Return messages [0..message_count) of `thread_id`.
+
+        `message_count=None` returns all messages currently in the thread.
+        Raises `ThreadNotFoundError`, `ForkBoundaryError`.
+        """
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        message_count: int | None = None,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        """Atomically create `new_thread_id` with the first `message_count`
+        messages of `src_thread_id`.
+
+        Records `parent_thread_id=src_thread_id` and `forked_at_seq` on
+        the new thread row. Copies `extra` deeply. Writes
+        `extra['fork'] = metadata` when `metadata` is not None.
+
+        Raises `ThreadNotFoundError`, `ThreadAlreadyExistsError`,
+        `ForkBoundaryError`.
+        """
+```
+
+#### `cubepi.checkpointer.exceptions`
+
+Add:
+
+```python
+class ThreadNotFoundError(CheckpointerError): ...
+class ThreadAlreadyExistsError(CheckpointerError): ...
+class ForkBoundaryError(CheckpointerError):
+    """message_count cuts across an unresolved tool_call/tool_result pair."""
+    def __init__(self, message_count: int, unresolved_tool_call_ids: list[str]):
+        ...
+```
+
+`CheckpointerError` is the existing base in `cubepi/checkpointer/exceptions.py`.
+
+#### `cubepi.agent.agent`
+
+```python
+class Agent(Generic[TMessage]):
+
+    async def fork(
+        self,
+        src_thread_id: str,
+        new_thread_id: str,
+        *,
+        message_count: int | None = None,
+        metadata: JsonObject | None = None,
+    ) -> None:
+        """Persistent fork. Requires `self.checkpointer`. Delegates to
+        `self.checkpointer.fork(...)`. Does NOT mutate `self`.
+        """
+
+    async def fork_once(
+        self,
+        src_thread_id: str,
+        prompt: str | list[Content],
+        *,
+        message_count: int | None = None,
+    ) -> ForkOnceResult:
+        """One-shot continuation. Reads snapshot from `self.checkpointer`,
+        constructs an ephemeral `Agent` with this agent's `model`,
+        `tools`, `middleware`, `system_prompt`; runs one full turn
+        (including any tool calls); returns the result. Never writes
+        to the checkpointer.
+        """
+```
+
+#### `cubepi.agent.types`
+
+```python
+@dataclass(frozen=True)
+class ForkOnceResult:
+    text: str
+    messages: list[Message]   # new messages produced this turn only
+    stop_reason: str
+```
+
+### 3.8 Per-backend implementation sketch
+
+- **Memory** (`cubepi/checkpointer/memory.py`): add a `dict[str, dict]`
+  of thread metadata (parent_thread_id, forked_at_seq, extra). `fork()`
+  copies the first N messages from the source list under the new key.
+  `snapshot()` slices the list. Boundary validation walks the prefix
+  once.
+- **SQLite** (`cubepi/checkpointer/sqlite.py`): a thread is currently
+  one row keyed by `thread_id`. Schema needs a small migration to add
+  `parent_thread_id`, `forked_at_seq` columns (NULL for existing
+  rows). `fork()` re-serializes the prefix into a new row.
+- **Postgres** (`cubepi/checkpointer/postgres/`): the columns already
+  exist (schema version 3). `fork()` is a single transaction:
+  - `INSERT INTO cubepi_threads (thread_id, parent_thread_id, forked_at_seq, extra, …) …`
+  - `INSERT INTO cubepi_messages (thread_id, seq, role, metadata, payload)
+     SELECT $new_thread_id, seq, role, metadata, payload
+     FROM cubepi_messages
+     WHERE thread_id=$src AND ($n IS NULL OR seq <= $cut_seq)
+     ORDER BY seq`
+  - Holds the per-thread advisory lock on `src_thread_id` so an
+    in-flight `append()` cannot make the count drift mid-copy.
+- **MySQL** (`cubepi/checkpointer/mysql/`): same idea, MySQL syntax.
+  The `cubepi_messages` table is KEY-partitioned by `thread_id` and
+  has no FK to `cubepi_threads`. Order is enforced by `ORDER BY seq`
+  in the `INSERT…SELECT`. Uses the existing locking idiom.
+
+Schema bump from v3 → v4 for Postgres/MySQL is **not** required —
+the necessary columns are already there. SQLite needs a small
+in-process migration (it has no formal schema_version table today;
+the code already handles backfills on `CREATE TABLE … IF NOT EXISTS`,
+the same pattern applies to the new columns).
+
+### 3.9 `Agent.fork_once()` execution detail
+
+1. `self._require_checkpointer()` — raises with a clear message when
+   the agent has no checkpointer bound.
+2. `snapshot = await self.checkpointer.snapshot(src_thread_id, message_count=...)`
+   — performs boundary validation.
+3. Build a transient `Agent` configured with this agent's `model`,
+   `system_prompt`, `tools`, `middleware`, and `convert_to_llm`, with
+   no `checkpointer` and no `thread_id`. Pre-seed its message history
+   with `snapshot`. The exact pre-seed hook (constructor arg vs.
+   dedicated method) is left to the implementation plan — the
+   constraint is that `fork_once()` must not reach into private
+   attributes of `Agent`.
+4. Start a `cubepi.agent.fork_once` root span. Attach a one-shot
+   listener that captures the child's new messages (everything after
+   the pre-seed length).
+5. `await child.prompt(prompt)` — runs the full turn (any tool calls
+   included).
+6. Read final assistant text + new messages from the child; close the
+   span.
+7. Return `ForkOnceResult(text, new_messages, stop_reason)`.
+
+The transient `Agent` is local to the call frame and dropped on return.
+No state leak to `self`.
+
+### 3.10 Error semantics summary
+
+| Situation | Raised |
+|---|---|
+| `self.checkpointer is None` (fork or fork_once) | `RuntimeError("fork requires a checkpointer")` |
+| `src_thread_id` does not exist | `ThreadNotFoundError(src_thread_id)` |
+| `new_thread_id` already exists (fork) | `ThreadAlreadyExistsError(new_thread_id)` |
+| `message_count < 0` | `ValueError` |
+| `message_count > len(messages)` | `ValueError` (caller asked for more than exists) |
+| cut would orphan a tool_call | `ForkBoundaryError(message_count, unresolved_ids)` |
+| `Agent.fork_once()` child run errors | propagates (same surface as `Agent.prompt()`) |
+
+## 4. Migration / Compatibility
+
+- **Protocol change**: `Checkpointer.snapshot` and `Checkpointer.fork` are
+  new methods on the `runtime_checkable` Protocol. Existing
+  user-implemented checkpointers will keep type-checking (Protocol
+  membership is structural; missing methods only matter when called).
+  Documenting the new optional surface in the checkpointer guide is
+  sufficient.
+- **Storage**: Postgres / MySQL — no migration. SQLite — additive
+  columns, in-process backfill (`ALTER TABLE … ADD COLUMN`). Memory —
+  N/A.
+- **No public API changes** to existing methods. No deprecations.
+
+## 5. Testing
+
+- **Unit / per-backend** (Memory + SQLite in-process; Postgres
+  against the bundled docker fixture; MySQL against the live test
+  server documented at `reference_mysql_test_server`):
+  - fork all messages → new thread reads back identically
+  - fork prefix → new thread holds prefix, source still holds full
+  - fork preserves `extra`; sets `parent_thread_id` + `forked_at_seq`
+  - fork copies `extra['fork']` from `metadata` arg
+  - fork does NOT copy `pending_request` / `run_id`
+  - `ThreadAlreadyExistsError` on collision; nothing written
+  - `ThreadNotFoundError` on bad source
+  - `ForkBoundaryError` when cutting mid-tool-call (and the error
+    payload lists unresolved tool_call_ids)
+  - source thread unaffected by fork (independence test)
+  - subsequent `append()` to the new thread continues seq numbering
+    from `forked_at_seq + 1`
+  - concurrent fork + append on source serializes correctly (no
+    half-copied state)
+
+- **`Agent.fork_once()` (FauxProvider)**:
+  - simple text-only follow-up returns expected final text
+  - turn with tool calls completes fully, returns new messages
+  - source thread (and its checkpointer) is byte-for-byte unchanged
+  - raises when no checkpointer bound
+  - emits a `cubepi.agent.fork_once` span with the documented
+    attributes (using the in-memory tracing exporter helper)
+
+- **`Agent.fork()` (FauxProvider)**:
+  - happy path returns None; checkpointer state is correct
+  - error pass-through (`ThreadNotFoundError`, etc.)
+
+## 6. Open questions
+
+None remaining — answers locked in during brainstorm:
+
+- Storage model → physical copy
+- Cut parameter → `message_count`
+- Caller supplies `new_thread_id` (required, not auto-generated)
+- Boundary on unresolved tool_calls → raise `ForkBoundaryError`
+- `extra` copied; `pending_request` / `run_id` not copied
+- `metadata` arg merged into `extra['fork']`
+- Spec scope → both `fork()` and `fork_once()` together
+- Both methods live on `Agent` (thin wrappers over checkpointer
+  primitives for `fork`; runtime work for `fork_once`)
+
+## 7. Out of this PR (follow-ups)
+
+- Cubebox-side wiring: new `Conversation.parent_conversation_id` column,
+  `POST /conversations/{id}/fork` endpoint, per-assistant-message UI
+  button. Lives in the cubebox repo.
+- CLI sugar (`cubepi fork`) — only if a real user asks.
+- GC / size cap for heavily forked thread trees — only if a real
+  workload hits the space cost.

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -492,9 +492,14 @@ the same pattern applies to the new columns).
    Semantics:
 
    - When `messages` is provided, `Agent` deep-copies the sequence
-     (`list(map(model_copy, messages))`) into its initial
-     `_state._messages`. The deep copy prevents external mutation of
-     the source list from corrupting agent state.
+     (`[m.model_copy(deep=True) for m in messages]`) into its initial
+     `_state._messages`. **`deep=True` is mandatory** — pydantic's
+     `model_copy()` is shallow by default, which would leave
+     `AssistantMessage.content` (a list of ToolCall / TextContent /
+     ThinkingContent), `ToolCall.arguments` (a dict), `UserMessage.content`,
+     `ToolResultMessage.content`, and the `metadata` dicts on all three
+     message variants sharing references with the source. Shallow copy
+     defeats the isolation `fork_once()` depends on.
    - When `messages` is provided AND (`thread_id` AND `checkpointer`)
      are also set, the constructor raises `ValueError`: the lazy-load
      contract in `prompt()` would either drop the preload or duplicate
@@ -566,11 +571,15 @@ detection**:
 - This spec adds an attribute `requires_hitl: bool = False` to
   `cubepi.agent.types.AgentTool` and an attribute
   `requires_hitl: bool = False` to `cubepi.middleware.base.Middleware`.
-- This spec sets `requires_hitl=True` on the `AgentTool` returned by
-  the built-in `cubepi.hitl.ask_user_tool(...)` factory and on
-  `cubepi.hitl.middleware.HitlMiddleware`. Third-party HITL tools
-  and middleware MUST set the same flag — this is the documented
-  contract for "this tool/middleware requires HITL".
+- This spec sets `requires_hitl=True` on:
+  - the `AgentTool` returned by the built-in
+    `cubepi.hitl.ask_user_tool(...)` factory, AND
+  - `cubepi.hitl.middleware.ApprovalPolicyMiddleware` (the in-tree
+    HITL base; `ConfirmToolCallMiddleware` inherits the flag through
+    subclassing).
+  Third-party HITL tools and middleware MUST set the same flag —
+  this is the documented contract for "this tool/middleware requires
+  HITL".
 - `fork_once()` scans `self.tools` and `self.middleware` and rejects
   the call if any element has `requires_hitl is True`.
 - The detection is documented in `website/docs/guides/checkpointing/forking.md`
@@ -688,10 +697,11 @@ channel) is explicit follow-up scope.
   - turn with tool calls completes fully, returns new messages
   - source thread (and its checkpointer) is byte-for-byte unchanged
   - raises `RuntimeError` when no checkpointer bound
-  - raises `RuntimeError` when an `ask_user` tool is in
-    `self.tools` (HITL pre-flight, §3.9.1)
-  - raises `RuntimeError` when `HitlMiddleware` is in
-    `self.middleware`
+  - raises `RuntimeError` when any tool in `self.tools` has
+    `requires_hitl=True` (HITL pre-flight, §3.9.1) — exercised with
+    the actual `ask_user_tool(...)` factory result, not a stub
+  - raises `RuntimeError` when `ApprovalPolicyMiddleware` (or its
+    subclass `ConfirmToolCallMiddleware`) is in `self.middleware`
   - cancellation: `asyncio.wait_for(agent.fork_once(...), timeout=…)`
     raises `TimeoutError` and the transient agent's abort signal
     fires (verified via FauxProvider abort hook)
@@ -711,6 +721,26 @@ channel) is explicit follow-up scope.
   - error pass-through (`ThreadNotFoundError`, `ThreadAlreadyExistsError`,
     `ForkBoundaryError`, `RuntimeError` for missing checkpointer)
   - does NOT mutate `self.thread_id`
+
+- **`Agent(messages=...)` constructor (§3.7a)** — a dedicated test
+  group, distinct from `fork_once()` tests, so the new constructor
+  path is exercised even if `fork_once()` is later refactored:
+  - happy path: `Agent(messages=[UserMessage(...)])` ends up with
+    those messages reflected by the next `prompt()` call
+  - `Agent(messages=[...], thread_id="t", checkpointer=cp)` raises
+    `ValueError`
+  - `Agent(messages=<invalid-prefix>)` raises `ForkBoundaryError`
+    for each §3.3 invariant violation (re-uses the
+    snapshot-validator test fixtures)
+  - **deep-copy isolation**: construct an `Agent` with a list
+    containing one `UserMessage`, one `AssistantMessage` carrying a
+    `ToolCall` (with mutable `arguments` dict), and one
+    `ToolResultMessage` (with `content` list and `metadata` dict).
+    Mutate every nested mutable field on the ORIGINAL message
+    objects after construction. Assert the agent's internal copies
+    are unchanged. Mirror the mutation against the agent and assert
+    the originals are unchanged (isolation runs both directions).
+  - `messages=None` is the no-op default (sanity check)
 
 ## 6. Open questions
 

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -131,63 +131,150 @@ for every call before the next assistant turn. Forking mid-tool-call
 would leave the new thread in a state the provider rejects on the next
 `prompt()` call ("`tool_use` block without matching `tool_result`").
 
-`snapshot()` and `fork()` both validate the cut: if message
-`message_count - 1` is an `AssistantMessage` with unresolved
-`ToolCall`s (i.e. one of its tool_call_ids has no corresponding
-`ToolResultMessage` in the prefix), they raise `ForkBoundaryError`.
-The error message lists the unresolved `tool_call_id`s so the caller
-can re-pick a later message_count.
+`snapshot()` and `fork()` validate the **entire prefix**
+`[0..message_count)`, not just the last message. The prefix is valid
+iff all of the following hold:
 
-### 3.4 Atomicity
+1. Every `ToolCall.id` produced by an `AssistantMessage` in the prefix
+   has exactly one `ToolResultMessage.tool_call_id` later in the
+   prefix that matches it.
+2. Every `ToolResultMessage.tool_call_id` in the prefix matches a
+   `ToolCall.id` produced by some earlier `AssistantMessage` in the
+   prefix.
+3. Tool-result messages for the same producing assistant turn appear
+   contiguously after that assistant turn (no other assistant turn
+   interleaves).
+
+Examples that MUST raise `ForkBoundaryError`:
+
+- `[assistant(tc-1), user(...)]` — assistant emits `tc-1` but the
+  prefix never carries its tool_result before another user turn.
+- `[assistant(tc-1), tool_result(tc-1), assistant(tc-2)]` with
+  `message_count=3` — the last assistant has an unresolved `tc-2`.
+- `[tool_result(tc-99)]` — orphan tool_result; no producer.
+- `[assistant(tc-1, tc-2), tool_result(tc-1)]` — partial close of a
+  multi-call turn; `tc-2` is unresolved.
+- `[assistant(tc-1), assistant(...)]` — two assistants in a row with
+  `tc-1` unresolved between them.
+
+The error payload lists the offending state (`unresolved_tool_call_ids`,
+`orphan_tool_result_ids`) so the caller can re-pick a valid
+`message_count`. `ForkBoundaryError` is raised before any write
+happens.
+
+The check runs in O(message_count) time and a single pass over the
+prefix; it is performed by `snapshot()` and reused by `fork()`.
+
+### 3.4 Atomicity and concurrency
 
 `fork()` is atomic per backend:
 
-- **Memory**: holds `asyncio.Lock`; copies under the lock.
-- **SQLite**: single `BEGIN…COMMIT`.
-- **Postgres**: single transaction; thread row INSERT + messages
-  `INSERT…SELECT WHERE thread_id=$1 AND seq <= $2`. Per-thread advisory
-  lock on the source thread (the same lock `append()` already uses for
-  monotonic seq allocation) prevents racing appends from being included
-  half-and-half.
-- **MySQL**: single transaction; thread row INSERT + `INSERT…SELECT`.
-  Uses the same locking discipline already in `append()`.
+- **Memory**: holds `asyncio.Lock` for the source thread (a single
+  shared lock is acceptable for this backend's scale); copies under
+  the lock. Memory backend is **single-process only by definition**;
+  this is already documented for the existing methods and applies to
+  fork unchanged. The fork doc page calls it out explicitly so users
+  do not expect fork lineage to survive a process restart.
+- **SQLite**: opens its transaction with `BEGIN IMMEDIATE` to take a
+  RESERVED lock on the database for the duration of the fork. This
+  blocks concurrent writers (`append`, `save_extra`,
+  `save_pending_request`, other `fork`s) — including writers from
+  other processes sharing the same DB file — until the fork commits
+  or rolls back. Readers (`load`, `load_pending_request`, `snapshot`)
+  continue under WAL. The existing `append()` does NOT currently use
+  `BEGIN IMMEDIATE`; this spec promotes it to `BEGIN IMMEDIATE` as
+  well so writer-vs-writer races are uniformly serialized. (The
+  promotion is a strict subset of correctness — current behavior
+  relies on aiosqlite's single-connection serialization within one
+  process; the upgrade makes the contract explicit and
+  cross-process-safe.)
+- **Postgres**: single transaction. Inside it:
+  1. `pg_advisory_xact_lock(hashtext($src_thread_id))` — the same
+     per-thread advisory lock `append()` uses, but here taken on the
+     SOURCE thread to fence racing appends to the source for the
+     duration of the fork.
+  2. `INSERT INTO cubepi_threads` for the new thread.
+  3. `INSERT INTO cubepi_messages (...) SELECT ... FROM cubepi_messages
+     WHERE thread_id=$src AND seq <= $cut_seq ORDER BY seq`.
+  4. Commit (releases the advisory lock).
 
-If the new thread already exists, `fork()` raises
-`ThreadAlreadyExistsError` and writes nothing.
+  `save_extra`, `save_pending_request`, and `compaction` on the source
+  also take this same per-thread advisory lock, so they serialize
+  against the fork.
 
-If the source thread does not exist, `fork()` raises `ThreadNotFoundError`.
+- **MySQL**: single transaction with `SELECT ... FOR UPDATE` on the
+  source thread row in `cubepi_threads` (MySQL has no advisory lock
+  equivalent that fits the model). The existing `append()` already
+  takes the same row lock; this spec confirms `save_extra`,
+  `save_pending_request`, and compaction follow suit. Then the same
+  thread-row INSERT + messages `INSERT…SELECT` as Postgres.
+
+Concurrent forks from the same source (`fork(src=X, new=A)` and
+`fork(src=X, new=B)`) serialize cleanly on the source-thread
+lock/row-lock in every backend; the two new threads end up with
+identical or differently-prefixed message sets depending on which
+fork ran first relative to any concurrent append, and either ordering
+is correct.
+
+Error pre-checks: if the new thread already exists, `fork()` raises
+`ThreadAlreadyExistsError` and writes nothing. If the source thread
+does not exist, `fork()` raises `ThreadNotFoundError`. Both checks
+happen inside the transaction so they see the same world the copy
+will see.
 
 ### 3.5 What gets copied
 
 | Field | Copied? | Notes |
 |---|---|---|
-| `messages` `[0..message_count)` | yes | physical copy; new thread's seqs equal the copied parent seqs |
-| `extra` | yes | deep copy of the source JSON object |
+| `messages` `[0..message_count)` | yes | physical copy; Postgres/MySQL preserve the source seq values for the copied range |
+| `extra` | yes | deep copy of the source JSON object (`json.loads(json.dumps(extra))`) |
 | `parent_thread_id` | written (new) | set to `src_thread_id` on new row |
-| `forked_at_seq` | written (new) | the seq of message `message_count - 1` (Postgres/MySQL); equals `message_count` for Memory/SQLite |
-| `extra['fork']` | written (new) | `= metadata` argument when caller supplies it |
+| `forked_at_seq` | written (new, Postgres/MySQL only) | seq of the last copied message. NULL for Memory and SQLite — those backends have no per-message seq column and forging a value would invite false continuation logic. The column exists in the SQLite schema for parity but is always NULL there. |
+| `extra['fork']` | written (new) when `metadata` is supplied | merge rule below |
 | `pending_request` | **no** | new thread starts clean; HITL is run-state, not history |
 | `run_id` | **no** | host-side run identifier; new thread has none |
 | `created_at` / `updated_at` | new | server-default to fork time |
 
+**`extra['fork']` merge rule.** The source's existing `extra` is
+deep-copied first. Then, if the caller passes `metadata`, fork writes
+`new_extra['fork'] = metadata` — unconditionally overwriting whatever
+key was at `extra['fork']` in the source. Rationale: a fork's `fork`
+key describes THIS fork, not the parent's fork ancestry. Lineage is
+already recoverable from the `parent_thread_id` chain in the threads
+table, so callers that want full ancestry walk the chain rather than
+reading nested `fork` blobs. Callers who want to preserve the source's
+`extra['fork']` under a different key are free to do so themselves via
+a follow-up `save_extra()` call.
+
 ### 3.6 Tracing for `fork_once()`
 
-`fork_once()` runs an in-memory `Agent` instance that is never persisted.
-It emits its own root span (it does **not** nest under the source
-thread's last run span — those spans are completed and unrelated):
+`fork_once()` emits a span named `cubepi.agent.fork_once` that:
 
-- Span name: `cubepi.agent.fork_once`
-- Attributes:
-  - `cubepi.fork.src_thread_id`
-  - `cubepi.fork.src_message_count`
-  - `cubepi.fork.src_seq` (the storage seq of the last copied message,
-    when the source backend has one)
-  - `cubepi.model.id`, etc. — the standard cubepi tracing attributes
-- The in-process child `Agent` it runs subscribes to the standard
-  tracing middleware if the host has one bound; child events nest under
-  this span as normal.
-- The persistent `fork()` does not need a special span; existing
-  checkpointer instrumentation (if any) covers it.
+- **Inherits the active OTel parent context** if one is bound when
+  `fork_once()` is called (e.g., the FastAPI request span, a
+  cubebox stream span). This is standard OTel convention; "fork_once
+  emits its own logical root" does NOT mean "detach from the
+  surrounding trace_id". A `fork_once` invoked outside any active
+  context becomes a true trace root.
+- Does **not** attempt to attach to or replay spans from the source
+  thread's prior runs. Those spans are completed and live in
+  different traces; we only carry forward the source thread's
+  identity via attributes.
+
+Attributes on the span:
+
+- `cubepi.fork.src_thread_id`
+- `cubepi.fork.src_message_count`
+- `cubepi.fork.src_seq` (Postgres/MySQL only — the storage seq of the
+  last copied message; absent for Memory/SQLite for the same reason
+  `forked_at_seq` is NULL there)
+- The standard cubepi tracing attributes (`cubepi.model.id`, etc.)
+
+The in-process child `Agent` it runs nests its agent / turn / tool
+spans under the `cubepi.agent.fork_once` span as normal.
+
+The persistent `fork()` does not need a special span; existing
+checkpointer instrumentation (if any) covers it.
 
 ### 3.7 API
 
@@ -265,7 +352,7 @@ class Agent(Generic[TMessage]):
     async def fork_once(
         self,
         src_thread_id: str,
-        prompt: str | list[Content],
+        message: str | Message | list[Message],
         *,
         message_count: int | None = None,
     ) -> ForkOnceResult:
@@ -274,6 +361,14 @@ class Agent(Generic[TMessage]):
         `tools`, `middleware`, `system_prompt`; runs one full turn
         (including any tool calls); returns the result. Never writes
         to the checkpointer.
+
+        The `message` parameter accepts the same types as
+        `Agent.prompt()` for consistency. The transient agent receives
+        the snapshot as pre-seeded history, then `prompt(message)` runs
+        the single turn.
+
+        Raises `RuntimeError` if any inherited tool or middleware
+        requires HITL (see §3.9.1).
         """
 ```
 
@@ -295,9 +390,20 @@ class ForkOnceResult:
   `snapshot()` slices the list. Boundary validation walks the prefix
   once.
 - **SQLite** (`cubepi/checkpointer/sqlite.py`): a thread is currently
-  one row keyed by `thread_id`. Schema needs a small migration to add
-  `parent_thread_id`, `forked_at_seq` columns (NULL for existing
-  rows). `fork()` re-serializes the prefix into a new row.
+  one row keyed by `thread_id`. Schema needs an additive migration to
+  add `parent_thread_id` (TEXT, NULL) and `forked_at_seq` (INTEGER,
+  always NULL). The existing checkpointer initialises its tables via
+  `CREATE TABLE IF NOT EXISTS`; the new columns are added at connect
+  time using the existing pattern (`PRAGMA table_info` probe, then
+  `ALTER TABLE … ADD COLUMN` if missing — exact form decided by the
+  plan to match what the file already does for schema upgrades).
+  `fork()` opens a transaction with `BEGIN IMMEDIATE` (RESERVED
+  lock), re-serializes the prefix into a new row, writes the
+  `parent_thread_id` reference, leaves `forked_at_seq` NULL, commits.
+  `forked_at_seq` exists in the schema purely for parity with the SQL
+  backends — SQLite stores the messages as a single serialized blob,
+  there are no per-message seqs to record, and synthesising one would
+  give callers a false invariant to depend on.
 - **Postgres** (`cubepi/checkpointer/postgres/`): the columns already
   exist (schema version 3). `fork()` is a single transaction:
   - `INSERT INTO cubepi_threads (thread_id, parent_thread_id, forked_at_seq, extra, …) …`
@@ -321,40 +427,102 @@ the same pattern applies to the new columns).
 
 ### 3.9 `Agent.fork_once()` execution detail
 
-1. `self._require_checkpointer()` — raises with a clear message when
-   the agent has no checkpointer bound.
-2. `snapshot = await self.checkpointer.snapshot(src_thread_id, message_count=...)`
-   — performs boundary validation.
-3. Build a transient `Agent` configured with this agent's `model`,
+1. `self._require_checkpointer()` — raises `RuntimeError` with a
+   clear message when the agent has no checkpointer bound.
+2. **HITL pre-flight check** (see §3.9.1) — raises before doing any
+   work if the inherited toolset is HITL-capable.
+3. `snapshot = await self.checkpointer.snapshot(src_thread_id, message_count=...)`
+   — performs the full-prefix boundary validation in §3.3.
+4. Build a transient `Agent` configured with this agent's `model`,
    `system_prompt`, `tools`, `middleware`, and `convert_to_llm`, with
-   no `checkpointer` and no `thread_id`. Pre-seed its message history
-   with `snapshot`. The exact pre-seed hook (constructor arg vs.
-   dedicated method) is left to the implementation plan — the
-   constraint is that `fork_once()` must not reach into private
-   attributes of `Agent`.
-4. Start a `cubepi.agent.fork_once` root span. Attach a one-shot
-   listener that captures the child's new messages (everything after
-   the pre-seed length).
-5. `await child.prompt(prompt)` — runs the full turn (any tool calls
+   `checkpointer=None` and `thread_id=None`. Pre-seed its message
+   history with `snapshot`.
+
+   **This requires a new public Agent surface for seeding initial
+   history.** The exact form (constructor arg `messages=...` vs. a
+   dedicated `Agent.preload(messages)` method) is decided in the
+   implementation plan, but it is in scope for THIS spec — `fork_once()`
+   MUST NOT reach into private attributes of `Agent`. The plan SHOULD
+   prefer a constructor arg because it keeps the agent's "ready to run"
+   state machine single-phase; if the plan picks a separate method,
+   document that the method must be called before any `prompt()`.
+
+5. Start a `cubepi.agent.fork_once` span (inheriting the surrounding
+   OTel context per §3.6). Capture the pre-seed length.
+6. Cancellation is propagated: if the surrounding task is cancelled
+   (or `asyncio.CancelledError` is raised), the transient agent's
+   abort signal fires and the cancellation re-raises after the agent
+   loop returns — same semantics as cancelling `Agent.prompt()`. The
+   tracing span is closed in a `finally` block with the failure
+   status set.
+7. `await child.prompt(message)` — runs the full turn (any tool calls
    included).
-6. Read final assistant text + new messages from the child; close the
-   span.
-7. Return `ForkOnceResult(text, new_messages, stop_reason)`.
+8. Read final assistant text + the messages added after the pre-seed
+   length from the child; close the span.
+9. Return `ForkOnceResult(text, new_messages, stop_reason)`.
 
 The transient `Agent` is local to the call frame and dropped on return.
 No state leak to `self`.
+
+#### 3.9.1 HITL is not supported inside `fork_once()`
+
+Two reasons HITL cannot work in `fork_once()`:
+
+1. **No persistence target.** HITL pending requests are written via
+   `Checkpointer.save_pending_request(thread_id, ...)`. The transient
+   agent has no checkpointer and no thread_id; there is nowhere to
+   persist the pause.
+2. **Worse: inherited HITL channels would write to the SOURCE thread.**
+   A real cubepi host typically constructs a
+   `CheckpointedChannel(checkpointer=cp, thread_id=conversation_id, …)`
+   and binds it to `ask_user_tool(channel)`. The channel object holds
+   the source `thread_id` by reference. Reusing such a tool inside
+   `fork_once()` would persist the fork's pending HITL request to the
+   SOURCE conversation, contaminating it. Silent failure mode.
+
+`fork_once()` therefore pre-checks `self.tools` and `self.middleware`
+for HITL involvement. Detection rule:
+
+- Any tool whose `name` is `ask_user` (cubepi's built-in HITL tool name).
+- Any middleware that is an instance of `cubepi.hitl.middleware.HitlMiddleware`
+  (or any subclass).
+- Any tool whose `name` matches a configurable host-supplied set —
+  the spec defers the exact extension hook to the plan.
+
+If any match, `fork_once()` raises:
+
+```
+RuntimeError(
+    "fork_once() does not support HITL. Found HITL-bearing tools/"
+    "middleware: <names>. Construct a different Agent without these "
+    "for ephemeral probes."
+)
+```
+
+The error is raised BEFORE the snapshot is read. The
+recommended pattern for callers that need probes with most of the
+host's tools but no HITL is to build a second `Agent` with a filtered
+toolset and call `fork_once()` on that one.
+
+This is documented in the user guide page as a known limitation.
+Lifting it (e.g., supporting in-memory HITL via a special transient
+channel) is explicit follow-up scope.
 
 ### 3.10 Error semantics summary
 
 | Situation | Raised |
 |---|---|
 | `self.checkpointer is None` (fork or fork_once) | `RuntimeError("fork requires a checkpointer")` |
+| `fork_once()` finds HITL-bearing tool/middleware (§3.9.1) | `RuntimeError("fork_once() does not support HITL: <names>")` |
 | `src_thread_id` does not exist | `ThreadNotFoundError(src_thread_id)` |
 | `new_thread_id` already exists (fork) | `ThreadAlreadyExistsError(new_thread_id)` |
 | `message_count < 0` | `ValueError` |
 | `message_count > len(messages)` | `ValueError` (caller asked for more than exists) |
-| cut would orphan a tool_call | `ForkBoundaryError(message_count, unresolved_ids)` |
+| `message_count = 0` | **valid**: clones an empty starter thread. Boundary check passes vacuously. For Postgres/MySQL, `forked_at_seq IS NULL`. The new thread row is created with no messages and acts as if just-created with a `parent_thread_id` reference. |
+| `message_count = None` | normalized to `len(messages_in_src)` — copy everything currently present |
+| cut violates any §3.3 invariant (unresolved tool_call, orphan tool_result, partial multi-call close, two assistants in a row with unresolved calls) | `ForkBoundaryError(message_count, unresolved_tool_call_ids=[…], orphan_tool_result_ids=[…])` |
 | `Agent.fork_once()` child run errors | propagates (same surface as `Agent.prompt()`) |
+| `Agent.fork_once()` is cancelled mid-turn | `asyncio.CancelledError` re-raises after transient agent abort completes |
 
 ## 4. Migration / Compatibility
 
@@ -376,30 +544,70 @@ No state leak to `self`.
   server documented at `reference_mysql_test_server`):
   - fork all messages → new thread reads back identically
   - fork prefix → new thread holds prefix, source still holds full
-  - fork preserves `extra`; sets `parent_thread_id` + `forked_at_seq`
-  - fork copies `extra['fork']` from `metadata` arg
-  - fork does NOT copy `pending_request` / `run_id`
+  - fork preserves `extra`; sets `parent_thread_id`
+  - `forked_at_seq` assertions: equals last copied seq for
+    Postgres/MySQL; IS NULL for Memory/SQLite
+  - fork copies `extra['fork']` from `metadata` arg (and overwrites
+    a pre-existing `extra['fork']` on the source — explicit test for
+    the §3.5 merge rule)
+  - fork does NOT copy `pending_request`: verified via
+    `load_pending_request(new_thread_id) is None`
+  - fork does NOT copy `run_id`
   - `ThreadAlreadyExistsError` on collision; nothing written
+    (no partial thread row, no orphan messages)
   - `ThreadNotFoundError` on bad source
-  - `ForkBoundaryError` when cutting mid-tool-call (and the error
-    payload lists unresolved tool_call_ids)
-  - source thread unaffected by fork (independence test)
-  - subsequent `append()` to the new thread continues seq numbering
-    from `forked_at_seq + 1`
+  - `ValueError` for `message_count < 0` and `message_count > len`
+  - `message_count = 0` succeeds, produces an empty new thread with
+    `parent_thread_id` set
+  - `message_count = None` copies all current messages
+  - `ForkBoundaryError` for each illegal-prefix case enumerated in
+    §3.3: unresolved tool_call at end, orphan tool_result, partial
+    multi-call close, two assistants in a row with unresolved calls.
+    The error payload lists the offending ids.
+  - source thread unaffected by fork (independence test —
+    snapshot/load source before and after, byte-equal)
+  - Postgres/MySQL only: subsequent `append()` to the new thread
+    continues seq numbering from `forked_at_seq + 1`
   - concurrent fork + append on source serializes correctly (no
-    half-copied state)
+    half-copied state) — exercise with two concurrent tasks
+  - fork-of-fork: fork A → B; fork B → C. C's `parent_thread_id`
+    points to B (not A). Walking the chain via `parent_thread_id`
+    reaches A.
+  - fork after `respond()`-injected synthetic deny: the synthetic
+    messages are in the snapshot and survive the fork
+  - SQLite cross-connection: open two separate `SQLiteCheckpointer`
+    instances against the same DB file, exercise `fork()` from one
+    while `append()` runs from the other; `BEGIN IMMEDIATE`
+    serializes the two writers correctly
 
 - **`Agent.fork_once()` (FauxProvider)**:
   - simple text-only follow-up returns expected final text
   - turn with tool calls completes fully, returns new messages
   - source thread (and its checkpointer) is byte-for-byte unchanged
-  - raises when no checkpointer bound
-  - emits a `cubepi.agent.fork_once` span with the documented
-    attributes (using the in-memory tracing exporter helper)
+  - raises `RuntimeError` when no checkpointer bound
+  - raises `RuntimeError` when an `ask_user` tool is in
+    `self.tools` (HITL pre-flight, §3.9.1)
+  - raises `RuntimeError` when `HitlMiddleware` is in
+    `self.middleware`
+  - cancellation: `asyncio.wait_for(agent.fork_once(...), timeout=…)`
+    raises `TimeoutError` and the transient agent's abort signal
+    fires (verified via FauxProvider abort hook)
+  - tracing span: emits `cubepi.agent.fork_once` with the documented
+    attributes. When called inside an existing span context, the
+    fork_once span is a child of the surrounding span (parent
+    propagation test). When called outside any span, it is a trace
+    root.
+  - The existing tracing test infrastructure
+    (`tests/tracing/conftest.py` in-memory exporter, if present) is
+    reused; if no such infrastructure exists, the plan stage
+    introduces a minimal `InMemorySpanExporter` fixture as a
+    prerequisite.
 
 - **`Agent.fork()` (FauxProvider)**:
   - happy path returns None; checkpointer state is correct
-  - error pass-through (`ThreadNotFoundError`, etc.)
+  - error pass-through (`ThreadNotFoundError`, `ThreadAlreadyExistsError`,
+    `ForkBoundaryError`, `RuntimeError` for missing checkpointer)
+  - does NOT mutate `self.thread_id`
 
 ## 6. Open questions
 

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -1,326 +1,328 @@
-# Conversation Fork — `Agent.fork()` + `Agent.fork_once()`
+# Conversation Fork — `Agent.fork()` + `Agent.fork_once()` (run-based)
 
 - **Date**: 2026-06-05
-- **Status**: Draft
+- **Status**: Draft (v2 — run-based fork model)
 - **Branch / worktree**: `2026-06-05-conversation-fork` in `.worktrees/2026-06-05-conversation-fork`
-- **Drives**: cubebox "copy this conversation from message N" UI button; future
-  A/B exploration / reflection-runner side experiments.
+- **Drives**: cubebox "copy this conversation from this assistant reply" UI button;
+  one-shot off-thread probes; data model foundation for future
+  `Agent.delete_run()`.
 
 ## 1. Motivation
 
-Two related needs are unaddressed today:
+Three related needs are unaddressed today:
 
 1. **Persistent fork.** Cubebox wants a per-assistant-message button that
-   spawns a new conversation, pre-populated with all prior messages from a
-   chosen point. The user keeps both conversations and can continue them
-   independently (compare answers, try a different next question, save a
-   branch before risky edits, etc.).
+   spawns a new conversation, pre-populated with the prior runs up to a
+   chosen point. The user keeps both conversations and continues them
+   independently.
 2. **One-shot off-thread prompt.** Application code wants to ask the model a
-   follow-up question from the context of an existing thread without
-   polluting that thread's persisted history. Reflection-runner-style
-   probes, automated evaluation harnesses, scratch "what if I asked X
-   instead?" queries.
+   follow-up from the context of an existing thread without polluting the
+   thread's persisted history. Reflection-runner probes, automated eval
+   harnesses, scratch "what if I asked X instead?" queries.
+3. **Future: per-run deletion.** Cubebox plans a "delete this run" UX
+   (undo the last exchange). Not in this PR, but the data model laid down
+   here MUST make it a one-line query later.
 
-The Postgres and MySQL checkpointer schemas reserved `parent_thread_id` and
-`forked_at_seq` columns for this exact eventuality (see
+A "run" in cubepi is **one `Agent.prompt()` call from start to terminal
+completion** — the user message that initiated it plus every tool_use /
+tool_result / assistant message produced before the loop exits with a
+terminal stop_reason. Multi-step assistant loops live inside a single run.
+HITL pause/resume keep the same run_id across the suspension.
+
+The Postgres and MySQL checkpointer schemas reserved `parent_thread_id`
+and `forked_at_seq` columns for fork (see
 `website/docs/migration/from-langgraph.md` and
-`website/docs/guides/checkpointing/postgres.md`), but no API exists yet.
-The Memory and SQLite backends have no fork hooks at all.
-
-This spec adds the missing API across all four backends and exposes it on
-`Agent` as `fork()` (persistent) and `fork_once()` (ephemeral one-shot).
+`website/docs/guides/checkpointing/postgres.md`), but no API existed.
+The Memory and SQLite backends have no fork hooks at all. **Run-as-a-unit
+is a new concept**: today only `cubepi_threads.pending_request.run_id`
+mentions run, and only for HITL recovery. This spec extends run identity
+to every message and adds a per-run completion marker.
 
 ## 2. Goals / Non-goals
 
 **Goals**
 
-- A `Checkpointer.fork()` operation that physically copies a prefix of a
-  thread's messages under a caller-supplied new `thread_id`, records
-  lineage, and is atomic.
-- A `Checkpointer.snapshot()` operation that returns the same prefix as
-  `list[Message]` without writing anything — the shared primitive both
-  `fork()` and `fork_once()` build on.
-- `Agent.fork()` — thin wrapper over `Checkpointer.fork()`.
-- `Agent.fork_once()` — in-memory single-turn continuation from a snapshot
-  prefix; not persisted; emits its own tracing span.
+- Per-message `run_id` field on `Message` (all three variants), persisted
+  by every backend.
+- New `cubepi_run_completions` storage per backend recording which runs
+  have finished cleanly.
+- `Agent.prompt(message, *, run_id=None) -> str` (accept-or-generate;
+  returns the run_id actually used).
+- `Checkpointer.fork(src, new, *, after_run_id, metadata=None) -> None`
+  — physical copy of all messages of completed runs up through
+  `after_run_id`.
+- `Checkpointer.snapshot(thread_id, *, after_run_id) -> list[Message]`
+  — shared read primitive used by fork_once and tests.
+- `Agent.fork(src, new, *, after_run_id, metadata=None) -> None` — thin
+  wrapper over `Checkpointer.fork()`.
+- `Agent.fork_once(src, message, *, after_run_id) -> ForkOnceResult` —
+  in-memory single-turn continuation from a snapshot prefix.
 - Implementations across Memory, SQLite, Postgres, MySQL.
-- Boundary validation that rejects cuts that would orphan a `tool_call`
-  from its `tool_result`.
 - User-facing docs page under `website/docs/guides/checkpointing/`.
+- Foundation that makes `Agent.delete_run(thread_id, run_id, …)` a small
+  follow-up PR.
 
 **Non-goals**
 
-- Copy-on-write / logical pointer storage (deliberately rejected — see §3.1).
-- Forking subagent state, MCP session state, or external resources spun up
-  during the parent run.
-- Mutating the source thread (this is purely a read operation on the source).
-- A `fork_into_agent()` convenience that hands back a ready-to-use `Agent`
-  instance bound to the new thread. Caller decides what to do with the new
-  `thread_id`; constructing the next `Agent` is one line of user code and
-  keeping `Agent` state machinery out of `fork()` avoids confusing
-  "which agent instance owns which thread" questions.
-- Resuming a `fork_once()` session. By construction it is single-turn,
-  in-memory, and discarded.
-- Multi-turn ephemeral sessions. If they become a real need later they can
-  ship as a separate `EphemeralAgent` handle returned from a future call;
-  YAGNI for now.
-- A `cubepi fork` CLI subcommand. Not needed by the cubebox driving use
-  case; can be added later if it earns its keep.
+- `Agent.delete_run()` itself — separate follow-up spec.
+- Fork at message granularity (the cubebox UX and forward design only
+  ever fork at run boundaries; per-message cuts were considered and
+  rejected with the user — they produce surprising states mid-tool-call
+  and are not needed). The previously-discussed `message_count` /
+  `Message.id` / `after_response_id` parameters are NOT in this spec.
+- Copy-on-write storage (rejected for the same partitioning / mutation
+  reasons documented in §3.1).
+- Backfilling run identity into pre-existing messages. Legacy messages
+  remain `run_id=NULL` and are not forkable / not deletable — see §3.6.4.
+- A `fork_into_agent()` convenience or `fork_and_switch`. Caller owns
+  what to do with `new_thread_id`.
+- Resuming a `fork_once()` session.
+- A `cubepi fork` CLI subcommand.
 
 ## 3. Design
 
 ### 3.1 Storage semantics: physical copy
 
-`fork()` physically copies the prefix `[0..message_count)` of source-thread
-messages into the new thread, then records lineage metadata
-(`parent_thread_id`, `forked_at_seq`) on the new thread row. The new
-thread is fully independent — subsequent reads on either thread are
-single-thread operations.
+`fork()` physically copies messages of all completed runs up through
+`after_run_id` to the new thread, then records lineage
+(`parent_thread_id`, `forked_at_seq` for SQL backends) and copies the
+relevant `cubepi_run_completions` rows so the new thread keeps its
+run history.
 
-Considered and rejected: **logical pointer / copy-on-write** (store only
-parent reference + new tail in the child). Reasons:
+Rejected: **logical pointer / COW**. Same rationale as v1:
 
-- All four backends are designed to keep a single thread's reads local.
-  Postgres uses `HASH (thread_id)` partitioning on `cubepi_messages`;
-  MySQL uses `KEY` partitioning by `thread_id`. COW reads would have to
-  span parent and child partitions, defeating that invariant.
-- The source thread is mutable in real cubepi usage: `agent.respond()`,
-  HITL deny appends synthetic messages, future compaction may rewrite
-  history. Under COW the child silently drifts when the parent changes;
-  under physical copy the child is frozen at fork time.
-- Deletion semantics: with physical copy the parent and child are
-  independently deletable. Under COW, deleting the parent either breaks
-  the child (FK violation) or wipes it (CASCADE) — neither is
-  expressible cleanly across the four backends.
-- The `parent_thread_id` + `forked_at_seq` columns retain value as pure
-  lineage metadata (UI family tree, audit, debugging) under physical
-  copy. They keep the cost of a few bytes per fork, not the cost of a
-  recursive read.
-- LangGraph's `copy_thread` uses physical copy for the same reasons.
+- All four backends partition / shard reads per `thread_id`
+  (HASH/KEY partitioning in Postgres/MySQL; per-thread dict slot in
+  Memory). COW reads span parent and child partitions.
+- The source thread is mutable (`agent.respond()` injects synthetic
+  messages; future compaction may rewrite). Under COW the child
+  silently drifts; physical copy freezes the child at fork time.
+- Deletion semantics are clean under physical copy: parent and child
+  independently deletable. Under COW, parent deletion breaks the child.
+- The reserved `parent_thread_id` + `forked_at_seq` columns retain
+  value as lineage metadata at no recurring read cost.
+- LangGraph's `copy_thread` makes the same choice.
 
-Space cost (long conversations forked many times) is acknowledged. If a
-real workload hits it we add a GC / compaction job later — that is much
-cheaper to layer on physical copy than to retrofit COW.
+### 3.2 Run as the unit of fork
 
-### 3.2 Cut point: `message_count`, not `seq`
+The **only** fork handle is `after_run_id: str`. The new thread contains
+exactly the messages of every completed run on the source up through and
+including `after_run_id` (in source seq order).
 
-The user-facing cut is **`message_count`: include the first N messages**.
-`message_count=None` copies everything currently in the thread.
+Why a run is the right unit:
 
-`seq` is intentionally NOT exposed to callers:
+- A run is the atomic transaction the user thinks in ("I asked X, agent
+  did its thing, gave me an answer"). Cubebox's UI button maps directly
+  to "fork after this exchange".
+- A run boundary is by construction a clean cut. Inside a run there may
+  be unresolved `tool_use` blocks awaiting `tool_result`s; once the run
+  is marked complete (terminal stop_reason, no pending HITL), no
+  unresolved tool calls remain. So **the v1 spec's `ForkBoundaryError`
+  / mid-tool-call invariants vanish structurally**: there is no API to
+  ask for a cut mid-run, so no boundary check is needed.
+- It generalizes to the future `delete_run()` cleanly:
+  `DELETE FROM cubepi_messages WHERE thread_id=? AND run_id=?` is a
+  one-line operation backed by the same `run_id` column the fork uses
+  for lookup.
 
-- Cubepi's `Message` types (`UserMessage`, `AssistantMessage`,
-  `ToolResultMessage`) carry no `seq` field. Only the
-  Postgres/MySQL storage layer assigns seqs.
-- Cubebox renders messages from `Checkpointer.load()` and identifies the
-  click target by list index. "First N messages" lines up trivially with
-  that.
-- Memory and SQLite backends have no native seq column; `message_count`
-  reduces to "len of the first N elements" there.
-
-Storage-level `forked_at_seq` is written only for Postgres/MySQL
-(equal to the seq of the last copied message). It is NULL for Memory
-and SQLite — see §3.5 for the canonical rule. It is metadata; callers
-do not pass or read it directly.
-
-### 3.3 Boundary validation
-
-Cubepi's message protocol requires every `AssistantMessage` that emits
-`ToolCall` blocks to be followed (eventually) by `ToolResultMessage`s
-for every call before the next assistant turn. Forking mid-tool-call
-would leave the new thread in a state the provider rejects on the next
-`prompt()` call ("`tool_use` block without matching `tool_result`").
-
-`snapshot()` and `fork()` validate the **entire prefix**
-`[0..message_count)`, not just the last message. The prefix is valid
-iff all of the following hold:
-
-1. Every `ToolCall.id` produced by an `AssistantMessage` in the prefix
-   has exactly one `ToolResultMessage.tool_call_id` later in the
-   prefix that matches it.
-2. Every `ToolResultMessage.tool_call_id` in the prefix matches a
-   `ToolCall.id` produced by some earlier `AssistantMessage` in the
-   prefix.
-3. Tool-result messages for the same producing assistant turn appear
-   contiguously after that assistant turn (no other assistant turn
-   interleaves).
-
-Examples that MUST raise `ForkBoundaryError`:
-
-- `[assistant(tc-1), user(...)]` — assistant emits `tc-1` but the
-  prefix never carries its tool_result before another user turn.
-- `[assistant(tc-1), tool_result(tc-1), assistant(tc-2)]` with
-  `message_count=3` — the last assistant has an unresolved `tc-2`.
-- `[tool_result(tc-99)]` — orphan tool_result; no producer.
-- `[assistant(tc-1, tc-2), tool_result(tc-1)]` — partial close of a
-  multi-call turn; `tc-2` is unresolved.
-- `[assistant(tc-1), assistant(...)]` — two assistants in a row with
-  `tc-1` unresolved between them.
-
-The error payload lists the offending state (`unresolved_tool_call_ids`,
-`orphan_tool_result_ids`) so the caller can re-pick a valid
-`message_count`. `ForkBoundaryError` is raised before any write
-happens.
-
-The check runs in O(message_count) time and a single pass over the
-prefix; it is performed by `snapshot()` and reused by `fork()`.
-
-### 3.4 Atomicity and concurrency
+### 3.3 Atomicity and concurrency
 
 `fork()` is atomic per backend:
 
-- **Memory**: holds `asyncio.Lock` for the source thread (a single
-  shared lock is acceptable for this backend's scale); copies under
-  the lock. Memory backend is **single-process only by definition**;
-  this is already documented for the existing methods and applies to
-  fork unchanged. The fork doc page calls it out explicitly so users
-  do not expect fork lineage to survive a process restart.
-- **SQLite**: opens its transaction with `BEGIN IMMEDIATE` to take a
-  RESERVED lock on the database for the duration of the fork. This
-  blocks concurrent writers (`append`, `save_extra`,
-  `save_pending_request`, other `fork`s) — including writers from
-  other processes sharing the same DB file — until the fork commits
-  or rolls back. Readers (`load`, `load_pending_request`, `snapshot`)
-  continue under WAL. The existing `append()` does NOT currently use
-  `BEGIN IMMEDIATE`; this spec promotes it to `BEGIN IMMEDIATE` as
-  well so writer-vs-writer races are uniformly serialized. (The
-  promotion is a strict subset of correctness — current behavior
-  relies on aiosqlite's single-connection serialization within one
-  process; the upgrade makes the contract explicit and
-  cross-process-safe.)
+- **Memory**: `asyncio.Lock`; copy messages, completions row, and
+  lineage under the lock. Memory backend is single-process only by
+  definition (existing limitation, documented for fork too).
+- **SQLite**: `BEGIN IMMEDIATE` (RESERVED lock) wraps the entire fork
+  (validation, completion lookup, message copy, completions copy,
+  thread_extra insert with lineage). The existing `append()` /
+  `save_extra()` / `save_pending_request()` are also promoted to
+  `BEGIN IMMEDIATE` so writer-vs-writer races are uniformly
+  serialized, including across processes sharing the DB file.
+  At connect time the checkpointer sets `PRAGMA busy_timeout = 5000`.
+  If the 5 s window elapses without acquiring the lock, the
+  `aiosqlite.OperationalError` propagates as
+  `CheckpointerLockTimeoutError`.
+- **Postgres**: single transaction. Takes
+  `pg_advisory_xact_lock(hashtext($src_thread_id))` — the same
+  per-thread advisory lock `append()` / `save_extra()` /
+  `save_pending_request()` use — to fence racing appends on the source
+  for the duration of the fork. Then `INSERT INTO cubepi_threads`,
+  `INSERT INTO cubepi_messages … SELECT …`,
+  `INSERT INTO cubepi_run_completions … SELECT …`. Commit releases
+  the lock.
+- **MySQL**: single transaction with `SELECT … FOR UPDATE` on the
+  source `cubepi_threads` row. The existing `append()` already takes
+  the same row lock; this spec confirms `save_extra` /
+  `save_pending_request` follow suit. Then the same three INSERTs.
 
-  **SQLITE_BUSY contract.** When the immediate-lock acquisition
-  contends with another writer, SQLite returns `SQLITE_BUSY`. The
-  spec defines a deterministic policy:
+Concurrent forks from the same source serialize on the per-thread
+lock/row-lock; identical or different message-set outcomes both
+correct depending on append interleaving.
 
-  - At connect time the checkpointer sets `PRAGMA busy_timeout = 5000`
-    (5 seconds) — SQLite internally retries lock acquisition for that
-    long before raising. This is set unconditionally for all writer
-    operations, not just fork.
-  - If the 5 s window elapses without acquiring the lock, the
-    `aiosqlite.OperationalError("database is locked")` propagates as
-    a new typed error `CheckpointerLockTimeoutError(CheckpointerError)`
-    so callers can distinguish it from boundary / not-found / collision
-    errors. No further in-process retry is attempted — that's the
-    caller's policy decision.
-  - `BEGIN IMMEDIATE` (RESERVED lock) is the right strength: it lets
-    readers continue (good for UI list refresh during a fork) but
-    blocks the next writer. `BEGIN EXCLUSIVE` would needlessly stall
-    reads. The trade-off is documented in the SQLite section of
-    `website/docs/guides/checkpointing/`.
+Error pre-checks happen inside the transaction so they see the same
+world the copy will see:
 
-  The 5 s default and the new typed error apply to fork, append,
-  save_extra, and save_pending_request uniformly.
-- **Postgres**: single transaction. Inside it:
-  1. `pg_advisory_xact_lock(hashtext($src_thread_id))` — the same
-     per-thread advisory lock `append()` uses, but here taken on the
-     SOURCE thread to fence racing appends to the source for the
-     duration of the fork.
-  2. `INSERT INTO cubepi_threads` for the new thread.
-  3. `INSERT INTO cubepi_messages (...) SELECT ... FROM cubepi_messages
-     WHERE thread_id=$src AND seq <= $cut_seq ORDER BY seq`.
-  4. Commit (releases the advisory lock).
+- new thread already exists → `ThreadAlreadyExistsError`, nothing
+  written
+- source thread does not exist → `ThreadNotFoundError`
+- `after_run_id` has no completion marker on the source thread →
+  `RunNotCompletedError`
 
-  `save_extra`, `save_pending_request`, and `compaction` on the source
-  also take this same per-thread advisory lock, so they serialize
-  against the fork.
+### 3.4 What gets copied
 
-- **MySQL**: single transaction with `SELECT ... FOR UPDATE` on the
-  source thread row in `cubepi_threads` (MySQL has no advisory lock
-  equivalent that fits the model). The existing `append()` already
-  takes the same row lock; this spec confirms `save_extra`,
-  `save_pending_request`, and compaction follow suit. Then the same
-  thread-row INSERT + messages `INSERT…SELECT` as Postgres.
-
-Concurrent forks from the same source (`fork(src=X, new=A)` and
-`fork(src=X, new=B)`) serialize cleanly on the source-thread
-lock/row-lock in every backend; the two new threads end up with
-identical or differently-prefixed message sets depending on which
-fork ran first relative to any concurrent append, and either ordering
-is correct.
-
-Error pre-checks: if the new thread already exists, `fork()` raises
-`ThreadAlreadyExistsError` and writes nothing. If the source thread
-does not exist, `fork()` raises `ThreadNotFoundError`. Both checks
-happen inside the transaction so they see the same world the copy
-will see.
-
-### 3.5 What gets copied
-
-| Field | Copied? | Notes |
+| Field / row | Copied? | Notes |
 |---|---|---|
-| `messages` `[0..message_count)` | yes | physical copy. Postgres/MySQL preserve the source seq values for the copied range. SQLite copies the JSON payloads under fresh global `id`s — its `messages.id` is a global auto-increment, not a per-thread seq, so identity is not meaningful to preserve. Memory copies in-list order. |
-| `extra` | yes | deep copy of the source JSON object (`json.loads(json.dumps(extra))`) |
-| `parent_thread_id` | written (new) | set to `src_thread_id` on new row |
-| `forked_at_seq` | written (new, Postgres/MySQL only) | seq of the last copied message. Memory and SQLite do NOT store this — neither has a per-message seq, and forging a value would invite false continuation logic. No `forked_at_seq` column is added to SQLite's `thread_extra`, and no field is added to Memory's `CheckpointData`. Lineage for those backends comes from `parent_thread_id` alone. |
-| `extra['fork']` | written (new) when `metadata` is supplied | merge rule below |
+| `cubepi_messages` rows with `seq <= last_seq_of(after_run_id)` | yes | physical copy; PG/MySQL preserve source `seq` values for the copied range. SQLite copies the JSON payloads under fresh global `id`s (its `messages.id` is a global auto-increment, not a per-thread seq). Memory copies in-list order. Each copied row keeps its original `run_id` value. |
+| `cubepi_run_completions` rows for the copied runs | yes | so the new thread can be further forked / deleted by run |
+| `extra` | yes | deep copy of the source JSON object |
+| `parent_thread_id` | written (new) | set to `src_thread_id` on the new thread row |
+| `forked_at_seq` | written (PG/MySQL only) | the `seq` of the last message of `after_run_id`. Memory and SQLite store no equivalent — those backends have no per-message seq column and lineage is recoverable from `parent_thread_id` + `cubepi_run_completions` alone. |
+| `extra['fork']` | written (new) when `metadata` arg supplied | overwrites any pre-existing `extra['fork']` on source (lineage is recoverable via the `parent_thread_id` chain) |
 | `pending_request` | **no** | new thread starts clean; HITL is run-state, not history |
-| `run_id` | **no** | host-side run identifier; new thread has none |
+| `cubepi_threads.run_id` (the host-side HITL marker, NOT a run on this thread) | **no** | new thread has no run in flight |
 | `created_at` / `updated_at` | new | server-default to fork time |
 
-**`extra['fork']` merge rule.** The source's existing `extra` is
-deep-copied first. Then, if the caller passes `metadata`, fork writes
-`new_extra['fork'] = metadata` — unconditionally overwriting whatever
-key was at `extra['fork']` in the source. Rationale: a fork's `fork`
-key describes THIS fork, not the parent's fork ancestry. Lineage is
-already recoverable from the `parent_thread_id` chain in the threads
-table, so callers that want full ancestry walk the chain rather than
-reading nested `fork` blobs. Callers who want to preserve the source's
-`extra['fork']` under a different key are free to do so themselves via
-a follow-up `save_extra()` call.
+### 3.5 Tracing for `fork_once()`
 
-### 3.6 Tracing for `fork_once()`
+Unchanged from v1:
 
-`fork_once()` emits a span named `cubepi.agent.fork_once` that:
-
-- **Inherits the active OTel parent context** if one is bound when
-  `fork_once()` is called (e.g., the FastAPI request span, a
-  cubebox stream span). This is standard OTel convention; "fork_once
-  emits its own logical root" does NOT mean "detach from the
-  surrounding trace_id". A `fork_once` invoked outside any active
-  context becomes a true trace root.
-- Does **not** attempt to attach to or replay spans from the source
-  thread's prior runs. Those spans are completed and live in
-  different traces; we only carry forward the source thread's
-  identity via attributes.
-
-Attributes on the span:
-
-- `cubepi.fork.src_thread_id`
-- `cubepi.fork.src_message_count`
-- `cubepi.fork.src_seq` (Postgres/MySQL only — the storage seq of the
-  last copied message; absent for Memory/SQLite for the same reason
-  `forked_at_seq` is NULL there)
-- The standard cubepi tracing attributes (`cubepi.model.id`, etc.)
-
-The in-process child `Agent` it runs nests its agent / turn / tool
-spans under the `cubepi.agent.fork_once` span as normal.
+- Span name: `cubepi.agent.fork_once`
+- Inherits the active OTel parent context if one is bound; otherwise
+  becomes a true trace root. Does NOT attempt to attach to or replay
+  spans from the source thread's prior runs.
+- Attributes: `cubepi.fork.src_thread_id`, `cubepi.fork.after_run_id`,
+  `cubepi.fork.src_seq` (PG/MySQL only — the seq of the last copied
+  message), plus the standard cubepi tracing attributes.
+- The in-process child Agent's spans nest under this span.
 
 The persistent `fork()` does not need a special span; existing
-checkpointer instrumentation (if any) covers it.
+checkpointer instrumentation covers it.
 
-### 3.7 API
+### 3.6 Run lifecycle in cubepi
+
+#### 3.6.1 `Agent.prompt()` signature change
+
+```python
+class Agent(Generic[TMessage]):
+    async def prompt(
+        self,
+        message: str | Message | list[Message],
+        *,
+        run_id: str | None = None,
+    ) -> str: ...
+```
+
+`run_id` is accept-or-generate:
+
+- If the caller supplies a string, cubepi uses it verbatim.
+- If `None`, cubepi generates one via `uuid.uuid4().hex` (no host
+  dependency on uuid7; cubebox can keep generating its own and pass it
+  in — single source of truth).
+- The return value is the run_id actually in effect, so the caller can
+  store it / cross-check.
+
+The active `run_id` is threaded through the agent loop to
+`Checkpointer.append()` by stamping it on every `Message` instance
+about to be appended. **`Checkpointer.append()` signature does not
+change** — the run_id rides on the messages themselves
+(`Message.run_id` field, §3.6.5).
+
+If the caller supplies a `run_id` that already has a completion marker
+on the source thread, `prompt()` raises `RunAlreadyCompletedError` —
+runs are append-only; you cannot continue or re-run a completed run.
+(Use a new `run_id` for a new exchange.)
+
+#### 3.6.2 Completion marker — when written
+
+The marker `cubepi_run_completions(thread_id, run_id, completed_at)`
+is written **inside the same transaction as the final `append()` of
+the run** — atomic with the last message. The agent loop signals
+"this is the last append of the run" via a flag on the checkpointer
+call (or via a dedicated `Checkpointer.complete_run()` call made in
+the same lock window — exact form decided in the implementation plan,
+but the requirement is atomicity).
+
+Trigger conditions for writing the marker:
+
+- The agent loop exits with a terminal stop_reason (`end_turn`,
+  `tool_use_completed` followed by `end_turn`, etc. — any
+  non-suspended terminal state)
+- AND no pending HITL request remains for this run
+
+If `prompt()` returns because of:
+
+- HITL pause (pending_request set) → marker NOT written; the run is
+  resumed later by `respond()`.
+- Exception / abort / cancellation → marker NOT written; the run is
+  abandoned. Its messages remain on the thread under the same
+  `run_id`, but `fork(after_run_id=X)` raises `RunNotCompletedError`,
+  and the future `delete_run(X)` can clean them up.
+
+#### 3.6.3 HITL pause / resume continuity
+
+A run that pauses for HITL keeps its `run_id` across the suspension.
+
+- `Agent.prompt(message, run_id=R)` runs partway, hits HITL → writes
+  `pending_request` with `run_id=R` (existing schema v3 mechanism), no
+  completion marker.
+- `Agent.respond(question_id, answer)` recovers `run_id=R` from
+  `pending_request` (it's already there), continues the same run,
+  writes the completion marker when the resumed loop terminates
+  cleanly.
+
+`Agent.respond()` signature does **not** change. The run_id is
+sourced from `pending_request`.
+
+#### 3.6.4 Legacy data
+
+Messages persisted before this spec carry `run_id = NULL`. No
+completion markers exist for them. Consequence:
+
+- `fork(src_thread_id, …, after_run_id=X)` on a legacy thread raises
+  `RunNotCompletedError` for every `X` because no marker exists.
+- Future `delete_run(thread_id, run_id)` will likewise have nothing
+  to target.
+- Legacy threads remain readable (`load()` works); only the
+  by-run operations are blocked.
+
+No backfill is provided. (We can not reliably reconstruct historical
+run boundaries from messages alone — multi-step tool_use sequences
+look like multiple runs.) Users who need to fork a legacy
+conversation can manually start a new conversation; the loss is
+limited to "no clone shortcut on threads that predate the upgrade".
+
+#### 3.6.5 `Message.run_id` field
+
+```python
+class UserMessage(BaseModel):
+    ...
+    run_id: str | None = None     # NEW
+
+class AssistantMessage(BaseModel):
+    ...
+    run_id: str | None = None     # NEW
+
+class ToolResultMessage(BaseModel):
+    ...
+    run_id: str | None = None     # NEW
+```
+
+Default `None` preserves backward compatibility for callers that
+construct `Message`s directly without going through `Agent.prompt()`.
+The agent loop populates it from the active run before every append.
+
+### 3.7 API surface
 
 #### `cubepi.checkpointer.base`
-
-`CheckpointData` (the return type of `load()`) gains one optional
-field so callers can read the lineage of a loaded thread:
 
 ```python
 @dataclass
 class CheckpointData:
     messages: list[Message] = field(default_factory=list)
     extra: JsonObject = field(default_factory=dict)
-    parent_thread_id: str | None = None   # NEW — None for non-fork threads
-```
+    parent_thread_id: str | None = None     # NEW (v1 had this too)
 
-Memory and SQLite backends populate this from the new `parent_thread_id`
-they store (CheckpointData attr / `thread_extra` column respectively).
-Postgres and MySQL populate it from `cubepi_threads.parent_thread_id`.
-The field is unconditionally present on every load; backends that
-have no lineage information set it to `None`.
 
-```python
 @runtime_checkable
 class Checkpointer(Protocol):
     # existing: load, append, save_extra, save_pending_request, load_pending_request
@@ -329,12 +331,12 @@ class Checkpointer(Protocol):
         self,
         thread_id: str,
         *,
-        message_count: int | None = None,
+        after_run_id: str,
     ) -> list[Message]:
-        """Return messages [0..message_count) of `thread_id`.
+        """Return all messages of completed runs up through `after_run_id`
+        (inclusive), in source order.
 
-        `message_count=None` returns all messages currently in the thread.
-        Raises `ThreadNotFoundError`, `ForkBoundaryError`.
+        Raises `ThreadNotFoundError`, `RunNotCompletedError`.
         """
 
     async def fork(
@@ -342,105 +344,115 @@ class Checkpointer(Protocol):
         src_thread_id: str,
         new_thread_id: str,
         *,
-        message_count: int | None = None,
+        after_run_id: str,
         metadata: JsonObject | None = None,
     ) -> None:
-        """Atomically create `new_thread_id` with the first `message_count`
-        messages of `src_thread_id`.
-
-        Records `parent_thread_id=src_thread_id` and `forked_at_seq` on
-        the new thread row. Copies `extra` deeply. Writes
-        `extra['fork'] = metadata` when `metadata` is not None.
+        """Atomically create `new_thread_id` populated with the messages
+        of every completed run on `src_thread_id` up through
+        `after_run_id`. Copies `cubepi_run_completions` rows for the
+        included runs. Records `parent_thread_id=src_thread_id` and
+        (PG/MySQL only) `forked_at_seq`. Copies `extra` deeply. Writes
+        `extra['fork'] = metadata` when `metadata` is supplied.
 
         Raises `ThreadNotFoundError`, `ThreadAlreadyExistsError`,
-        `ForkBoundaryError`.
+        `RunNotCompletedError`.
+        """
+
+    async def complete_run(
+        self,
+        thread_id: str,
+        run_id: str,
+        last_messages: list[Message],
+    ) -> None:
+        """Atomically append `last_messages` to the thread AND write the
+        `cubepi_run_completions` row for `(thread_id, run_id)`.
+
+        Called by the agent loop on terminal-state exit only. Replaces
+        the final `append()` of the run — the agent loop normally uses
+        `append()` for intermediate messages of a run and
+        `complete_run()` for the last batch. Idempotent: a second call
+        with the same `(thread_id, run_id)` is an error
+        (`RunAlreadyCompletedError`) since runs are append-only.
         """
 ```
 
 #### `cubepi.checkpointer.exceptions`
 
-Today, `cubepi/checkpointer/exceptions.py` only defines schema-related
-errors (`CubepiSchemaError`, `CubepiSchemaUninitialized`,
-`CubepiSchemaMismatch`). There is no shared base for runtime-operation
-errors. This spec adds one alongside the new fork errors so callers
-have a single `except` surface:
-
 ```python
 class CheckpointerError(Exception):
     """Base class for cubepi checkpointer runtime errors.
 
-    Separate from CubepiSchemaError: schema errors are about the DB
-    being incompatible with the library; CheckpointerError is about
-    runtime operation outcomes (missing thread, lock timeout, fork
-    boundary violations, etc.).
+    Separate from CubepiSchemaError (which is about DB-vs-library
+    schema incompatibility). CheckpointerError is for runtime
+    operation outcomes (missing thread, lock timeout, run state, etc.).
     """
 
 
 class ThreadNotFoundError(CheckpointerError): ...
 class ThreadAlreadyExistsError(CheckpointerError): ...
 
+
+class RunNotCompletedError(CheckpointerError):
+    """No completion marker for (thread_id, run_id). The run either
+    does not exist on this thread, was paused for HITL and never
+    resumed, or failed / was aborted before terminal completion."""
+
+
+class RunAlreadyCompletedError(CheckpointerError):
+    """The run already has a completion marker. Runs are append-only;
+    start a new run with a different run_id."""
+
+
 class CheckpointerLockTimeoutError(CheckpointerError):
     """SQLite (or other locking backend) could not acquire the writer
-    lock within the configured busy_timeout. See §3.4."""
-
-
-class ForkBoundaryError(CheckpointerError):
-    """The prefix violates one of the §3.3 tool-call/tool-result invariants."""
-    def __init__(
-        self,
-        message_count: int,
-        *,
-        unresolved_tool_call_ids: list[str] | None = None,
-        orphan_tool_result_ids: list[str] | None = None,
-    ):
-        # At least one of unresolved_tool_call_ids / orphan_tool_result_ids
-        # is non-empty. Both may be present for prefixes with multiple
-        # protocol violations of different kinds.
-        ...
+    lock within the configured busy_timeout. See §3.3."""
 ```
-
-`CheckpointerError` is a NEW base added by this spec; it does NOT
-subclass `CubepiSchemaError` (different concern). Tests assert that
-all four new errors are catchable via `except CheckpointerError`.
 
 #### `cubepi.agent.agent`
 
 ```python
 class Agent(Generic[TMessage]):
+    def __init__(
+        self,
+        *,
+        # ... all existing args unchanged ...
+        messages: Sequence[Message] | None = None,
+    ):
+        """`messages`: pre-seed initial history for ephemeral runs
+        (used by fork_once). Deep-copies via `m.model_copy(deep=True)`.
+        Raises `ValueError` if `messages` is combined with
+        `thread_id` + `checkpointer` (pre-seed conflicts with lazy
+        load). The exact validation of pre-seeded messages is
+        backend-agnostic at this point (no §3.3-style invariants);
+        callers passing arbitrary `messages` are on their own."""
+
+    async def prompt(
+        self,
+        message: str | Message | list[Message],
+        *,
+        run_id: str | None = None,
+    ) -> str:
+        """See §3.6.1. Returns the run_id actually used."""
 
     async def fork(
         self,
         src_thread_id: str,
         new_thread_id: str,
         *,
-        message_count: int | None = None,
+        after_run_id: str,
         metadata: JsonObject | None = None,
     ) -> None:
         """Persistent fork. Requires `self.checkpointer`. Delegates to
-        `self.checkpointer.fork(...)`. Does NOT mutate `self`.
-        """
+        `self.checkpointer.fork(...)`. Does NOT mutate `self`."""
 
     async def fork_once(
         self,
         src_thread_id: str,
         message: str | Message | list[Message],
         *,
-        message_count: int | None = None,
+        after_run_id: str,
     ) -> ForkOnceResult:
-        """One-shot continuation. Reads snapshot from `self.checkpointer`,
-        constructs an ephemeral `Agent` with this agent's `model`,
-        `tools`, `middleware`, `system_prompt`; runs one full turn
-        (including any tool calls); returns the result. Never writes
-        to the checkpointer.
-
-        The `message` parameter accepts the same types as
-        `Agent.prompt()` for consistency. The transient agent receives
-        the snapshot as pre-seeded history, then `prompt(message)` runs
-        the single turn.
-
-        Raises `RuntimeError` if any inherited tool or middleware
-        requires HITL (see §3.9.1).
-        """
+        """See §3.8."""
 ```
 
 #### `cubepi.agent.types`
@@ -453,414 +465,346 @@ class ForkOnceResult:
     stop_reason: str
 ```
 
-### 3.8 Per-backend implementation sketch
+### 3.8 `Agent.fork_once()` execution detail
 
-- **Memory** (`cubepi/checkpointer/memory.py`): today it holds
-  `dict[str, CheckpointData]` keyed by `thread_id`, where
-  `CheckpointData` already carries `messages: list[Message]` and
-  `extra: JsonObject`. The current implementation has no lock — this
-  spec adds an `asyncio.Lock` for the fork transaction (the existing
-  methods are single-statement dict mutations that don't strictly
-  need it, but the lock keeps fork's read-validate-write atomic).
-  `CheckpointData` gains one optional field: `parent_thread_id: str
-  | None = None` (defaults to None for the no-fork case). `fork()`
-  takes the lock, slices the first `message_count` messages from
-  `src.messages` (deep-copying each via `model_copy(deep=True)`),
-  deep-copies `src.extra`, merges `extra['fork']=metadata` per §3.5,
-  and stores `CheckpointData(messages=..., extra=...,
-  parent_thread_id=src_thread_id)` under the new key. `snapshot()`
-  slices in-list order and runs the §3.3 validator. `forked_at_seq`
-  is not stored — Memory has no seq concept.
-- **SQLite** (`cubepi/checkpointer/sqlite.py`): the existing schema
-  is **three flat tables**, NOT a single thread row with a blob:
-  - `messages (id INTEGER PRIMARY KEY AUTOINCREMENT, thread_id TEXT,
-    message_json TEXT, created_at REAL)` — one row per message;
-    `id` is a global auto-increment sequence (not per-thread monotonic),
-    `thread_id` is a filter column with no index/constraint.
-  - `thread_extra (thread_id TEXT PRIMARY KEY, extra_json TEXT)` —
-    per-thread JSON extra.
-  - `thread_pending_request (thread_id TEXT PRIMARY KEY, …)` — HITL.
-
-  There is no `threads` table today. This spec extends `thread_extra`
-  to also carry lineage metadata (it is already the per-thread
-  metadata row keyed by `thread_id`, so this avoids inventing a
-  fourth table):
-
-  - Add `parent_thread_id TEXT NULL` column to `thread_extra`.
-  - Do NOT add `forked_at_seq` — SQLite has no per-thread seq to
-    record (the `messages.id` column is a global counter, not a
-    per-thread sequence, and copied rows get fresh ids on INSERT).
-    Per §3.5 this column is Postgres/MySQL-only.
-
-  The new column is added at connect time using the existing pattern
-  the file already uses for the `run_id` backfill (`PRAGMA table_info`
-  probe + `ALTER TABLE thread_extra ADD COLUMN parent_thread_id TEXT`
-  if missing). Pre-existing rows get NULL — there is no lineage to
-  reconstruct.
-
-  `fork()` runs inside a single `BEGIN IMMEDIATE` transaction
-  (RESERVED lock — see §3.4):
-
-  1. Validate source exists (`SELECT 1 FROM messages WHERE thread_id=?
-     LIMIT 1` OR `SELECT 1 FROM thread_extra WHERE thread_id=?`) →
-     `ThreadNotFoundError` if neither hits.
-  2. Validate new thread does not exist (same probes against
-     `new_thread_id`) → `ThreadAlreadyExistsError` if either hits.
-  3. Snapshot + boundary validation per §3.3 (reads `messages` ordered
-     by `id` LIMIT `message_count`, deserializes, validates prefix).
-  4. Copy messages: for the first `message_count` rows (ordered by
-     `id`), insert new rows with `thread_id = new_thread_id` and the
-     same `message_json`. New rows get fresh `id` values from the
-     global sequence — copied row identity is NOT preserved (this is
-     the §3.5 table footnote about SQLite).
-  5. Insert lineage row:
-     `INSERT INTO thread_extra (thread_id, extra_json, parent_thread_id)
-      VALUES (?, ?, ?)` — with deep-copied source `extra_json`
-     (merging `extra['fork']=metadata` per §3.5 before serializing)
-     and `parent_thread_id = src_thread_id`. If the source has no
-     `thread_extra` row (extra was never written), the new row still
-     gets inserted with `extra_json='{}'` and the parent reference.
-  6. Commit (releases the lock). Lock-timeout / SQLITE_BUSY → see
-     §3.4 contract (`CheckpointerLockTimeoutError`).
-
-  `pending_request` / `run_id` are not copied (their `thread_pending_request`
-  rows are not touched for `new_thread_id`).
-- **Postgres** (`cubepi/checkpointer/postgres/`): the columns already
-  exist (schema version 3). `fork()` is a single transaction:
-  - `INSERT INTO cubepi_threads (thread_id, parent_thread_id, forked_at_seq, extra, …) …`
-  - `INSERT INTO cubepi_messages (thread_id, seq, role, metadata, payload)
-     SELECT $new_thread_id, seq, role, metadata, payload
-     FROM cubepi_messages
-     WHERE thread_id=$src AND ($n IS NULL OR seq <= $cut_seq)
-     ORDER BY seq`
-  - Holds the per-thread advisory lock on `src_thread_id` so an
-    in-flight `append()` cannot make the count drift mid-copy.
-- **MySQL** (`cubepi/checkpointer/mysql/`): same idea, MySQL syntax.
-  The `cubepi_messages` table is KEY-partitioned by `thread_id` and
-  has no FK to `cubepi_threads`. Order is enforced by `ORDER BY seq`
-  in the `INSERT…SELECT`. Uses the existing locking idiom.
-
-Schema bump from v3 → v4 for Postgres/MySQL is **not** required —
-the necessary columns are already there. SQLite needs a small
-in-process migration (it has no formal schema_version table today;
-the code already handles backfills on `CREATE TABLE … IF NOT EXISTS`,
-the same pattern applies to the new columns).
-
-### 3.9 `Agent.fork_once()` execution detail
-
-1. `self._require_checkpointer()` — raises `RuntimeError` with a
-   clear message when the agent has no checkpointer bound.
-2. **HITL pre-flight check** (see §3.9.1) — raises before doing any
-   work if the inherited toolset is HITL-capable.
-3. `snapshot = await self.checkpointer.snapshot(src_thread_id, message_count=...)`
-   — performs the full-prefix boundary validation in §3.3.
-4. Build a transient `Agent` configured with this agent's `model`,
-   `system_prompt`, `tools`, `middleware`, and `convert_to_llm`, with
-   `checkpointer=None` and `thread_id=None`. Pre-seed its message
-   history with `snapshot` via the new constructor argument
-   `messages=...` (see §3.7a below).
-
-   #### 3.7a — Required public `Agent` API addition
-
-   This spec adds one new constructor argument to `Agent.__init__`:
-
-   ```python
-   class Agent(Generic[TMessage]):
-       def __init__(
-           self,
-           *,
-           # ... all existing args unchanged ...
-           messages: Sequence[Message] | None = None,
-       ):
-           ...
-   ```
-
-   Semantics:
-
-   - When `messages` is provided, `Agent` deep-copies the sequence
-     (`[m.model_copy(deep=True) for m in messages]`) into its initial
-     `_state._messages`. **`deep=True` is mandatory** — pydantic's
-     `model_copy()` is shallow by default, which would leave
-     `AssistantMessage.content` (a list of ToolCall / TextContent /
-     ThinkingContent), `ToolCall.arguments` (a dict), `UserMessage.content`,
-     `ToolResultMessage.content`, and the `metadata` dicts on all three
-     message variants sharing references with the source. Shallow copy
-     defeats the isolation `fork_once()` depends on.
-   - When `messages` is provided AND (`thread_id` AND `checkpointer`)
-     are also set, the constructor raises `ValueError`: the lazy-load
-     contract in `prompt()` would either drop the preload or duplicate
-     history. Pre-seeding is for ephemeral agents only.
-   - When `messages` is provided AND any of the messages violates the
-     §3.3 boundary invariants, `Agent.__init__` raises
-     `ForkBoundaryError` (the same validator function powers both
-     `Checkpointer.snapshot()` and the constructor — single source of
-     truth).
-   - When `messages` is `None`, behavior is unchanged from today.
-
-   `fork_once()` uses this argument. `fork_once()` MUST NOT touch
-   any private `Agent` attribute. No `Agent.preload(...)` method is
-   added — keeping pre-seeding in `__init__` makes the agent's
-   "ready to run" lifecycle single-phase.
-
+1. `self._require_checkpointer()` — `RuntimeError` if no checkpointer.
+2. HITL pre-flight (§3.8.1) — `RuntimeError` if inherited tools or
+   middleware mark `requires_hitl=True`.
+3. `snapshot = await self.checkpointer.snapshot(src_thread_id,
+   after_run_id=...)` — propagates
+   `ThreadNotFoundError` / `RunNotCompletedError`.
+4. Build a transient `Agent` with this agent's `model`, `system_prompt`,
+   `tools`, `middleware`, `convert_to_llm`, `messages=snapshot`,
+   `checkpointer=None`, `thread_id=None`.
 5. Start a `cubepi.agent.fork_once` span (inheriting the surrounding
-   OTel context per §3.6). Capture the pre-seed length.
-6. Cancellation is **best-effort**, not bounded. If the surrounding
-   task is cancelled (or `asyncio.CancelledError` is raised), the
-   transient agent's abort signal fires; the agent loop honors the
-   signal at each tool/turn checkpoint; cancellation re-raises after
-   the agent loop returns. This matches `Agent.prompt()` cancellation.
-
-   Caveat: cubepi tools are not required to honor the abort signal
-   mid-call (a tool can run a blocking subprocess and ignore the
-   signal until it returns). In that case `fork_once()` blocks until
-   the offending tool returns, then re-raises `CancelledError`. The
-   spec does NOT add an unconditional hard timeout — that would
-   change the cancellation surface for all of `Agent.prompt()` /
-   `fork_once()` consistently and is out of scope. Callers that need
-   a hard wall-clock bound MUST wrap with `asyncio.wait_for(...)` AND
-   accept that a poorly-behaved tool will still hold the task until
-   it returns. This is documented in the user guide.
-
-   The tracing span is closed in a `finally` block with status
-   `error` and the cancellation tag set, regardless of how long the
-   cancellation actually takes to land.
-7. `await child.prompt(message)` — runs the full turn (any tool calls
-   included).
-8. Read final assistant text + the messages added after the pre-seed
+   OTel context per §3.5). Capture the pre-seed length.
+6. Cancellation is best-effort, not bounded — same caveats as
+   `Agent.prompt()` (a tool that ignores abort can hold the task until
+   it returns). Span is closed in `finally` with the appropriate
+   status.
+7. `await child.prompt(message, run_id=<fresh-uuid>)`. The fresh run_id
+   is internal — never persisted (no checkpointer), but populated on
+   the in-memory messages so observers see consistent metadata.
+8. Read final assistant text + messages added after the pre-seed
    length from the child; close the span.
 9. Return `ForkOnceResult(text, new_messages, stop_reason)`.
 
-The transient `Agent` is local to the call frame and dropped on return.
-No state leak to `self`.
-
-#### 3.9.1 HITL is not supported inside `fork_once()`
+#### 3.8.1 HITL is not supported inside `fork_once()`
 
 Two reasons HITL cannot work in `fork_once()`:
 
 1. **No persistence target.** HITL pending requests are written via
    `Checkpointer.save_pending_request(thread_id, ...)`. The transient
-   agent has no checkpointer and no thread_id; there is nowhere to
-   persist the pause.
-2. **Worse: inherited HITL channels would write to the SOURCE thread.**
-   A real cubepi host typically constructs a
+   agent has no checkpointer and no thread_id.
+2. **Worse: inherited HITL channels write to the source thread.** A
+   host typically constructs
    `CheckpointedChannel(checkpointer=cp, thread_id=conversation_id, …)`
    and binds it to `ask_user_tool(channel)`. The channel object holds
-   the source `thread_id` by reference. Reusing such a tool inside
-   `fork_once()` would persist the fork's pending HITL request to the
-   SOURCE conversation, contaminating it. Silent failure mode.
+   the source `thread_id`. Reusing such a tool in `fork_once()` would
+   persist a pending HITL request to the source thread — silent
+   contamination.
 
-`fork_once()` therefore pre-checks `self.tools` and `self.middleware`
-for HITL involvement. Name-based detection is bypassable (anyone can
-wrap `ask_user_tool` and rename it), so the spec uses **marker-based
-detection**:
+Detection (marker-based, bypass-proof):
 
-- This spec adds an attribute `requires_hitl: bool = False` to
-  `cubepi.agent.types.AgentTool` and an attribute
-  `requires_hitl: bool = False` to `cubepi.middleware.base.Middleware`.
-- This spec sets `requires_hitl=True` on:
-  - the `AgentTool` returned by the built-in
-    `cubepi.hitl.ask_user_tool(...)` factory, AND
-  - `cubepi.hitl.middleware.ApprovalPolicyMiddleware` (the in-tree
-    HITL base; `ConfirmToolCallMiddleware` inherits the flag through
-    subclassing).
-  Third-party HITL tools and middleware MUST set the same flag —
-  this is the documented contract for "this tool/middleware requires
-  HITL".
-- `fork_once()` scans `self.tools` and `self.middleware` and rejects
-  the call if any element has `requires_hitl is True`.
-- The detection is documented in `website/docs/guides/checkpointing/forking.md`
-  with the cross-link to the contract: third-party HITL implementers
-  must set the flag or they break `fork_once()` safety guarantees.
+- New attribute `requires_hitl: bool = False` on
+  `cubepi.agent.types.AgentTool` and `cubepi.middleware.base.Middleware`.
+- Set `True` on the `AgentTool` returned by
+  `cubepi.hitl.ask_user_tool(...)` and on
+  `cubepi.hitl.middleware.ApprovalPolicyMiddleware`
+  (`ConfirmToolCallMiddleware` inherits via subclassing).
+- Third-party HITL tools / middleware MUST set the same flag.
+- `fork_once()` scans `self.tools` and `self.middleware`; any
+  `requires_hitl=True` element triggers `RuntimeError` BEFORE any
+  snapshot is read.
 
-Channel-binding inspection (walking each tool's closure to find a
-`CheckpointedChannel` pointing at the source thread) was considered
-and rejected: cubepi tools are constructed as closures or partials
-with no structural channel exposure, so the check would be
-non-portable and easy to evade. A boolean marker is uniformly
-discoverable and self-documenting.
+### 3.9 Per-backend implementation sketch
 
-If any match, `fork_once()` raises:
+#### Postgres / MySQL
 
-```
-RuntimeError(
-    "fork_once() does not support HITL. Found HITL-bearing tools/"
-    "middleware: <names>. Construct a different Agent without these "
-    "for ephemeral probes."
-)
-```
+Existing schema is at version 3. This spec bumps to **version 4** with
+two additive changes (alembic migration in cubebox / cubepi-using apps):
 
-The error is raised BEFORE the snapshot is read. The
-recommended pattern for callers that need probes with most of the
-host's tools but no HITL is to build a second `Agent` with a filtered
-toolset and call `fork_once()` on that one.
+- `ALTER TABLE cubepi_messages ADD COLUMN run_id VARCHAR/TEXT NULL`
+  + index `(thread_id, run_id)`.
+- New table `cubepi_run_completions(thread_id TEXT/VARCHAR, run_id
+  TEXT/VARCHAR, completed_at TIMESTAMPTZ, PRIMARY KEY (thread_id,
+  run_id), FOREIGN KEY (thread_id) REFERENCES cubepi_threads)`.
+  Postgres: `HASH (thread_id)` partitioned to match `cubepi_messages`.
+  MySQL: `KEY (thread_id)` partitioned, no FK (consistent with
+  `cubepi_messages`).
 
-This is documented in the user guide page as a known limitation.
-Lifting it (e.g., supporting in-memory HITL via a special transient
-channel) is explicit follow-up scope.
+`fork()` in one transaction:
+
+1. Advisory lock / `FOR UPDATE` on the source thread.
+2. `SELECT MAX(seq) AS last_seq FROM cubepi_messages WHERE thread_id =
+   $src AND seq <= (SELECT MAX(seq) FROM cubepi_messages WHERE
+   thread_id = $src AND run_id = $after_run_id)`
+   AND `EXISTS (SELECT 1 FROM cubepi_run_completions WHERE thread_id =
+   $src AND run_id = $after_run_id)` → if no row,
+   `RunNotCompletedError`.
+3. `INSERT INTO cubepi_threads (thread_id, parent_thread_id,
+   forked_at_seq, extra, …) VALUES ($new, $src, $last_seq,
+   $merged_extra, …)` — `ThreadAlreadyExistsError` on PK violation.
+4. `INSERT INTO cubepi_messages (thread_id, seq, role, run_id,
+   metadata, payload) SELECT $new, seq, role, run_id, metadata, payload
+   FROM cubepi_messages WHERE thread_id = $src AND seq <= $last_seq
+   ORDER BY seq`.
+5. `INSERT INTO cubepi_run_completions (thread_id, run_id,
+   completed_at) SELECT $new, run_id, completed_at FROM
+   cubepi_run_completions WHERE thread_id = $src AND run_id IN
+   (SELECT DISTINCT run_id FROM cubepi_messages WHERE thread_id = $src
+   AND seq <= $last_seq)`.
+6. Commit.
+
+`complete_run()` in one transaction:
+
+- Same advisory lock / `FOR UPDATE` on `thread_id`.
+- `INSERT INTO cubepi_messages …` for `last_messages` (allocating seqs).
+- `INSERT INTO cubepi_run_completions (thread_id, run_id,
+  completed_at) VALUES (?, ?, now())` —
+  `RunAlreadyCompletedError` on PK violation.
+- Commit.
+
+`append()` (existing) is unchanged in surface but must persist
+`message.run_id` into the new column.
+
+#### SQLite
+
+Schema additions at connect time using the existing PRAGMA-probe +
+`ALTER TABLE` pattern (the file already does this for `run_id` on
+`thread_pending_request`):
+
+- `ALTER TABLE messages ADD COLUMN run_id TEXT NULL`.
+- `CREATE TABLE IF NOT EXISTS run_completions (thread_id TEXT NOT
+  NULL, run_id TEXT NOT NULL, completed_at REAL NOT NULL DEFAULT
+  (julianday('now')), PRIMARY KEY (thread_id, run_id))`.
+- `ALTER TABLE thread_extra ADD COLUMN parent_thread_id TEXT NULL`.
+
+`fork()`:
+
+1. `BEGIN IMMEDIATE`.
+2. Validate source exists; validate `(src_thread_id, after_run_id)`
+   has a `run_completions` row → else `RunNotCompletedError`.
+3. Validate new thread does not exist (probe `messages` /
+   `thread_extra` / `run_completions` for `new_thread_id`) →
+   `ThreadAlreadyExistsError`.
+4. `INSERT INTO messages (thread_id, run_id, message_json) SELECT
+   $new, run_id, message_json FROM messages WHERE thread_id = $src
+   AND id <= (SELECT MAX(id) FROM messages WHERE thread_id = $src AND
+   run_id = $after_run_id) ORDER BY id`. New rows get fresh global
+   `id`s (the `messages.id` column is a global auto-increment;
+   identity is not preserved across the copy, but per-thread row
+   order is).
+5. `INSERT INTO run_completions (thread_id, run_id, completed_at)
+   SELECT $new, run_id, completed_at FROM run_completions WHERE
+   thread_id = $src AND run_id IN (SELECT DISTINCT run_id FROM
+   messages WHERE thread_id = $src AND id <= $cut_id)`.
+6. `INSERT INTO thread_extra (thread_id, extra_json, parent_thread_id)
+   VALUES ($new, $merged_extra_json, $src)`.
+7. Commit.
+
+`complete_run()`:
+
+- `BEGIN IMMEDIATE`.
+- `INSERT INTO messages …` for each `last_messages` element (each
+  carrying its `run_id`).
+- `INSERT INTO run_completions (thread_id, run_id) VALUES (?, ?)` →
+  `RunAlreadyCompletedError` if `(thread_id, run_id)` PK conflict.
+- Commit.
+
+`append()` is also wrapped in `BEGIN IMMEDIATE` (uniform writer
+discipline; see §3.3). `PRAGMA busy_timeout = 5000` set at connect.
+
+No `forked_at_seq` column added — SQLite has no per-thread seq.
+
+#### Memory
+
+`MemoryCheckpointer` today is `dict[str, CheckpointData]`. This spec:
+
+- Extends `CheckpointData` with `parent_thread_id: str | None = None`.
+- Adds an internal `dict[str, set[str]]` mapping
+  `thread_id -> set of completed run_ids`.
+- Adds an `asyncio.Lock` for fork (existing single-statement methods
+  do not strictly need one, but fork is multi-step).
+- `Message.run_id` is just a field — Memory persists the whole
+  Message via `model_dump`, so no extra storage scaffolding.
+
+`fork()` under the lock:
+
+1. Source-exists check, new-thread-does-not-exist check.
+2. Look up the completed run_ids set; if `after_run_id` not there →
+   `RunNotCompletedError`.
+3. Walk `src.messages`, find the index of the last message with
+   `run_id == after_run_id`. Take prefix `[0..idx+1)`. Deep-copy
+   each message (`model_copy(deep=True)`).
+4. Compute the subset of `src`'s completed run_ids that appear in the
+   prefix; carry that set under the new thread_id.
+5. Deep-copy `src.extra`; merge `extra['fork']=metadata` per §3.4.
+6. Store `CheckpointData(messages=…, extra=…,
+   parent_thread_id=src_thread_id)` under `new_thread_id`.
+
+`complete_run()`:
+
+- Append `last_messages` to `src.messages`.
+- Add `run_id` to the completed-runs set; if already present →
+  `RunAlreadyCompletedError`.
+
+No `forked_at_seq` field — Memory has no seq.
 
 ### 3.10 Error semantics summary
 
 | Situation | Raised |
 |---|---|
 | `self.checkpointer is None` (fork or fork_once) | `RuntimeError("fork requires a checkpointer")` |
-| `fork_once()` finds HITL-bearing tool/middleware (§3.9.1) | `RuntimeError("fork_once() does not support HITL: <names>")` |
+| `fork_once()` finds HITL-bearing tool/middleware (§3.8.1) | `RuntimeError("fork_once() does not support HITL: <names>")` |
 | `src_thread_id` does not exist | `ThreadNotFoundError(src_thread_id)` |
 | `new_thread_id` already exists (fork) | `ThreadAlreadyExistsError(new_thread_id)` |
-| `message_count < 0` | `ValueError` |
-| `message_count > len(messages)` | `ValueError` (caller asked for more than exists) |
-| `message_count = 0` | **valid**: clones an empty starter thread. Boundary check passes vacuously. For Postgres/MySQL, `forked_at_seq IS NULL`. The new thread row is created with no messages and acts as if just-created with a `parent_thread_id` reference. |
-| `message_count = None` | normalized to `len(messages_in_src)` — copy everything currently present |
-| cut violates any §3.3 invariant (unresolved tool_call, orphan tool_result, partial multi-call close, two assistants in a row with unresolved calls) | `ForkBoundaryError(message_count, unresolved_tool_call_ids=[…], orphan_tool_result_ids=[…])` |
+| `after_run_id` has no completion marker on the source thread | `RunNotCompletedError(thread_id=src_thread_id, run_id=after_run_id)` |
+| `prompt(run_id=R)` and `R` already has a completion marker on the thread | `RunAlreadyCompletedError(thread_id=..., run_id=R)` |
 | `Agent.fork_once()` child run errors | propagates (same surface as `Agent.prompt()`) |
-| `Agent.fork_once()` is cancelled mid-turn | `asyncio.CancelledError` re-raises after transient agent abort completes (best-effort — see §3.9 step 6) |
-| SQLite cannot acquire writer lock within `busy_timeout` | `CheckpointerLockTimeoutError` (applies to fork, append, save_extra, save_pending_request uniformly) |
+| `Agent.fork_once()` is cancelled mid-turn | `asyncio.CancelledError` re-raises after transient agent abort completes (best-effort; see §3.8 step 6) |
+| SQLite cannot acquire writer lock within `busy_timeout` | `CheckpointerLockTimeoutError` |
 | `Agent(messages=..., thread_id=X, checkpointer=Y)` | `ValueError` — pre-seeding conflicts with lazy load |
-| `Agent(messages=...)` with a prefix that violates §3.3 | `ForkBoundaryError` (constructor uses the same validator as snapshot()) |
 
 ## 4. Migration / Compatibility
 
-- **Protocol change**: `Checkpointer.snapshot` and `Checkpointer.fork` are
-  new methods on the `runtime_checkable` Protocol. Existing
-  user-implemented checkpointers will keep type-checking (Protocol
-  membership is structural; missing methods only matter when called).
-  Documenting the new optional surface in the checkpointer guide is
-  sufficient.
-- **Storage**: Postgres / MySQL — no migration. SQLite — additive
-  columns, in-process backfill (`ALTER TABLE … ADD COLUMN`). Memory —
-  N/A.
-- **No public API changes** to existing methods. No deprecations.
+- **Protocol change**: `Checkpointer.snapshot`, `Checkpointer.fork`,
+  `Checkpointer.complete_run` are new methods on the
+  `runtime_checkable` Protocol. Existing user-implemented checkpointers
+  keep type-checking; they only fail when the new methods are actually
+  called.
+- **`Agent.prompt()` signature**: adds an optional keyword `run_id`
+  and changes return type from `None` to `str`. Returning a value that
+  the caller previously ignored is **not** a breaking change for
+  callers that wrote `await agent.prompt(msg)` — the return value can
+  simply be discarded. Callers using `await agent.prompt(msg); …` keep
+  working. Documenting the new return type in the migration page is
+  enough.
+- **`Agent.respond()` signature**: unchanged. Internal logic reads
+  `run_id` from `pending_request`.
+- **Storage**: Postgres / MySQL — schema v3 → v4 (additive: one
+  column on `cubepi_messages`, one new table `cubepi_run_completions`,
+  matching partition strategy). Alembic migration provided.
+  SQLite — additive `ALTER TABLE` and `CREATE TABLE IF NOT EXISTS` at
+  connect time. Memory — N/A.
+- **Existing messages** (`run_id IS NULL`) remain readable; not
+  forkable / not deletable (§3.6.4). No backfill.
+- **Existing `cubepi_threads.pending_request.run_id`** semantics
+  unchanged — it is the host-side run identifier for HITL recovery.
+  The new `Message.run_id` is structurally the same string; the same
+  value lives in both places during an active HITL pause, and that is
+  intentional (the value passed to `Agent.prompt(run_id=…)` is the
+  value written to `pending_request.run_id` and to every appended
+  `Message.run_id`).
 
 ## 5. Testing
 
-- **Unit / per-backend** (Memory + SQLite in-process; Postgres
-  against the bundled docker fixture; MySQL against the live test
-  server documented at `reference_mysql_test_server`):
-  - fork all messages → new thread reads back identically
-  - fork prefix → new thread holds prefix, source still holds full
-  - fork preserves `extra`; sets `parent_thread_id`
-  - subsequent `load(new_thread_id).parent_thread_id == src_thread_id`
-    (CheckpointData lineage round-trip)
-  - `load(src_thread_id).parent_thread_id is None` for an originally
-    non-forked source
-  - Lineage assertions:
-    - Postgres/MySQL: `forked_at_seq` equals the last copied seq
-    - Memory/SQLite: no `forked_at_seq` field/column exists; lineage
-      is asserted only via `load(new_thread_id).parent_thread_id ==
-      src_thread_id`
-  - fork copies `extra['fork']` from `metadata` arg (and overwrites
-    a pre-existing `extra['fork']` on the source — explicit test for
-    the §3.5 merge rule)
-  - fork does NOT copy `pending_request`: verified via
-    `load_pending_request(new_thread_id) is None`
-  - fork does NOT copy `run_id`
+- **Unit / per-backend** (Memory + SQLite in-process; Postgres against
+  the bundled docker fixture; MySQL against the live test server at
+  `reference_mysql_test_server`):
+
+  - `prompt()` accept-or-generate: caller-supplied run_id is used
+    verbatim; None generates a uuid; return value matches what was
+    persisted on appended messages
+  - `prompt()` raises `RunAlreadyCompletedError` if caller passes a
+    run_id that already has a completion marker
+  - completion marker written atomically with the final append (test:
+    crash between final append and marker write is structurally
+    impossible — they're one transaction)
+  - HITL pause does NOT write a completion marker; `respond()` resume
+    DOES write it once the resumed loop completes
+  - fork happy path: source has 3 completed runs A, B, C →
+    `fork(after_run_id=B)` produces a thread with messages of A+B
+    (in source order), `run_completions` rows for A+B, and no
+    pending_request
+  - fork preserves `extra`; sets `parent_thread_id`; (PG/MySQL) sets
+    `forked_at_seq` to the last copied seq
+  - `forked_at_seq` is NOT stored for Memory/SQLite (no column/field)
+  - `extra['fork']` overwrites any pre-existing `extra['fork']` on
+    the source
+  - `fork` does NOT copy `pending_request` / host-side run_id
   - `ThreadAlreadyExistsError` on collision; nothing written
-    (no partial thread row, no orphan messages)
   - `ThreadNotFoundError` on bad source
-  - `ValueError` for `message_count < 0` and `message_count > len`
-  - `message_count = 0` succeeds, produces an empty new thread with
-    `parent_thread_id` set
-  - `message_count = None` copies all current messages
-  - `ForkBoundaryError` for each illegal-prefix case enumerated in
-    §3.3: unresolved tool_call at end, orphan tool_result, partial
-    multi-call close, two assistants in a row with unresolved calls.
-    The error payload lists the offending ids.
-  - source thread unaffected by fork (independence test —
-    snapshot/load source before and after, byte-equal)
-  - Postgres/MySQL only: subsequent `append()` to the new thread
-    continues seq numbering from `forked_at_seq + 1`
-  - concurrent fork + append on source serializes correctly (no
-    half-copied state) — exercise with two concurrent tasks
-  - fork-of-fork: fork A → B; fork B → C. C's `parent_thread_id`
-    points to B (not A). C's `forked_at_seq` is computed from the
-    snapshot of B at C's fork point — it is B's seq value at that
-    point, NOT A's original seq (Postgres/MySQL preserve source seqs
-    on copy, so if B's seqs come from A unchanged the value
-    coincides; but the spec contract is "immediate source's seq",
-    which the test asserts explicitly). Walking the chain via
-    `parent_thread_id` reaches A.
-  - fork after `respond()`-injected synthetic deny: the synthetic
-    messages are in the snapshot and survive the fork
-  - SQLite cross-connection: open two separate `SQLiteCheckpointer`
-    instances against the same DB file, exercise `fork()` from one
-    while `append()` runs from the other; `BEGIN IMMEDIATE`
-    serializes the two writers correctly
+  - `RunNotCompletedError` when `after_run_id` does not exist, is
+    from a different thread, or is paused / aborted (no marker)
+  - source thread unaffected by fork (independence test, byte-equal
+    before/after)
+  - fork-of-fork lineage: A → B at run X; B → C at run Y (Y is one of
+    B's runs). C's `parent_thread_id == B`; for PG/MySQL,
+    `forked_at_seq` is B's seq for Y, not A's
+  - subsequent `prompt()` on a forked thread starts a new run_id; new
+    messages get the new run_id; completion writes its own marker
+  - concurrent fork + complete_run on source serialize correctly
+  - SQLite cross-connection: two `SQLiteCheckpointer` instances on
+    the same DB file, one `fork()` and one `complete_run()` from
+    different processes serialize via `BEGIN IMMEDIATE`
+  - legacy data: thread with `run_id=NULL` messages and no completion
+    markers raises `RunNotCompletedError` on `fork(...)`
+  - `CheckpointData.parent_thread_id` round-trip via `load()`
 
 - **`Agent.fork_once()` (FauxProvider)**:
-  - simple text-only follow-up returns expected final text
+
+  - simple text-only follow-up returns expected final text; source
+    thread unchanged
   - turn with tool calls completes fully, returns new messages
-  - source thread (and its checkpointer) is byte-for-byte unchanged
-  - raises `RuntimeError` when no checkpointer bound
-  - raises `RuntimeError` when any tool in `self.tools` has
-    `requires_hitl=True` (HITL pre-flight, §3.9.1) — exercised with
-    the actual `ask_user_tool(...)` factory result, not a stub
+  - raises `RuntimeError` when no checkpointer
+  - raises `RuntimeError` when `requires_hitl=True` tool in
+    `self.tools` (exercised with the actual `ask_user_tool(...)`
+    factory result)
   - raises `RuntimeError` when `ApprovalPolicyMiddleware` (or its
-    subclass `ConfirmToolCallMiddleware`) is in `self.middleware`
+    subclass `ConfirmToolCallMiddleware`) in `self.middleware`
   - cancellation: `asyncio.wait_for(agent.fork_once(...), timeout=…)`
-    raises `TimeoutError` and the transient agent's abort signal
-    fires (verified via FauxProvider abort hook)
+    raises `TimeoutError`; transient agent's abort fires
   - tracing span: emits `cubepi.agent.fork_once` with the documented
-    attributes. When called inside an existing span context, the
-    fork_once span is a child of the surrounding span (parent
-    propagation test). When called outside any span, it is a trace
-    root.
-  - The existing tracing test infrastructure
-    (`tests/tracing/conftest.py` in-memory exporter, if present) is
-    reused; if no such infrastructure exists, the plan stage
-    introduces a minimal `InMemorySpanExporter` fixture as a
-    prerequisite.
+    attributes; nests under surrounding span if one exists; otherwise
+    is a trace root
 
-- **`Agent.fork()` (FauxProvider)**:
-  - happy path returns None; checkpointer state is correct
-  - error pass-through (`ThreadNotFoundError`, `ThreadAlreadyExistsError`,
-    `ForkBoundaryError`, `RuntimeError` for missing checkpointer)
-  - does NOT mutate `self.thread_id`
+- **`Agent(messages=...)` constructor (§3.7)**:
 
-- **Exception hierarchy** (`tests/checkpointer/test_exceptions.py`):
-  - `ThreadNotFoundError`, `ThreadAlreadyExistsError`,
-    `ForkBoundaryError`, `CheckpointerLockTimeoutError` are all
-    catchable via `except CheckpointerError`
-  - `CheckpointerError` is NOT a subclass of `CubepiSchemaError`
-    (schema vs. runtime concerns stay separate)
-
-- **`Agent(messages=...)` constructor (§3.7a)** — a dedicated test
-  group, distinct from `fork_once()` tests, so the new constructor
-  path is exercised even if `fork_once()` is later refactored:
-  - happy path: `Agent(messages=[UserMessage(...)])` ends up with
-    those messages reflected by the next `prompt()` call
+  - happy path: pre-seeded messages reflected in the next `prompt()`
   - `Agent(messages=[...], thread_id="t", checkpointer=cp)` raises
     `ValueError`
-  - `Agent(messages=<invalid-prefix>)` raises `ForkBoundaryError`
-    for each §3.3 invariant violation (re-uses the
-    snapshot-validator test fixtures)
-  - **deep-copy isolation**: construct an `Agent` with a list
-    containing one `UserMessage`, one `AssistantMessage` carrying a
-    `ToolCall` (with mutable `arguments` dict), and one
-    `ToolResultMessage` (with `content` list and `metadata` dict).
-    Mutate every nested mutable field on the ORIGINAL message
-    objects after construction. Assert the agent's internal copies
-    are unchanged. Mirror the mutation against the agent and assert
-    the originals are unchanged (isolation runs both directions).
-  - `messages=None` is the no-op default (sanity check)
+  - deep-copy isolation: mutate every nested mutable field
+    (`AssistantMessage.content`, `ToolCall.arguments`,
+    `ToolResultMessage.content`, every `metadata` dict) on the
+    ORIGINAL messages after construction; assert the agent's
+    internals are unchanged. Mirror the mutation against the agent
+    and assert the originals are unchanged.
+
+- **Exception hierarchy** (`tests/checkpointer/test_exceptions.py`):
+  every new error (`ThreadNotFoundError`, `ThreadAlreadyExistsError`,
+  `RunNotCompletedError`, `RunAlreadyCompletedError`,
+  `CheckpointerLockTimeoutError`) is catchable via
+  `except CheckpointerError`. `CheckpointerError` is NOT a subclass
+  of `CubepiSchemaError`.
 
 ## 6. Open questions
 
-None remaining — answers locked in during brainstorm:
+All closed during brainstorm:
 
 - Storage model → physical copy
-- Cut parameter → `message_count`
-- Caller supplies `new_thread_id` (required, not auto-generated)
-- Boundary on unresolved tool_calls → raise `ForkBoundaryError`
-- `extra` copied; `pending_request` / `run_id` not copied
-- `metadata` arg merged into `extra['fork']`
-- Spec scope → both `fork()` and `fork_once()` together
-- Both methods live on `Agent` (thin wrappers over checkpointer
-  primitives for `fork`; runtime work for `fork_once`)
+- Fork handle → `after_run_id` only (no message_count, no Message.id,
+  no after_response_id)
+- Run state ownership → cubepi (not cubebox)
+- Run_id source → accept-or-generate from `Agent.prompt`
+- Legacy data → not forkable / not deletable; no backfill
+- Run completion atomicity → same transaction as final append
+  (`complete_run()` Protocol method)
+- HITL pause/resume → same run_id across suspension; marker written
+  on resume completion
+- fork_once HITL → banned via `requires_hitl` marker
 
 ## 7. Out of this PR (follow-ups)
 
-- Cubebox-side wiring: new `Conversation.parent_conversation_id` column,
+- **`Agent.delete_run(thread_id, run_id, *, including_subsequent: bool
+  = True)`** — separate spec. Data model laid down here makes it a
+  small change: a `DELETE WHERE thread_id=? AND run_id=?` (single-run
+  surgical delete, leaves a hole; documented caveat) or a
+  `DELETE WHERE thread_id=? AND seq >= min_seq_of_run` (rollback,
+  also drops subsequent run_completions).
+- Cubebox wiring: new `Conversation.parent_conversation_id` column,
   `POST /conversations/{id}/fork` endpoint, per-assistant-message UI
   button. Lives in the cubebox repo.
 - CLI sugar (`cubepi fork`) — only if a real user asks.
-- GC / size cap for heavily forked thread trees — only if a real
-  workload hits the space cost.
+- Backfill heuristic for legacy threads (best-effort run-boundary
+  inference) — only if a real workload needs it.

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -443,44 +443,63 @@ implementation would mark FAILED runs complete. To prevent that, the
 spec enumerates each loop outcome AND adds a structural pre-completion
 invariant (below).
 
-#### Pre-completion invariant: no orphan tool_use
+#### Pre-completion invariant: well-formed tool-use turns
 
 **Before calling `mark_run_complete()`, the agent loop MUST verify
-that no `AssistantMessage` appended under the active run carries a
-`ToolCall` whose `id` has no matching `ToolResultMessage`
-(`tool_call_id`) later in the same run's messages.**
+that every `AssistantMessage` with `ToolCall` blocks in this run is
+immediately followed by a contiguous block of `ToolResultMessage`s
+whose `tool_call_id`s exactly cover (set-equal to) that
+assistant's `ToolCall.id`s, before any other `AssistantMessage` or
+`UserMessage` appears in the run's message list.**
 
-This catches a real loop-level escape hatch: a custom
-`after_model_response` middleware can return
-`TurnAction(decision="stop")` after an assistant message that
-contains `ToolCall` blocks, in which case the loop short-circuits
-WITHOUT executing the tools or appending `ToolResultMessage`s. The
-loop then emits `AgentEndEvent` with `stop_reason="tool_use"` and
-returns normally. Without this check, a naive implementation would
-call `mark_run_complete()` on a run whose messages contain orphan
-`ToolCall`s — and `fork(after_run_id=R)` would later copy those
-orphans, reintroducing the very mid-tool-call hazard the run-based
-design claims to eliminate.
+Concretely, for each `AssistantMessage` A in the run carrying
+ToolCalls with ids `{c1, c2, …}`:
 
-The check is O(N) over the run's own messages (the ones tagged with
+- The next K messages in the run (where K = number of A's ToolCalls)
+  MUST all be `ToolResultMessage`s.
+- Their `tool_call_id` set MUST equal `{c1, c2, …}` exactly (no
+  missing, no extras, no duplicates).
+- No `UserMessage` or `AssistantMessage` may appear within that
+  K-message window.
+
+A weaker "any matching tool_call_id later in the run" check is NOT
+sufficient: cubepi's existing code documents that `tool_call_id`s
+are not globally unique, so a later same-id result could falsely
+satisfy an earlier orphan. Strict per-turn adjacency closes that
+hole.
+
+This catches two real loop-level escape hatches:
+
+1. A custom `after_model_response` middleware returns
+   `TurnAction(decision="stop")` after an assistant message
+   containing `ToolCall` blocks — loop short-circuits without
+   executing tools, prompt() returns with `stop_reason="tool_use"`
+   and no `ToolResultMessage` ever appended for this turn.
+2. A custom middleware injects intervening messages (a user message,
+   a separate assistant message) between the tool-use assistant and
+   what would be its tool_results — leaves the providers' strict
+   adjacency expectation broken even when a matching tool_call_id
+   eventually appears later.
+
+The check is O(N) over the run's own messages (those tagged with
 this `run_id` appended since `claim_run`). On violation the loop
-treats the outcome as **"incomplete tool cycle"** — a new row in
-the outcome table below — and does NOT call `mark_run_complete`.
-The cubepi_runs row remains with `completed_at IS NULL`; fork sees
+treats the outcome as **"incomplete tool cycle"** — a row in the
+outcome table below — and does NOT call `mark_run_complete`. The
+cubepi_runs row remains with `completed_at IS NULL`; fork sees
 `RunNotCompletedError`. Future `delete_run(R)` can clean up.
 
 The check is the only remaining vestige of v1's boundary validation,
-relocated to run-completion time (where it can be enforced once)
-rather than fork-cut time (where v1 had to validate at arbitrary
-positions). Because runs are by construction the only fork unit, a
-single check at completion suffices.
+relocated from arbitrary fork-cut time to run-completion time (where
+a single pass suffices). Because runs are by construction the only
+fork unit, validating each run once at completion is enough — fork
+never needs to re-validate.
 
 #### Outcome table
 
 | Loop outcome | Detection signal | `mark_run_complete()` called? |
 |---|---|---|
 | **Clean success** | Final `AssistantMessage` has `stop_reason in {"end_turn", "stop", "tool_use", …}` (any non-error / non-aborted stop_reason) AND `error_message is None` AND no pending HITL on the thread AND **the pre-completion invariant above passes** (no orphan `ToolCall`s in this run) | **YES** |
-| **Incomplete tool cycle** | Pre-completion invariant fails: some `AssistantMessage` in this run has a `ToolCall` whose `id` has no matching `ToolResultMessage` later in the run (typically caused by `after_model_response(decision="stop")` middleware short-circuit on a tool-use response) | NO — same handling as a failed run; claim row remains; `delete_run()` can clean up |
+| **Incomplete tool cycle** | Pre-completion invariant (above) fails: some `AssistantMessage` in this run is not immediately followed by a contiguous block of `ToolResultMessage`s covering exactly its `ToolCall.id`s. Typical triggers: `after_model_response(decision="stop")` on a tool-use response; middleware injecting intervening user/assistant messages between the tool-use turn and its results | NO — same handling as a failed run; claim row remains; `delete_run()` can clean up |
 | **HITL suspended** (normal pause) | `pending_request` row written this run; `prompt()` returns with the agent in suspended state | NO — `respond()` writes the marker on resume's clean exit |
 | **HITL detached** (`HitlDetached` caught in `loop.py:196` / `loop.py:418`) | Exception caught internally; loop returns silently, NO `AgentEndEvent` emitted. `pending_request` may still be set so `respond()` can resume later. | NO — same as normal HITL pause; resume handles completion |
 | **HITL aborted** (`HitlAborted`, via `Agent.abort_pending()`) | Exception caught internally; loop returns silently, NO `AgentEndEvent` emitted. The synthetic deny + terminal aborted assistant are appended by `abort_pending()` itself (see `agent.py:582-595`). | NO — claim row remains; the run is terminally abandoned; future `delete_run()` cleans up |
@@ -1502,9 +1521,23 @@ No `forked_at_seq` field — Memory has no seq.
     `cubepi_runs.completed_at IS NULL` for every non-success outcome
     and `IS NOT NULL` for the clean-success outcome. HITL
     suspended → respond() resume → assert marker now NOT NULL.
-    The incomplete-tool-cycle test specifically asserts: (a) the
-    pre-completion invariant rejected the run, (b) no orphan
-    tool_use ever becomes forkable via `fork(after_run_id=R)`.
+    The incomplete-tool-cycle test specifically covers each
+    shape rejected by the §3.6.2 invariant:
+    - (i) `after_model_response(decision="stop")` on a tool-use
+      response (no tool_results appended at all);
+    - (ii) `after_model_response` injects a `UserMessage` between
+      the tool-use assistant and what would be its tool_results
+      (subsequent matching tool_call_id later in the run does NOT
+      satisfy the strict-adjacency requirement);
+    - (iii) `after_model_response` produces a partial cover (only
+      some of the assistant's tool_call_ids have results in the
+      adjacent block);
+    - (iv) two assistants in the run with reused tool_call_ids —
+      strict adjacency prevents the later assistant's results from
+      satisfying the earlier assistant's calls.
+    For each shape: assert (a) the pre-completion invariant
+    rejected the run; (b) `fork(after_run_id=R)` raises
+    `RunNotCompletedError`.
   - **Legacy-degraded mode** (regression test for v2 R7 HIGH #4 +
     v2 R8 HIGH #3): construct an Agent with a checkpointer that
     implements only the v3 surface (no `claim_run` /

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -72,8 +72,10 @@ to every message and adds a per-run completion marker.
   `Message.id` / `after_response_id` parameters are NOT in this spec.
 - Copy-on-write storage (rejected for the same partitioning / mutation
   reasons documented in §3.1).
-- Backfilling run identity into pre-existing messages. Legacy messages
-  remain `run_id=NULL` and are not forkable / not deletable — see §3.6.4.
+- Backfilling run identity into pre-existing messages. Legacy
+  messages remain `run_id=NULL`; they are not deletable by run_id but
+  ARE included in forks as the "legacy prefix" of a mixed thread —
+  see §3.6.4.
 - A `fork_into_agent()` convenience or `fork_and_switch`. Caller owns
   what to do with `new_thread_id`.
 - Resuming a `fork_once()` session.
@@ -105,25 +107,63 @@ Rejected: **logical pointer / COW**. Same rationale as v1:
 
 ### 3.2 Run as the unit of fork
 
-The **only** fork handle is `after_run_id: str`. The new thread contains
-exactly the messages of every completed run on the source up through and
-including `after_run_id` (in source seq order).
+The **only** fork handle is `after_run_id: str`. The new thread contains:
 
-Why a run is the right unit:
+1. Every message whose `run_id IS NULL` (legacy prefix — see §3.6.4),
+   PLUS
+2. Every message whose `run_id` belongs to the set of completed runs
+   on `src_thread_id` whose `completed_at` is **at or before**
+   `after_run_id`'s `completed_at`.
 
-- A run is the atomic transaction the user thinks in ("I asked X, agent
-  did its thing, gave me an answer"). Cubebox's UI button maps directly
-  to "fork after this exchange".
-- A run boundary is by construction a clean cut. Inside a run there may
-  be unresolved `tool_use` blocks awaiting `tool_result`s; once the run
-  is marked complete (terminal stop_reason, no pending HITL), no
-  unresolved tool calls remain. So **the v1 spec's `ForkBoundaryError`
-  / mid-tool-call invariants vanish structurally**: there is no API to
-  ask for a cut mid-run, so no boundary check is needed.
+Messages are inserted into the new thread in source seq order.
+
+#### Why "set of completed runs", not "seq <= last_seq_of(after_run_id)"
+
+A naive seq-cut is unsafe under concurrent runs. Example: runs A and B
+both active on the same thread; A writes seqs 1, 2, 5 and completes,
+while B writes seqs 3, 4 and is still in flight. A seq-cut
+"`seq <= 5`" would pull B's seqs 3, 4 into the fork — messages of an
+unfinished run we have no right to copy. The set-based selection
+solves this by construction: only messages tagged with a *completed*
+run_id (or NULL for legacy) are eligible.
+
+This selection is also robust to:
+
+- **Interleaved runs**: each run's messages are addressed by tag, not
+  by position. Gaps in seq are fine.
+- **In-flight runs**: their messages have a `run_id` not yet in
+  `cubepi_run_completions` → excluded.
+- **Mixed legacy + post-upgrade threads**: NULL-run_id messages are
+  preserved as a chronological prefix, post-upgrade completed runs
+  appear after.
+- **Tie in `completed_at`**: two completions at the same wall-clock
+  tick are tiebroken by lexicographic `run_id` for deterministic
+  output. (Rare in practice; documented for spec completeness.)
+
+#### Why a run is the right unit
+
+- A run is the atomic transaction the user thinks in ("I asked X,
+  agent did its thing, gave me an answer"). Cubebox's UI button maps
+  directly to "fork after this exchange".
+- A run boundary is by construction a clean cut. Inside a run there
+  may be unresolved `tool_use` blocks awaiting `tool_result`s; once
+  the run is marked complete (terminal stop_reason, no pending HITL),
+  no unresolved tool calls remain. **The v1 spec's `ForkBoundaryError`
+  / mid-tool-call invariants vanish structurally**: there is no API
+  to ask for a cut mid-run, so no boundary check is needed.
 - It generalizes to the future `delete_run()` cleanly:
   `DELETE FROM cubepi_messages WHERE thread_id=? AND run_id=?` is a
   one-line operation backed by the same `run_id` column the fork uses
   for lookup.
+
+#### Recommendation (not enforced): one active run per thread
+
+For UX clarity and predictable ordering, hosts SHOULD serialize runs
+per thread (cubebox naturally does — one conversation = one in-flight
+prompt at a time). The spec does NOT enforce this — the set-based fork
+selection means interleaved runs are *correct*, just unusual. A future
+spec may add a "one active run per thread" lease if a real workload
+needs the stronger guarantee.
 
 ### 3.3 Atomicity and concurrency
 
@@ -172,11 +212,11 @@ world the copy will see:
 
 | Field / row | Copied? | Notes |
 |---|---|---|
-| `cubepi_messages` rows with `seq <= last_seq_of(after_run_id)` | yes | physical copy; PG/MySQL preserve source `seq` values for the copied range. SQLite copies the JSON payloads under fresh global `id`s (its `messages.id` is a global auto-increment, not a per-thread seq). Memory copies in-list order. Each copied row keeps its original `run_id` value. |
+| `cubepi_messages` rows where `run_id IS NULL` OR `run_id IN {completed runs of src with completed_at <= after_run_id.completed_at}` | yes | physical copy; PG/MySQL preserve source `seq` values for the copied range. SQLite copies the JSON payloads under fresh global `id`s (its `messages.id` is a global auto-increment, not a per-thread seq). Memory copies in-list order. Each copied row keeps its original `run_id` value (or NULL). Source seq order is preserved across the copy. |
 | `cubepi_run_completions` rows for the copied runs | yes | so the new thread can be further forked / deleted by run |
 | `extra` | yes | deep copy of the source JSON object |
 | `parent_thread_id` | written (new) | set to `src_thread_id` on the new thread row |
-| `forked_at_seq` | written (PG/MySQL only) | the `seq` of the last message of `after_run_id`. Memory and SQLite store no equivalent — those backends have no per-message seq column and lineage is recoverable from `parent_thread_id` + `cubepi_run_completions` alone. |
+| `forked_at_seq` | written (PG/MySQL only) | the `seq` of the last message in the copied set (highest copied seq). Memory and SQLite store no equivalent — those backends have no per-message seq column and lineage is recoverable from `parent_thread_id` + `cubepi_run_completions` alone. |
 | `extra['fork']` | written (new) when `metadata` arg supplied | overwrites any pre-existing `extra['fork']` on source (lineage is recoverable via the `parent_thread_id` chain) |
 | `pending_request` | **no** | new thread starts clean; HITL is run-state, not history |
 | `cubepi_threads.run_id` (the host-side HITL marker, NOT a run on this thread) | **no** | new thread has no run in flight |
@@ -227,34 +267,72 @@ about to be appended. **`Checkpointer.append()` signature does not
 change** — the run_id rides on the messages themselves
 (`Message.run_id` field, §3.6.5).
 
-If the caller supplies a `run_id` that already has a completion marker
-on the source thread, `prompt()` raises `RunAlreadyCompletedError` —
-runs are append-only; you cannot continue or re-run a completed run.
-(Use a new `run_id` for a new exchange.)
+If the caller supplies a `run_id` that already has a completion
+marker on the source thread, `prompt()` raises
+`RunAlreadyCompletedError` **before any append happens** — runs are
+append-only; you cannot continue or re-run a completed run. (Use a
+new `run_id` for a new exchange.) The pre-flight check is mandatory
+to prevent "messages were written before the conflict was detected"
+half-states.
+
+There is a narrow race window: two processes both pre-check, both see
+no marker for run_id R, both begin appending. The first to call
+`mark_run_complete()` wins; the second raises
+`RunAlreadyCompletedError` from the marker INSERT (unique PK on
+`(thread_id, run_id)`). The losing process's intermediate appends
+remain on the thread, tagged with R but with no marker → fork by R
+excludes them, and the future `delete_run(thread_id, R)` cleans them
+up. Callers that race must retry with a fresh `run_id`. Hosts that
+serialize runs per thread (cubebox does) never hit this.
 
 #### 3.6.2 Completion marker — when written
 
 The marker `cubepi_run_completions(thread_id, run_id, completed_at)`
-is written **inside the same transaction as the final `append()` of
-the run** — atomic with the last message. The agent loop signals
-"this is the last append of the run" via a flag on the checkpointer
-call (or via a dedicated `Checkpointer.complete_run()` call made in
-the same lock window — exact form decided in the implementation plan,
-but the requirement is atomicity).
+is written by a dedicated, separate Protocol method
+`Checkpointer.mark_run_complete(thread_id, run_id) -> None` — a
+single-row INSERT, called AFTER the run's final `append()` and
+BEFORE `Agent.prompt()` returns to the caller.
 
-Trigger conditions for writing the marker:
+**The marker write is NOT atomic with the final append.** The
+existing cubepi event loop (`cubepi/agent/loop.py`) persists each
+message on its own `MessageEndEvent`; the loop only knows it has
+finished when `AgentEndEvent` fires, *after* the final append.
+Trying to atomically couple the two would require an Agent-layer
+buffering rewrite that is out of scope.
 
-- The agent loop exits with a terminal stop_reason (`end_turn`,
-  `tool_use_completed` followed by `end_turn`, etc. — any
+This is acceptable. Two failure modes and their consequences:
+
+- **Process crash between final append and `mark_run_complete()`**:
+  messages of run R are persisted but no completion marker exists.
+  `fork(after_run_id=R)` raises `RunNotCompletedError`. The user
+  sees "the run looks finished but I can't fork it yet." A future
+  admin / recovery API can backfill the marker. The data is not
+  corrupt — just in an unmarked state, same as an abandoned run.
+- **Transient checkpointer failure on `mark_run_complete()`**:
+  `prompt()` raises the underlying error so the caller knows. The
+  messages are already persisted; retrying just `mark_run_complete()`
+  with the same `(thread_id, run_id)` succeeds. Idempotency: if the
+  caller retries `prompt(run_id=R)` instead, it gets
+  `RunAlreadyCompletedError` from the pre-flight check (§3.6.1)
+  EXCEPT — pre-flight checks for the marker; if the marker still
+  isn't there because of the same persistent failure, the caller can
+  resume by calling `mark_run_complete()` directly, or by abandoning
+  R and starting fresh. The recommended pattern is "retry the marker
+  call, not the whole prompt".
+
+Trigger conditions for the agent loop to call `mark_run_complete()`:
+
+- The loop exits cleanly with a terminal stop_reason
+  (`end_turn` / `tool_use_completed`-then-`end_turn` / any
   non-suspended terminal state)
 - AND no pending HITL request remains for this run
 
 If `prompt()` returns because of:
 
-- HITL pause (pending_request set) → marker NOT written; the run is
-  resumed later by `respond()`.
-- Exception / abort / cancellation → marker NOT written; the run is
-  abandoned. Its messages remain on the thread under the same
+- **HITL pause** (`pending_request` set) → marker NOT written; resumed
+  by `respond()` (§3.6.3).
+- **Exception / abort / cancellation** → marker NOT written; the run
+  is abandoned. Its messages remain on the thread under the same
   `run_id`, but `fork(after_run_id=X)` raises `RunNotCompletedError`,
   and the future `delete_run(X)` can clean them up.
 
@@ -265,31 +343,84 @@ A run that pauses for HITL keeps its `run_id` across the suspension.
 - `Agent.prompt(message, run_id=R)` runs partway, hits HITL → writes
   `pending_request` with `run_id=R` (existing schema v3 mechanism), no
   completion marker.
-- `Agent.respond(question_id, answer)` recovers `run_id=R` from
-  `pending_request` (it's already there), continues the same run,
-  writes the completion marker when the resumed loop terminates
-  cleanly.
+- `Agent.respond(question_id, answer)` recovers `run_id=R` from the
+  same `pending_request` row, restores it as the active run_id in the
+  agent loop, continues the same run, stamps every subsequent
+  appended message with `run_id=R`, and calls `mark_run_complete()`
+  on terminal exit.
 
-`Agent.respond()` signature does **not** change. The run_id is
-sourced from `pending_request`.
+`Agent.respond()` signature does **not** change.
 
-#### 3.6.4 Legacy data
+**Protocol change required to support this.** Today,
+`Checkpointer.load_pending_request(thread_id) -> HitlRequest | None`
+returns only the request. The run_id lives in a backend-specific
+`load_pending_run_id(thread_id)` method that is NOT on the Protocol.
+This spec adds it to the Protocol so `respond()` can recover the
+run_id portably:
+
+```python
+class Checkpointer(Protocol):
+    async def load_pending(
+        self, thread_id: str
+    ) -> tuple[HitlRequest, str | None] | None:
+        """Load both the pending HITL request and the persisted run_id
+        in a single call. Returns None when no pending request exists.
+        The run_id may itself be None for legacy rows written before
+        run_id was tracked.
+
+        Backends MUST read both values from the same row in a single
+        statement (no separate round-trips), so the pair is internally
+        consistent.
+        """
+```
+
+`load_pending_request()` is kept as an alias for the
+request-only case (existing callers unchanged). New code uses
+`load_pending()`.
+
+Second-pause scenarios — a resumed run hits HITL *again* — work the
+same way: `respond()` re-suspends with the SAME `run_id=R` stored
+back to `pending_request`. A subsequent `respond()` call recovers R
+and continues.
+
+#### 3.6.4 Legacy data and mixed threads
 
 Messages persisted before this spec carry `run_id = NULL`. No
-completion markers exist for them. Consequence:
+completion markers exist for them. There are two cases:
 
-- `fork(src_thread_id, …, after_run_id=X)` on a legacy thread raises
-  `RunNotCompletedError` for every `X` because no marker exists.
-- Future `delete_run(thread_id, run_id)` will likewise have nothing
-  to target.
-- Legacy threads remain readable (`load()` works); only the
-  by-run operations are blocked.
+**All-legacy thread** (no post-upgrade runs ever appended):
 
-No backfill is provided. (We can not reliably reconstruct historical
+- `fork(src_thread_id, after_run_id=X)` raises `RunNotCompletedError`
+  for every `X` because no markers exist for this thread at all.
+- Future `delete_run(thread_id, run_id)` has nothing to target.
+- `load()` works; the thread is readable. Only by-run operations
+  are blocked.
+
+**Mixed thread** (legacy NULL-run_id prefix + post-upgrade
+completed runs):
+
+- `fork(src_thread_id, after_run_id=R)` where R is a completed
+  post-upgrade run on this thread:
+  - Includes ALL legacy NULL-run_id messages (the chronological
+    prefix the user has been chatting on top of)
+  - PLUS messages of every completed run with
+    `completed_at <= R.completed_at`
+  - Source seq order preserved across the copy
+- `delete_run(thread_id, R)` removes only R's messages (those with
+  `run_id = R`); the legacy NULL prefix is untouched. To clear the
+  legacy prefix the user must delete the whole thread.
+
+This means a typical cubebox upgrade path is graceful: users
+continue chatting on their existing conversations; their NEW exchanges
+get run identity automatically; clicking "fork from this new
+exchange" preserves the pre-upgrade history as expected.
+
+No backfill is provided. (We cannot reliably reconstruct historical
 run boundaries from messages alone — multi-step tool_use sequences
-look like multiple runs.) Users who need to fork a legacy
-conversation can manually start a new conversation; the loss is
-limited to "no clone shortcut on threads that predate the upgrade".
+look like multiple runs.) Users who upgrade and then immediately try
+to fork an all-legacy conversation see `RunNotCompletedError` because
+that conversation has no run-marked exchange yet; the first new
+prompt will create a forkable run.
 
 #### 3.6.5 `Message.run_id` field
 
@@ -358,22 +489,25 @@ class Checkpointer(Protocol):
         `RunNotCompletedError`.
         """
 
-    async def complete_run(
+    async def mark_run_complete(
         self,
         thread_id: str,
         run_id: str,
-        last_messages: list[Message],
     ) -> None:
-        """Atomically append `last_messages` to the thread AND write the
-        `cubepi_run_completions` row for `(thread_id, run_id)`.
+        """Insert the `cubepi_run_completions` row for `(thread_id,
+        run_id)`. Single-row write, NOT coupled to the final append
+        (see §3.6.2 for the rationale).
 
-        Called by the agent loop on terminal-state exit only. Replaces
-        the final `append()` of the run — the agent loop normally uses
-        `append()` for intermediate messages of a run and
-        `complete_run()` for the last batch. Idempotent: a second call
-        with the same `(thread_id, run_id)` is an error
-        (`RunAlreadyCompletedError`) since runs are append-only.
+        Called by the agent loop AFTER the run's final `append()` and
+        BEFORE `Agent.prompt()` returns. PK conflict on
+        `(thread_id, run_id)` raises `RunAlreadyCompletedError`.
         """
+
+    async def load_pending(
+        self, thread_id: str
+    ) -> tuple[HitlRequest, str | None] | None:
+        """See §3.6.3. Returns (request, run_id) in one read, or None
+        when no pending request exists."""
 ```
 
 #### `cubepi.checkpointer.exceptions`
@@ -468,7 +602,7 @@ class ForkOnceResult:
 ### 3.8 `Agent.fork_once()` execution detail
 
 1. `self._require_checkpointer()` — `RuntimeError` if no checkpointer.
-2. HITL pre-flight (§3.8.1) — `RuntimeError` if inherited tools or
+2. HITL pre-flight (§3.8.2) — `RuntimeError` if inherited tools or
    middleware mark `requires_hitl=True`.
 3. `snapshot = await self.checkpointer.snapshot(src_thread_id,
    after_run_id=...)` — propagates
@@ -489,7 +623,38 @@ class ForkOnceResult:
    length from the child; close the span.
 9. Return `ForkOnceResult(text, new_messages, stop_reason)`.
 
-#### 3.8.1 HITL is not supported inside `fork_once()`
+#### 3.8.1 Isolation contract
+
+`fork_once()` guarantees ONE thing: **no message produced by the
+transient run is written to the cubepi checkpointer**. The source
+thread's persisted history is byte-identical before and after the
+call.
+
+`fork_once()` does NOT guarantee:
+
+- That tools the transient agent invokes have no side effects.
+  A tool that writes to an external DB / sends an email / calls a
+  remote API will do so. A tool whose closure captures
+  `self.thread_id` and writes to a side store keyed by it will
+  contaminate the source.
+- That middleware with internal mutable state doesn't change that
+  state across the transient run.
+
+This is by design. Cubepi cannot inspect closures or external
+systems. The contract is narrowly: "cubepi's own message store is
+untouched." Anything else is the caller's responsibility — pick the
+tool/middleware set for the transient agent accordingly. The
+recommended pattern when transient-safety matters: build a second
+`Agent(...)` with only read-only / idempotent / fork-safe tools and
+call `fork_once()` on that one.
+
+The one tool/middleware shape cubepi DOES detect and reject is HITL,
+because (a) HITL has no graceful "no-op" mode (the run blocks
+forever) and (b) HITL channels write directly into the cubepi
+checkpointer, which would silently violate the isolation contract
+above. See §3.8.2.
+
+#### 3.8.2 HITL is not supported inside `fork_once()`
 
 Two reasons HITL cannot work in `fork_once()`:
 
@@ -536,30 +701,48 @@ two additive changes (alembic migration in cubebox / cubepi-using apps):
 `fork()` in one transaction:
 
 1. Advisory lock / `FOR UPDATE` on the source thread.
-2. `SELECT MAX(seq) AS last_seq FROM cubepi_messages WHERE thread_id =
-   $src AND seq <= (SELECT MAX(seq) FROM cubepi_messages WHERE
-   thread_id = $src AND run_id = $after_run_id)`
-   AND `EXISTS (SELECT 1 FROM cubepi_run_completions WHERE thread_id =
-   $src AND run_id = $after_run_id)` → if no row,
+2. `SELECT completed_at AS cutoff FROM cubepi_run_completions WHERE
+   thread_id = $src AND run_id = $after_run_id` → if no row,
    `RunNotCompletedError`.
 3. `INSERT INTO cubepi_threads (thread_id, parent_thread_id,
-   forked_at_seq, extra, …) VALUES ($new, $src, $last_seq,
-   $merged_extra, …)` — `ThreadAlreadyExistsError` on PK violation.
+   forked_at_seq, extra, …)
+   VALUES ($new, $src, $last_copied_seq, $merged_extra, …)` —
+   `ThreadAlreadyExistsError` on PK violation. `$last_copied_seq` is
+   computed below in step 4 (or set with a CTE / temp value depending
+   on implementation).
 4. `INSERT INTO cubepi_messages (thread_id, seq, role, run_id,
-   metadata, payload) SELECT $new, seq, role, run_id, metadata, payload
-   FROM cubepi_messages WHERE thread_id = $src AND seq <= $last_seq
+   metadata, payload)
+   SELECT $new, seq, role, run_id, metadata, payload
+   FROM cubepi_messages
+   WHERE thread_id = $src
+     AND (
+       run_id IS NULL                                   -- legacy prefix
+       OR run_id IN (
+         SELECT run_id FROM cubepi_run_completions
+         WHERE thread_id = $src
+           AND (completed_at, run_id) <= ($cutoff, $after_run_id)
+       )
+     )
    ORDER BY seq`.
+   The composite `(completed_at, run_id)` comparison gives the
+   deterministic tiebreak from §3.2.
 5. `INSERT INTO cubepi_run_completions (thread_id, run_id,
-   completed_at) SELECT $new, run_id, completed_at FROM
-   cubepi_run_completions WHERE thread_id = $src AND run_id IN
-   (SELECT DISTINCT run_id FROM cubepi_messages WHERE thread_id = $src
-   AND seq <= $last_seq)`.
-6. Commit.
+   completed_at)
+   SELECT $new, run_id, completed_at
+   FROM cubepi_run_completions
+   WHERE thread_id = $src
+     AND (completed_at, run_id) <= ($cutoff, $after_run_id)`.
+6. (Optional, audit) `UPDATE cubepi_threads SET forked_at_seq =
+   (SELECT MAX(seq) FROM cubepi_messages WHERE thread_id = $new)
+   WHERE thread_id = $new` — sets the lineage marker.
+7. Commit.
 
-`complete_run()` in one transaction:
+`mark_run_complete()` (single statement, own transaction OR within
+the existing append/save lock window — the spec doesn't mandate;
+either is correct because the row is independently consistent):
 
-- Same advisory lock / `FOR UPDATE` on `thread_id`.
-- `INSERT INTO cubepi_messages …` for `last_messages` (allocating seqs).
+- Take the per-thread advisory lock / `FOR UPDATE` to serialize
+  vs. concurrent appends / forks.
 - `INSERT INTO cubepi_run_completions (thread_id, run_id,
   completed_at) VALUES (?, ?, now())` —
   `RunAlreadyCompletedError` on PK violation.
@@ -588,32 +771,42 @@ Schema additions at connect time using the existing PRAGMA-probe +
 3. Validate new thread does not exist (probe `messages` /
    `thread_extra` / `run_completions` for `new_thread_id`) →
    `ThreadAlreadyExistsError`.
-4. `INSERT INTO messages (thread_id, run_id, message_json) SELECT
-   $new, run_id, message_json FROM messages WHERE thread_id = $src
-   AND id <= (SELECT MAX(id) FROM messages WHERE thread_id = $src AND
-   run_id = $after_run_id) ORDER BY id`. New rows get fresh global
-   `id`s (the `messages.id` column is a global auto-increment;
-   identity is not preserved across the copy, but per-thread row
-   order is).
-5. `INSERT INTO run_completions (thread_id, run_id, completed_at)
-   SELECT $new, run_id, completed_at FROM run_completions WHERE
-   thread_id = $src AND run_id IN (SELECT DISTINCT run_id FROM
-   messages WHERE thread_id = $src AND id <= $cut_id)`.
-6. `INSERT INTO thread_extra (thread_id, extra_json, parent_thread_id)
+4. Read cutoff: `SELECT completed_at FROM run_completions WHERE
+   thread_id = $src AND run_id = $after_run_id` (already validated
+   non-null in step 2).
+5. `INSERT INTO messages (thread_id, run_id, message_json)
+   SELECT $new, run_id, message_json FROM messages
+   WHERE thread_id = $src
+     AND (
+       run_id IS NULL
+       OR run_id IN (
+         SELECT run_id FROM run_completions
+         WHERE thread_id = $src
+           AND (completed_at, run_id) <= ($cutoff, $after_run_id)
+       )
+     )
+   ORDER BY id`. New rows get fresh global `id`s (the `messages.id`
+   column is a global auto-increment; identity is not preserved
+   across the copy, but per-thread row order is).
+6. `INSERT INTO run_completions (thread_id, run_id, completed_at)
+   SELECT $new, run_id, completed_at FROM run_completions
+   WHERE thread_id = $src
+     AND (completed_at, run_id) <= ($cutoff, $after_run_id)`.
+7. `INSERT INTO thread_extra (thread_id, extra_json, parent_thread_id)
    VALUES ($new, $merged_extra_json, $src)`.
-7. Commit.
+8. Commit.
 
-`complete_run()`:
+`mark_run_complete()`:
 
 - `BEGIN IMMEDIATE`.
-- `INSERT INTO messages …` for each `last_messages` element (each
-  carrying its `run_id`).
 - `INSERT INTO run_completions (thread_id, run_id) VALUES (?, ?)` →
   `RunAlreadyCompletedError` if `(thread_id, run_id)` PK conflict.
 - Commit.
 
 `append()` is also wrapped in `BEGIN IMMEDIATE` (uniform writer
 discipline; see §3.3). `PRAGMA busy_timeout = 5000` set at connect.
+Each appended `Message` carries its `run_id` value into the new
+`messages.run_id` column.
 
 No `forked_at_seq` column added — SQLite has no per-thread seq.
 
@@ -622,32 +815,50 @@ No `forked_at_seq` column added — SQLite has no per-thread seq.
 `MemoryCheckpointer` today is `dict[str, CheckpointData]`. This spec:
 
 - Extends `CheckpointData` with `parent_thread_id: str | None = None`.
-- Adds an internal `dict[str, set[str]]` mapping
-  `thread_id -> set of completed run_ids`.
-- Adds an `asyncio.Lock` for fork (existing single-statement methods
-  do not strictly need one, but fork is multi-step).
+- Adds an internal `dict[str, dict[str, float]]` mapping
+  `thread_id -> {run_id: completed_at_monotonic_index}` — the value
+  is just an insertion-order counter (per-thread monotonic int)
+  serving as the equivalent of `completed_at` for ordering. Memory
+  does not have a real wall-clock requirement; the counter is
+  sufficient for the `(completed_at, run_id) <= cutoff` comparison.
+- Adds a single shared `asyncio.Lock` that ALL write paths
+  (`append`, `save_extra`, `save_pending_request`,
+  `mark_run_complete`, `fork`) take. The existing single-statement
+  methods didn't strictly need one, but uniform locking removes the
+  finding-#4 check-then-write race in this backend.
 - `Message.run_id` is just a field — Memory persists the whole
-  Message via `model_dump`, so no extra storage scaffolding.
+  Message via reference, so no extra storage scaffolding.
 
 `fork()` under the lock:
 
 1. Source-exists check, new-thread-does-not-exist check.
-2. Look up the completed run_ids set; if `after_run_id` not there →
-   `RunNotCompletedError`.
-3. Walk `src.messages`, find the index of the last message with
-   `run_id == after_run_id`. Take prefix `[0..idx+1)`. Deep-copy
-   each message (`model_copy(deep=True)`).
-4. Compute the subset of `src`'s completed run_ids that appear in the
-   prefix; carry that set under the new thread_id.
-5. Deep-copy `src.extra`; merge `extra['fork']=metadata` per §3.4.
-6. Store `CheckpointData(messages=…, extra=…,
+2. Look up the completed run_ids map for `src_thread_id`; if
+   `after_run_id` not in it → `RunNotCompletedError`.
+3. Compute the cutoff index = `completions[src][after_run_id]`.
+4. Walk `src.messages` in order. For each message: include it if
+   `m.run_id is None` OR `(completions[src][m.run_id], m.run_id) <=
+   (cutoff, after_run_id)`. Deep-copy via `model_copy(deep=True)`.
+5. Subset of `src`'s completion map filtered by the same cutoff:
+   carry under the new thread_id.
+6. Deep-copy `src.extra`; merge `extra['fork']=metadata` per §3.4.
+7. Store `CheckpointData(messages=…, extra=…,
    parent_thread_id=src_thread_id)` under `new_thread_id`.
 
-`complete_run()`:
+`mark_run_complete()` under the lock:
 
-- Append `last_messages` to `src.messages`.
-- Add `run_id` to the completed-runs set; if already present →
+- Check `run_id NOT IN completions[thread_id]` → else
   `RunAlreadyCompletedError`.
+- Add `run_id` with the next monotonic counter value as the ordering
+  key.
+
+`append()` under the lock:
+
+- Optional pre-check: if any `message.run_id is not None` and that
+  run_id is already in `completions[thread_id]` → raise
+  `RunAlreadyCompletedError` (defense in depth; agent loop already
+  pre-flights at prompt() entry, but checking here protects direct
+  `Checkpointer.append()` calls).
+- Extend the messages list.
 
 No `forked_at_seq` field — Memory has no seq.
 
@@ -656,7 +867,7 @@ No `forked_at_seq` field — Memory has no seq.
 | Situation | Raised |
 |---|---|
 | `self.checkpointer is None` (fork or fork_once) | `RuntimeError("fork requires a checkpointer")` |
-| `fork_once()` finds HITL-bearing tool/middleware (§3.8.1) | `RuntimeError("fork_once() does not support HITL: <names>")` |
+| `fork_once()` finds HITL-bearing tool/middleware (§3.8.2) | `RuntimeError("fork_once() does not support HITL: <names>")` |
 | `src_thread_id` does not exist | `ThreadNotFoundError(src_thread_id)` |
 | `new_thread_id` already exists (fork) | `ThreadAlreadyExistsError(new_thread_id)` |
 | `after_run_id` has no completion marker on the source thread | `RunNotCompletedError(thread_id=src_thread_id, run_id=after_run_id)` |
@@ -669,10 +880,13 @@ No `forked_at_seq` field — Memory has no seq.
 ## 4. Migration / Compatibility
 
 - **Protocol change**: `Checkpointer.snapshot`, `Checkpointer.fork`,
-  `Checkpointer.complete_run` are new methods on the
-  `runtime_checkable` Protocol. Existing user-implemented checkpointers
-  keep type-checking; they only fail when the new methods are actually
-  called.
+  `Checkpointer.mark_run_complete`, `Checkpointer.load_pending`
+  are new methods on the `runtime_checkable` Protocol. Existing
+  user-implemented checkpointers keep type-checking; they only fail
+  when the new methods are actually called.
+  `Checkpointer.load_pending_request` is kept as a thin alias for
+  `load_pending()` returning only the request part — existing callers
+  unchanged.
 - **`Agent.prompt()` signature**: adds an optional keyword `run_id`
   and changes return type from `None` to `str`. Returning a value that
   the caller previously ignored is **not** a breaking change for
@@ -734,10 +948,32 @@ No `forked_at_seq` field — Memory has no seq.
     `forked_at_seq` is B's seq for Y, not A's
   - subsequent `prompt()` on a forked thread starts a new run_id; new
     messages get the new run_id; completion writes its own marker
-  - concurrent fork + complete_run on source serialize correctly
+  - concurrent fork + mark_run_complete on source serialize correctly
+  - **interleaved runs**: append run A's msgs (seq 1,2), append run
+    B's msgs (seq 3,4), mark B complete, mark A complete (later than
+    B). `fork(after_run_id=A)` copies A+B both (B completed earlier);
+    `fork(after_run_id=B)` copies only B; messages of B's seqs 3,4
+    are NOT pulled by `fork(after_run_id=A)` if A completed first
+    (regression test for the v2 R1 CRITICAL finding)
+  - **legacy + new mixed thread**: legacy NULL-run_id messages on a
+    pre-spec thread + a new completed run R. `fork(after_run_id=R)`
+    copies the legacy prefix AND R's messages, in source seq order;
+    `delete_run(thread_id, R)` (when implemented) removes only R's
+    messages, legacy prefix untouched
+  - **`Agent.prompt(run_id=R)` pre-flight check**: if R has a
+    completion marker on the source thread, raise
+    `RunAlreadyCompletedError` BEFORE any append happens (asserted
+    by snapshotting message count, attempting prompt, asserting
+    raise + unchanged count)
+  - **HITL resume run_id continuity**: prompt(run_id=R) pauses;
+    pending_request stores R; respond() recovers R via
+    `load_pending()` (single read), continues, every appended message
+    post-resume carries `run_id=R`, `mark_run_complete()` writes R's
+    marker on terminal exit. Second-pause variant: respond() pauses
+    again with same R, third respond() resumes again with same R
   - SQLite cross-connection: two `SQLiteCheckpointer` instances on
-    the same DB file, one `fork()` and one `complete_run()` from
-    different processes serialize via `BEGIN IMMEDIATE`
+    the same DB file, one `fork()` and one `mark_run_complete()`
+    from different processes serialize via `BEGIN IMMEDIATE`
   - legacy data: thread with `run_id=NULL` messages and no completion
     markers raises `RunNotCompletedError` on `fork(...)`
   - `CheckpointData.parent_thread_id` round-trip via `load()`
@@ -788,8 +1024,10 @@ All closed during brainstorm:
 - Run state ownership → cubepi (not cubebox)
 - Run_id source → accept-or-generate from `Agent.prompt`
 - Legacy data → not forkable / not deletable; no backfill
-- Run completion atomicity → same transaction as final append
-  (`complete_run()` Protocol method)
+- Run completion atomicity → NOT coupled to final append; separate
+  `mark_run_complete()` Protocol method called after the final
+  append, before `Agent.prompt()` returns. Crash window between the
+  two is acceptable (run looks unfinished, fork blocked, recoverable)
 - HITL pause/resume → same run_id across suspension; marker written
   on resume completion
 - fork_once HITL → banned via `requires_hitl` marker

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -249,7 +249,7 @@ will see.
 
 | Field | Copied? | Notes |
 |---|---|---|
-| `messages` `[0..message_count)` | yes | physical copy; Postgres/MySQL preserve the source seq values for the copied range |
+| `messages` `[0..message_count)` | yes | physical copy. Postgres/MySQL preserve the source seq values for the copied range. SQLite copies the JSON payloads under fresh global `id`s — its `messages.id` is a global auto-increment, not a per-thread seq, so identity is not meaningful to preserve. Memory copies in-list order. |
 | `extra` | yes | deep copy of the source JSON object (`json.loads(json.dumps(extra))`) |
 | `parent_thread_id` | written (new) | set to `src_thread_id` on new row |
 | `forked_at_seq` | written (new, Postgres/MySQL only) | seq of the last copied message. NULL for Memory and SQLite — those backends have no per-message seq column and forging a value would invite false continuation logic. The column exists in the SQLite schema for parity but is always NULL there. |
@@ -302,6 +302,23 @@ checkpointer instrumentation (if any) covers it.
 ### 3.7 API
 
 #### `cubepi.checkpointer.base`
+
+`CheckpointData` (the return type of `load()`) gains one optional
+field so callers can read the lineage of a loaded thread:
+
+```python
+@dataclass
+class CheckpointData:
+    messages: list[Message] = field(default_factory=list)
+    extra: JsonObject = field(default_factory=dict)
+    parent_thread_id: str | None = None   # NEW — None for non-fork threads
+```
+
+Memory and SQLite backends populate this from the new `parent_thread_id`
+they store (CheckpointData attr / `thread_extra` column respectively).
+Postgres and MySQL populate it from `cubepi_threads.parent_thread_id`.
+The field is unconditionally present on every load; backends that
+have no lineage information set it to `None`.
 
 ```python
 @runtime_checkable
@@ -438,26 +455,76 @@ class ForkOnceResult:
 
 ### 3.8 Per-backend implementation sketch
 
-- **Memory** (`cubepi/checkpointer/memory.py`): add a `dict[str, dict]`
-  of thread metadata (parent_thread_id, forked_at_seq, extra). `fork()`
-  copies the first N messages from the source list under the new key.
-  `snapshot()` slices the list. Boundary validation walks the prefix
-  once.
-- **SQLite** (`cubepi/checkpointer/sqlite.py`): a thread is currently
-  one row keyed by `thread_id`. Schema needs an additive migration to
-  add `parent_thread_id` (TEXT, NULL) and `forked_at_seq` (INTEGER,
-  always NULL). The existing checkpointer initialises its tables via
-  `CREATE TABLE IF NOT EXISTS`; the new columns are added at connect
-  time using the existing pattern (`PRAGMA table_info` probe, then
-  `ALTER TABLE … ADD COLUMN` if missing — exact form decided by the
-  plan to match what the file already does for schema upgrades).
-  `fork()` opens a transaction with `BEGIN IMMEDIATE` (RESERVED
-  lock), re-serializes the prefix into a new row, writes the
-  `parent_thread_id` reference, leaves `forked_at_seq` NULL, commits.
-  `forked_at_seq` exists in the schema purely for parity with the SQL
-  backends — SQLite stores the messages as a single serialized blob,
-  there are no per-message seqs to record, and synthesising one would
-  give callers a false invariant to depend on.
+- **Memory** (`cubepi/checkpointer/memory.py`): today it holds
+  `dict[str, CheckpointData]` keyed by `thread_id`, where
+  `CheckpointData` already carries `messages: list[Message]` and
+  `extra: JsonObject`. The current implementation has no lock — this
+  spec adds an `asyncio.Lock` for the fork transaction (the existing
+  methods are single-statement dict mutations that don't strictly
+  need it, but the lock keeps fork's read-validate-write atomic).
+  `CheckpointData` gains one optional field: `parent_thread_id: str
+  | None = None` (defaults to None for the no-fork case). `fork()`
+  takes the lock, slices the first `message_count` messages from
+  `src.messages` (deep-copying each via `model_copy(deep=True)`),
+  deep-copies `src.extra`, merges `extra['fork']=metadata` per §3.5,
+  and stores `CheckpointData(messages=..., extra=...,
+  parent_thread_id=src_thread_id)` under the new key. `snapshot()`
+  slices in-list order and runs the §3.3 validator. `forked_at_seq`
+  is not stored — Memory has no seq concept.
+- **SQLite** (`cubepi/checkpointer/sqlite.py`): the existing schema
+  is **three flat tables**, NOT a single thread row with a blob:
+  - `messages (id INTEGER PRIMARY KEY AUTOINCREMENT, thread_id TEXT,
+    message_json TEXT, created_at REAL)` — one row per message;
+    `id` is a global auto-increment sequence (not per-thread monotonic),
+    `thread_id` is a filter column with no index/constraint.
+  - `thread_extra (thread_id TEXT PRIMARY KEY, extra_json TEXT)` —
+    per-thread JSON extra.
+  - `thread_pending_request (thread_id TEXT PRIMARY KEY, …)` — HITL.
+
+  There is no `threads` table today. This spec extends `thread_extra`
+  to also carry lineage metadata (it is already the per-thread
+  metadata row keyed by `thread_id`, so this avoids inventing a
+  fourth table):
+
+  - Add `parent_thread_id TEXT NULL` column to `thread_extra`.
+  - Do NOT add `forked_at_seq` — SQLite has no per-thread seq to
+    record (the `messages.id` column is a global counter, not a
+    per-thread sequence, and copied rows get fresh ids on INSERT).
+    Per §3.5 this column is Postgres/MySQL-only.
+
+  The new column is added at connect time using the existing pattern
+  the file already uses for the `run_id` backfill (`PRAGMA table_info`
+  probe + `ALTER TABLE thread_extra ADD COLUMN parent_thread_id TEXT`
+  if missing). Pre-existing rows get NULL — there is no lineage to
+  reconstruct.
+
+  `fork()` runs inside a single `BEGIN IMMEDIATE` transaction
+  (RESERVED lock — see §3.4):
+
+  1. Validate source exists (`SELECT 1 FROM messages WHERE thread_id=?
+     LIMIT 1` OR `SELECT 1 FROM thread_extra WHERE thread_id=?`) →
+     `ThreadNotFoundError` if neither hits.
+  2. Validate new thread does not exist (same probes against
+     `new_thread_id`) → `ThreadAlreadyExistsError` if either hits.
+  3. Snapshot + boundary validation per §3.3 (reads `messages` ordered
+     by `id` LIMIT `message_count`, deserializes, validates prefix).
+  4. Copy messages: for the first `message_count` rows (ordered by
+     `id`), insert new rows with `thread_id = new_thread_id` and the
+     same `message_json`. New rows get fresh `id` values from the
+     global sequence — copied row identity is NOT preserved (this is
+     the §3.5 table footnote about SQLite).
+  5. Insert lineage row:
+     `INSERT INTO thread_extra (thread_id, extra_json, parent_thread_id)
+      VALUES (?, ?, ?)` — with deep-copied source `extra_json`
+     (merging `extra['fork']=metadata` per §3.5 before serializing)
+     and `parent_thread_id = src_thread_id`. If the source has no
+     `thread_extra` row (extra was never written), the new row still
+     gets inserted with `extra_json='{}'` and the parent reference.
+  6. Commit (releases the lock). Lock-timeout / SQLITE_BUSY → see
+     §3.4 contract (`CheckpointerLockTimeoutError`).
+
+  `pending_request` / `run_id` are not copied (their `thread_pending_request`
+  rows are not touched for `new_thread_id`).
 - **Postgres** (`cubepi/checkpointer/postgres/`): the columns already
   exist (schema version 3). `fork()` is a single transaction:
   - `INSERT INTO cubepi_threads (thread_id, parent_thread_id, forked_at_seq, extra, …) …`
@@ -671,6 +738,10 @@ channel) is explicit follow-up scope.
   - fork all messages → new thread reads back identically
   - fork prefix → new thread holds prefix, source still holds full
   - fork preserves `extra`; sets `parent_thread_id`
+  - subsequent `load(new_thread_id).parent_thread_id == src_thread_id`
+    (CheckpointData lineage round-trip)
+  - `load(src_thread_id).parent_thread_id is None` for an originally
+    non-forked source
   - `forked_at_seq` assertions: equals last copied seq for
     Postgres/MySQL; IS NULL for Memory/SQLite
   - fork copies `extra['fork']` from `metadata` arg (and overwrites

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -44,8 +44,10 @@ to every message and adds a per-run completion marker.
 
 - Per-message `run_id` field on `Message` (all three variants), persisted
   by every backend.
-- New `cubepi_run_completions` storage per backend recording which runs
-  have finished cleanly.
+- New `cubepi_runs` storage per backend recording per-run lifecycle:
+  `(thread_id, run_id, claimed_at, completed_at, completion_seq)`,
+  PK `(thread_id, run_id)`. Atomic claim on `Agent.prompt()` entry
+  prevents same-run_id races (see §3.6.1).
 - `Agent.prompt(message, *, run_id=None) -> str` (accept-or-generate;
   returns the run_id actually used).
 - `Checkpointer.fork(src, new, *, after_run_id, metadata=None) -> None`
@@ -88,7 +90,7 @@ to every message and adds a per-run completion marker.
 `fork()` physically copies messages of all completed runs up through
 `after_run_id` to the new thread, then records lineage
 (`parent_thread_id`, `forked_at_seq` for SQL backends) and copies the
-relevant `cubepi_run_completions` rows so the new thread keeps its
+relevant `cubepi_runs` rows so the new thread keeps its
 run history.
 
 Rejected: **logical pointer / COW**. Same rationale as v1:
@@ -111,11 +113,31 @@ The **only** fork handle is `after_run_id: str`. The new thread contains:
 
 1. Every message whose `run_id IS NULL` (legacy prefix — see §3.6.4),
    PLUS
-2. Every message whose `run_id` belongs to the set of completed runs
-   on `src_thread_id` whose `completed_at` is **at or before**
-   `after_run_id`'s `completed_at`.
+2. Every message whose `run_id` is in `cubepi_runs` for
+   `src_thread_id` with **`completion_seq IS NOT NULL` AND
+   `completion_seq <= after_run_id.completion_seq`**.
 
 Messages are inserted into the new thread in source seq order.
+
+#### Why `completion_seq`, not `completed_at`
+
+Wall-clock timestamps are not safe ordering keys:
+
+- SQLite's `julianday('now')` can produce identical values for runs
+  completed in the same tick.
+- MySQL `TIMESTAMP` precision varies by version and configuration.
+- Lex-tiebreaking by `run_id` is deterministic but **not the same as
+  correct completion ordering** — a later-completing run with a
+  lexicographically-earlier `run_id` would sort before an earlier
+  completion.
+
+`completion_seq` is a per-thread monotonic BIGINT allocated under the
+same per-thread lock that serializes other writes. The allocation is
+`(SELECT COALESCE(MAX(completion_seq), 0) + 1 FROM cubepi_runs WHERE
+thread_id = ? AND completion_seq IS NOT NULL)`. Under the lock this
+yields a strictly-monotonic per-thread sequence whose ordering matches
+real completion ordering. `completed_at` is retained as audit
+metadata only — never used for ordering or filtering.
 
 #### Why "set of completed runs", not "seq <= last_seq_of(after_run_id)"
 
@@ -131,14 +153,11 @@ This selection is also robust to:
 
 - **Interleaved runs**: each run's messages are addressed by tag, not
   by position. Gaps in seq are fine.
-- **In-flight runs**: their messages have a `run_id` not yet in
-  `cubepi_run_completions` → excluded.
+- **In-flight runs**: their messages have a `run_id` whose row has
+  `completion_seq IS NULL` → excluded.
 - **Mixed legacy + post-upgrade threads**: NULL-run_id messages are
   preserved as a chronological prefix, post-upgrade completed runs
   appear after.
-- **Tie in `completed_at`**: two completions at the same wall-clock
-  tick are tiebroken by lexicographic `run_id` for deterministic
-  output. (Rare in practice; documented for spec completeness.)
 
 #### Why a run is the right unit
 
@@ -188,7 +207,7 @@ needs the stronger guarantee.
   `save_pending_request()` use — to fence racing appends on the source
   for the duration of the fork. Then `INSERT INTO cubepi_threads`,
   `INSERT INTO cubepi_messages … SELECT …`,
-  `INSERT INTO cubepi_run_completions … SELECT …`. Commit releases
+  `INSERT INTO cubepi_runs … SELECT …`. Commit releases
   the lock.
 - **MySQL**: single transaction with `SELECT … FOR UPDATE` on the
   source `cubepi_threads` row. The existing `append()` already takes
@@ -213,10 +232,10 @@ world the copy will see:
 | Field / row | Copied? | Notes |
 |---|---|---|
 | `cubepi_messages` rows where `run_id IS NULL` OR `run_id IN {completed runs of src with completed_at <= after_run_id.completed_at}` | yes | physical copy; PG/MySQL preserve source `seq` values for the copied range. SQLite copies the JSON payloads under fresh global `id`s (its `messages.id` is a global auto-increment, not a per-thread seq). Memory copies in-list order. Each copied row keeps its original `run_id` value (or NULL). Source seq order is preserved across the copy. |
-| `cubepi_run_completions` rows for the copied runs | yes | so the new thread can be further forked / deleted by run |
+| `cubepi_runs` rows for the copied runs | yes | so the new thread can be further forked / deleted by run |
 | `extra` | yes | deep copy of the source JSON object |
 | `parent_thread_id` | written (new) | set to `src_thread_id` on the new thread row |
-| `forked_at_seq` | written (PG/MySQL only) | the `seq` of the last message in the copied set (highest copied seq). Memory and SQLite store no equivalent — those backends have no per-message seq column and lineage is recoverable from `parent_thread_id` + `cubepi_run_completions` alone. |
+| `forked_at_seq` | written (PG/MySQL only) | the `seq` of the last message in the copied set (highest copied seq). Memory and SQLite store no equivalent — those backends have no per-message seq column and lineage is recoverable from `parent_thread_id` + `cubepi_runs` alone. |
 | `extra['fork']` | written (new) when `metadata` arg supplied | overwrites any pre-existing `extra['fork']` on source (lineage is recoverable via the `parent_thread_id` chain) |
 | `pending_request` | **no** | new thread starts clean; HITL is run-state, not history |
 | `cubepi_threads.run_id` (the host-side HITL marker, NOT a run on this thread) | **no** | new thread has no run in flight |
@@ -267,58 +286,87 @@ about to be appended. **`Checkpointer.append()` signature does not
 change** — the run_id rides on the messages themselves
 (`Message.run_id` field, §3.6.5).
 
-If the caller supplies a `run_id` that already has a completion
-marker on the source thread, `prompt()` raises
-`RunAlreadyCompletedError` **before any append happens** — runs are
-append-only; you cannot continue or re-run a completed run. (Use a
-new `run_id` for a new exchange.) The pre-flight check is mandatory
-to prevent "messages were written before the conflict was detected"
-half-states.
+Before any append happens, `Agent.prompt()` calls
+`Checkpointer.claim_run(thread_id, run_id)` which atomically inserts
+a row into `cubepi_runs` with `claimed_at = now()` and
+`completed_at = NULL`. The insert is the synchronization point:
 
-There is a narrow race window: two processes both pre-check, both see
-no marker for run_id R, both begin appending. The first to call
-`mark_run_complete()` wins; the second raises
-`RunAlreadyCompletedError` from the marker INSERT (unique PK on
-`(thread_id, run_id)`). The losing process's intermediate appends
-remain on the thread, tagged with R but with no marker → fork by R
-excludes them, and the future `delete_run(thread_id, R)` cleans them
-up. Callers that race must retry with a fresh `run_id`. Hosts that
-serialize runs per thread (cubebox does) never hit this.
+- PK conflict where the existing row has `completed_at IS NULL` →
+  `RunAlreadyClaimedError` (another process is currently running
+  this run_id; concurrent claim is rejected, the loser must retry
+  with a different run_id)
+- PK conflict where the existing row has `completed_at IS NOT NULL` →
+  `RunAlreadyCompletedError` (this run_id has already finished;
+  runs are append-only — use a new `run_id`)
 
-#### 3.6.2 Completion marker — when written
+This **eliminates** the v2 R1 "messages were appended before the
+conflict was detected" half-state: no message is appended unless the
+claim succeeded, and a successful claim guarantees no other process
+can append messages tagged with the same run_id (they will hit
+`RunAlreadyClaimedError` at their own claim step).
 
-The marker `cubepi_run_completions(thread_id, run_id, completed_at)`
-is written by a dedicated, separate Protocol method
-`Checkpointer.mark_run_complete(thread_id, run_id) -> None` — a
-single-row INSERT, called AFTER the run's final `append()` and
-BEFORE `Agent.prompt()` returns to the caller.
+`Agent.state.active_run_id` is set to the claimed `run_id` for the
+duration of the run, so observers (callbacks, listeners, debugging)
+can see it. The same value is the return value of a successful
+`prompt()` call.
 
-**The marker write is NOT atomic with the final append.** The
+If `Agent.prompt()` raises any error AFTER a successful claim, the
+claim row is left with `completed_at IS NULL` (abandoned). The
+abandoned row prevents accidental reuse of the same run_id (still
+gets `RunAlreadyClaimedError` on retry). The future `delete_run()`
+admin operation can clean up abandoned claims.
+
+If `prompt()` raises BEFORE the claim (validation failure, no
+checkpointer, etc.), no row is inserted.
+
+#### 3.6.2 Completion — when written
+
+Completion is recorded by `Checkpointer.mark_run_complete(thread_id,
+run_id)`, which under the per-thread lock:
+
+1. Allocates the next per-thread `completion_seq` (see §3.2).
+2. `UPDATE cubepi_runs SET completed_at = now(), completion_seq = ?
+   WHERE thread_id = ? AND run_id = ? AND completed_at IS NULL`.
+3. If 0 rows updated: either the row doesn't exist
+   (`RunNotClaimedError`) or it is already completed
+   (`RunAlreadyCompletedError`). Backends distinguish the two by a
+   followup SELECT under the same lock.
+
+`mark_run_complete()` is called by the agent loop AFTER the run's
+final `append()` and BEFORE `Agent.prompt()` returns.
+
+**The completion write is NOT atomic with the final append.** The
 existing cubepi event loop (`cubepi/agent/loop.py`) persists each
 message on its own `MessageEndEvent`; the loop only knows it has
 finished when `AgentEndEvent` fires, *after* the final append.
-Trying to atomically couple the two would require an Agent-layer
-buffering rewrite that is out of scope.
+Coupling them atomically would require an Agent-layer buffering
+rewrite that is out of scope.
 
-This is acceptable. Two failure modes and their consequences:
+Two failure modes and their consequences:
 
 - **Process crash between final append and `mark_run_complete()`**:
-  messages of run R are persisted but no completion marker exists.
-  `fork(after_run_id=R)` raises `RunNotCompletedError`. The user
-  sees "the run looks finished but I can't fork it yet." A future
-  admin / recovery API can backfill the marker. The data is not
-  corrupt — just in an unmarked state, same as an abandoned run.
+  messages of run R are persisted; the `cubepi_runs` row remains
+  with `completed_at IS NULL` (abandoned claim). `fork(after_run_id=R)`
+  raises `RunNotCompletedError`. The data is not corrupt; the run is
+  in the same "abandoned" state as if the loop had been killed for
+  any other reason. The future `delete_run()` admin operation can
+  remove abandoned claims (and their messages) by querying
+  `WHERE completed_at IS NULL`. The same operation can also
+  manually-finalize via direct DB UPDATE if the host knows the run
+  actually completed.
 - **Transient checkpointer failure on `mark_run_complete()`**:
-  `prompt()` raises the underlying error so the caller knows. The
-  messages are already persisted; retrying just `mark_run_complete()`
-  with the same `(thread_id, run_id)` succeeds. Idempotency: if the
-  caller retries `prompt(run_id=R)` instead, it gets
-  `RunAlreadyCompletedError` from the pre-flight check (§3.6.1)
-  EXCEPT — pre-flight checks for the marker; if the marker still
-  isn't there because of the same persistent failure, the caller can
-  resume by calling `mark_run_complete()` directly, or by abandoning
-  R and starting fresh. The recommended pattern is "retry the marker
-  call, not the whole prompt".
+  `Agent.prompt()` raises `CompletionMarkerFailedError(run_id=R,
+  cause=<underlying>)`. The exception **carries the run_id** so
+  callers using `prompt(run_id=None)` (cubepi-generated id) still
+  know the value and can:
+  - retry `mark_run_complete(thread_id, R)` directly (idempotent —
+    the row exists, only completed_at update is in flight); OR
+  - abandon R; the messages remain under R but the run is not
+    forkable. `delete_run(R)` cleans up later.
+
+The recommended retry pattern: "retry `mark_run_complete()`, not the
+whole `prompt()`" — re-running `prompt(run_id=R)` raises
+`RunAlreadyClaimedError` because R's claim row already exists.
 
 Trigger conditions for the agent loop to call `mark_run_complete()`:
 
@@ -327,14 +375,15 @@ Trigger conditions for the agent loop to call `mark_run_complete()`:
   non-suspended terminal state)
 - AND no pending HITL request remains for this run
 
-If `prompt()` returns because of:
+If `prompt()` returns / raises because of:
 
-- **HITL pause** (`pending_request` set) → marker NOT written; resumed
-  by `respond()` (§3.6.3).
-- **Exception / abort / cancellation** → marker NOT written; the run
-  is abandoned. Its messages remain on the thread under the same
-  `run_id`, but `fork(after_run_id=X)` raises `RunNotCompletedError`,
-  and the future `delete_run(X)` can clean them up.
+- **HITL pause** (`pending_request` set) → completion NOT written;
+  resumed by `respond()` (§3.6.3). Claim row remains (`completed_at
+  IS NULL`) so concurrent attempts to reuse the run_id correctly
+  hit `RunAlreadyClaimedError`.
+- **Exception / abort / cancellation** → completion NOT written;
+  claim row remains. `fork(after_run_id=R)` raises
+  `RunNotCompletedError`. The future `delete_run(R)` can clean up.
 
 #### 3.6.3 HITL pause / resume continuity
 
@@ -480,7 +529,7 @@ class Checkpointer(Protocol):
     ) -> None:
         """Atomically create `new_thread_id` populated with the messages
         of every completed run on `src_thread_id` up through
-        `after_run_id`. Copies `cubepi_run_completions` rows for the
+        `after_run_id`. Copies `cubepi_runs` rows for the
         included runs. Records `parent_thread_id=src_thread_id` and
         (PG/MySQL only) `forked_at_seq`. Copies `extra` deeply. Writes
         `extra['fork'] = metadata` when `metadata` is supplied.
@@ -489,18 +538,36 @@ class Checkpointer(Protocol):
         `RunNotCompletedError`.
         """
 
+    async def claim_run(
+        self,
+        thread_id: str,
+        run_id: str,
+    ) -> None:
+        """Atomically insert a `cubepi_runs` row with `claimed_at =
+        now()` and `completed_at = NULL`. PK conflict raises
+        `RunAlreadyClaimedError` (existing row has completed_at IS
+        NULL) or `RunAlreadyCompletedError` (existing row has
+        completed_at IS NOT NULL). See §3.6.1.
+
+        Called by `Agent.prompt()` before any `append()` of the run.
+        """
+
     async def mark_run_complete(
         self,
         thread_id: str,
         run_id: str,
     ) -> None:
-        """Insert the `cubepi_run_completions` row for `(thread_id,
-        run_id)`. Single-row write, NOT coupled to the final append
-        (see §3.6.2 for the rationale).
+        """Allocate the next per-thread `completion_seq` under the
+        per-thread lock and UPDATE the `cubepi_runs` row to set
+        `completed_at = now()` and `completion_seq = <allocated>`.
 
         Called by the agent loop AFTER the run's final `append()` and
-        BEFORE `Agent.prompt()` returns. PK conflict on
-        `(thread_id, run_id)` raises `RunAlreadyCompletedError`.
+        BEFORE `Agent.prompt()` returns. NOT coupled to the final
+        append — see §3.6.2.
+
+        Raises `RunNotClaimedError` if no row exists for
+        `(thread_id, run_id)`, or `RunAlreadyCompletedError` if the
+        row's `completed_at` is already non-NULL.
         """
 
     async def load_pending(
@@ -527,14 +594,43 @@ class ThreadAlreadyExistsError(CheckpointerError): ...
 
 
 class RunNotCompletedError(CheckpointerError):
-    """No completion marker for (thread_id, run_id). The run either
-    does not exist on this thread, was paused for HITL and never
-    resumed, or failed / was aborted before terminal completion."""
+    """The cubepi_runs row for (thread_id, run_id) either does not
+    exist, or exists with completed_at IS NULL (paused for HITL,
+    abandoned, or in-flight)."""
+
+
+class RunNotClaimedError(CheckpointerError):
+    """mark_run_complete() called but no cubepi_runs row exists for
+    (thread_id, run_id). Indicates a logic bug — claim_run() was
+    not called or was not persisted."""
+
+
+class RunAlreadyClaimedError(CheckpointerError):
+    """claim_run() called but a cubepi_runs row already exists for
+    (thread_id, run_id) with completed_at IS NULL. Another process
+    is currently running this run_id (or the prior attempt was
+    abandoned without cleanup). Retry with a different run_id."""
 
 
 class RunAlreadyCompletedError(CheckpointerError):
-    """The run already has a completion marker. Runs are append-only;
+    """claim_run() or mark_run_complete() called but the cubepi_runs
+    row already has completed_at IS NOT NULL. Runs are append-only;
     start a new run with a different run_id."""
+
+
+class CompletionMarkerFailedError(CheckpointerError):
+    """mark_run_complete() failed AFTER the run's final append
+    succeeded. The exception carries the `run_id` so callers using
+    Agent.prompt(run_id=None) (cubepi-generated) can recover it and
+    retry mark_run_complete() directly. See §3.6.2."""
+
+    def __init__(self, *, thread_id: str, run_id: str, cause: BaseException):
+        super().__init__(
+            f"mark_run_complete failed for ({thread_id}, {run_id}): {cause}"
+        )
+        self.thread_id = thread_id
+        self.run_id = run_id
+        self.__cause__ = cause
 
 
 class CheckpointerLockTimeoutError(CheckpointerError):
@@ -543,6 +639,20 @@ class CheckpointerLockTimeoutError(CheckpointerError):
 ```
 
 #### `cubepi.agent.agent`
+
+The existing `AgentState` dataclass gains one field:
+
+```python
+@dataclass
+class AgentState:
+    # ... existing fields ...
+    active_run_id: str | None = None     # NEW
+```
+
+Set to the claimed run_id at the start of `prompt()` (after a
+successful `claim_run()`), cleared back to `None` when the prompt
+returns or raises. Observable to listeners / debugging without
+needing the prompt() return value.
 
 ```python
 class Agent(Generic[TMessage]):
@@ -566,7 +676,12 @@ class Agent(Generic[TMessage]):
         *,
         run_id: str | None = None,
     ) -> str:
-        """See §3.6.1. Returns the run_id actually used."""
+        """See §3.6.1. Returns the run_id actually used. On any failure
+        AFTER a successful claim, `self.state.active_run_id` remains
+        set to the run_id so callers (and exception handlers) can
+        recover it even when the return value is unavailable. On
+        CompletionMarkerFailedError specifically, the run_id is also
+        carried on the exception."""
 
     async def fork(
         self,
@@ -691,61 +806,80 @@ two additive changes (alembic migration in cubebox / cubepi-using apps):
 
 - `ALTER TABLE cubepi_messages ADD COLUMN run_id VARCHAR/TEXT NULL`
   + index `(thread_id, run_id)`.
-- New table `cubepi_run_completions(thread_id TEXT/VARCHAR, run_id
-  TEXT/VARCHAR, completed_at TIMESTAMPTZ, PRIMARY KEY (thread_id,
-  run_id), FOREIGN KEY (thread_id) REFERENCES cubepi_threads)`.
-  Postgres: `HASH (thread_id)` partitioned to match `cubepi_messages`.
-  MySQL: `KEY (thread_id)` partitioned, no FK (consistent with
-  `cubepi_messages`).
+- New table `cubepi_runs`:
+  - `thread_id TEXT/VARCHAR NOT NULL`
+  - `run_id TEXT/VARCHAR NOT NULL`
+  - `claimed_at TIMESTAMPTZ NOT NULL DEFAULT now()`
+  - `completed_at TIMESTAMPTZ NULL`
+  - `completion_seq BIGINT NULL` (allocated per-thread monotonic
+    under the per-thread lock at mark_run_complete time;
+    NULL means "claimed but not completed")
+  - PRIMARY KEY `(thread_id, run_id)`
+  - INDEX `(thread_id, completion_seq)` for fork's set-selection query
+  - Postgres: `HASH (thread_id)` partitioned to match
+    `cubepi_messages`; FK to `cubepi_threads(thread_id)`
+  - MySQL: `KEY (thread_id)` partitioned (no FK, consistent with
+    `cubepi_messages`)
 
 `fork()` in one transaction:
 
 1. Advisory lock / `FOR UPDATE` on the source thread.
-2. `SELECT completed_at AS cutoff FROM cubepi_run_completions WHERE
-   thread_id = $src AND run_id = $after_run_id` → if no row,
-   `RunNotCompletedError`.
-3. `INSERT INTO cubepi_threads (thread_id, parent_thread_id,
-   forked_at_seq, extra, …)
-   VALUES ($new, $src, $last_copied_seq, $merged_extra, …)` —
-   `ThreadAlreadyExistsError` on PK violation. `$last_copied_seq` is
-   computed below in step 4 (or set with a CTE / temp value depending
-   on implementation).
-4. `INSERT INTO cubepi_messages (thread_id, seq, role, run_id,
-   metadata, payload)
+2. `SELECT completion_seq AS cutoff FROM cubepi_runs WHERE
+   thread_id = $src AND run_id = $after_run_id AND completion_seq IS
+   NOT NULL` → if no row, `RunNotCompletedError`.
+3. Copy messages (compute `$last_copied_seq` in the same statement
+   via RETURNING or follow-up):
+   ```sql
+   INSERT INTO cubepi_messages (thread_id, seq, role, run_id,
+                                metadata, payload)
    SELECT $new, seq, role, run_id, metadata, payload
    FROM cubepi_messages
    WHERE thread_id = $src
      AND (
-       run_id IS NULL                                   -- legacy prefix
+       run_id IS NULL
        OR run_id IN (
-         SELECT run_id FROM cubepi_run_completions
+         SELECT run_id FROM cubepi_runs
          WHERE thread_id = $src
-           AND (completed_at, run_id) <= ($cutoff, $after_run_id)
+           AND completion_seq IS NOT NULL
+           AND completion_seq <= $cutoff
        )
      )
-   ORDER BY seq`.
-   The composite `(completed_at, run_id)` comparison gives the
-   deterministic tiebreak from §3.2.
-5. `INSERT INTO cubepi_run_completions (thread_id, run_id,
-   completed_at)
-   SELECT $new, run_id, completed_at
-   FROM cubepi_run_completions
+   ORDER BY seq;
+   ```
+4. `INSERT INTO cubepi_threads (thread_id, parent_thread_id,
+   forked_at_seq, extra, …)
+   VALUES ($new, $src, $last_copied_seq, $merged_extra, …)` —
+   `ThreadAlreadyExistsError` on PK violation.
+   `$last_copied_seq = (SELECT MAX(seq) FROM cubepi_messages WHERE
+   thread_id = $new)`.
+5. `INSERT INTO cubepi_runs (thread_id, run_id, claimed_at,
+   completed_at, completion_seq)
+   SELECT $new, run_id, claimed_at, completed_at, completion_seq
+   FROM cubepi_runs
    WHERE thread_id = $src
-     AND (completed_at, run_id) <= ($cutoff, $after_run_id)`.
-6. (Optional, audit) `UPDATE cubepi_threads SET forked_at_seq =
-   (SELECT MAX(seq) FROM cubepi_messages WHERE thread_id = $new)
-   WHERE thread_id = $new` — sets the lineage marker.
-7. Commit.
+     AND completion_seq IS NOT NULL
+     AND completion_seq <= $cutoff`.
+6. Commit.
 
-`mark_run_complete()` (single statement, own transaction OR within
-the existing append/save lock window — the spec doesn't mandate;
-either is correct because the row is independently consistent):
+`claim_run()`:
 
-- Take the per-thread advisory lock / `FOR UPDATE` to serialize
-  vs. concurrent appends / forks.
-- `INSERT INTO cubepi_run_completions (thread_id, run_id,
-  completed_at) VALUES (?, ?, now())` —
-  `RunAlreadyCompletedError` on PK violation.
+- Take per-thread advisory lock / `FOR UPDATE`.
+- `INSERT INTO cubepi_runs (thread_id, run_id) VALUES (?, ?)` →
+  on PK conflict, `SELECT completed_at FROM cubepi_runs WHERE
+  thread_id = ? AND run_id = ?` → if NULL,
+  `RunAlreadyClaimedError`; else `RunAlreadyCompletedError`.
+- Commit.
+
+`mark_run_complete()`:
+
+- Take per-thread advisory lock / `FOR UPDATE`.
+- `next_seq = (SELECT COALESCE(MAX(completion_seq), 0) + 1 FROM
+  cubepi_runs WHERE thread_id = ? AND completion_seq IS NOT NULL)`.
+- `UPDATE cubepi_runs SET completed_at = now(), completion_seq =
+  $next_seq WHERE thread_id = ? AND run_id = ? AND completed_at IS
+  NULL`.
+- If 0 rows updated: SELECT to distinguish
+  `RunNotClaimedError` vs `RunAlreadyCompletedError`.
 - Commit.
 
 `append()` (existing) is unchanged in surface but must persist
@@ -758,49 +892,69 @@ Schema additions at connect time using the existing PRAGMA-probe +
 `thread_pending_request`):
 
 - `ALTER TABLE messages ADD COLUMN run_id TEXT NULL`.
-- `CREATE TABLE IF NOT EXISTS run_completions (thread_id TEXT NOT
-  NULL, run_id TEXT NOT NULL, completed_at REAL NOT NULL DEFAULT
-  (julianday('now')), PRIMARY KEY (thread_id, run_id))`.
+- `CREATE TABLE IF NOT EXISTS runs (thread_id TEXT NOT NULL, run_id
+  TEXT NOT NULL, claimed_at REAL NOT NULL DEFAULT (julianday('now')),
+  completed_at REAL NULL, completion_seq INTEGER NULL, PRIMARY KEY
+  (thread_id, run_id))`.
+- `CREATE INDEX IF NOT EXISTS ix_runs_thread_completion ON runs
+  (thread_id, completion_seq)`.
 - `ALTER TABLE thread_extra ADD COLUMN parent_thread_id TEXT NULL`.
 
 `fork()`:
 
 1. `BEGIN IMMEDIATE`.
 2. Validate source exists; validate `(src_thread_id, after_run_id)`
-   has a `run_completions` row → else `RunNotCompletedError`.
+   has a `runs` row with `completion_seq IS NOT NULL` → else
+   `RunNotCompletedError`.
 3. Validate new thread does not exist (probe `messages` /
-   `thread_extra` / `run_completions` for `new_thread_id`) →
+   `thread_extra` / `runs` for `new_thread_id`) →
    `ThreadAlreadyExistsError`.
-4. Read cutoff: `SELECT completed_at FROM run_completions WHERE
-   thread_id = $src AND run_id = $after_run_id` (already validated
-   non-null in step 2).
+4. Read cutoff: `SELECT completion_seq FROM runs WHERE thread_id =
+   $src AND run_id = $after_run_id` (validated non-null in step 2).
 5. `INSERT INTO messages (thread_id, run_id, message_json)
    SELECT $new, run_id, message_json FROM messages
    WHERE thread_id = $src
      AND (
        run_id IS NULL
        OR run_id IN (
-         SELECT run_id FROM run_completions
+         SELECT run_id FROM runs
          WHERE thread_id = $src
-           AND (completed_at, run_id) <= ($cutoff, $after_run_id)
+           AND completion_seq IS NOT NULL
+           AND completion_seq <= $cutoff
        )
      )
    ORDER BY id`. New rows get fresh global `id`s (the `messages.id`
    column is a global auto-increment; identity is not preserved
    across the copy, but per-thread row order is).
-6. `INSERT INTO run_completions (thread_id, run_id, completed_at)
-   SELECT $new, run_id, completed_at FROM run_completions
+6. `INSERT INTO runs (thread_id, run_id, claimed_at, completed_at,
+   completion_seq)
+   SELECT $new, run_id, claimed_at, completed_at, completion_seq
+   FROM runs
    WHERE thread_id = $src
-     AND (completed_at, run_id) <= ($cutoff, $after_run_id)`.
+     AND completion_seq IS NOT NULL
+     AND completion_seq <= $cutoff`.
 7. `INSERT INTO thread_extra (thread_id, extra_json, parent_thread_id)
    VALUES ($new, $merged_extra_json, $src)`.
 8. Commit.
 
+`claim_run()`:
+
+- `BEGIN IMMEDIATE`.
+- `INSERT INTO runs (thread_id, run_id) VALUES (?, ?)` → on PK
+  conflict, `SELECT completed_at FROM runs WHERE thread_id=? AND
+  run_id=?`; NULL → `RunAlreadyClaimedError`, non-NULL →
+  `RunAlreadyCompletedError`.
+- Commit.
+
 `mark_run_complete()`:
 
 - `BEGIN IMMEDIATE`.
-- `INSERT INTO run_completions (thread_id, run_id) VALUES (?, ?)` →
-  `RunAlreadyCompletedError` if `(thread_id, run_id)` PK conflict.
+- `next_seq = (SELECT COALESCE(MAX(completion_seq), 0) + 1 FROM
+  runs WHERE thread_id=? AND completion_seq IS NOT NULL)`.
+- `UPDATE runs SET completed_at = julianday('now'), completion_seq =
+  $next_seq WHERE thread_id=? AND run_id=? AND completed_at IS NULL`.
+- If 0 rows updated: SELECT to distinguish
+  `RunNotClaimedError` vs `RunAlreadyCompletedError`.
 - Commit.
 
 `append()` is also wrapped in `BEGIN IMMEDIATE` (uniform writer
@@ -815,49 +969,59 @@ No `forked_at_seq` column added — SQLite has no per-thread seq.
 `MemoryCheckpointer` today is `dict[str, CheckpointData]`. This spec:
 
 - Extends `CheckpointData` with `parent_thread_id: str | None = None`.
-- Adds an internal `dict[str, dict[str, float]]` mapping
-  `thread_id -> {run_id: completed_at_monotonic_index}` — the value
-  is just an insertion-order counter (per-thread monotonic int)
-  serving as the equivalent of `completed_at` for ordering. Memory
-  does not have a real wall-clock requirement; the counter is
-  sufficient for the `(completed_at, run_id) <= cutoff` comparison.
+- Adds an internal `dict[str, dict[str, RunState]]` mapping
+  `thread_id -> {run_id: RunState(claimed_at, completed_at,
+  completion_seq)}` where `completed_at` / `completion_seq` are None
+  until the run is marked complete. `completion_seq` is a per-thread
+  monotonic int allocated in `mark_run_complete()` under the lock,
+  mirroring the SQL backends.
 - Adds a single shared `asyncio.Lock` that ALL write paths
-  (`append`, `save_extra`, `save_pending_request`,
-  `mark_run_complete`, `fork`) take. The existing single-statement
-  methods didn't strictly need one, but uniform locking removes the
-  finding-#4 check-then-write race in this backend.
-- `Message.run_id` is just a field — Memory persists the whole
-  Message via reference, so no extra storage scaffolding.
+  (`append`, `save_extra`, `save_pending_request`, `claim_run`,
+  `mark_run_complete`, `fork`) take. Uniform locking removes
+  check-then-write races.
+- `Message.run_id` is just a field — Memory persists the Message via
+  reference, no extra scaffolding.
 
 `fork()` under the lock:
 
 1. Source-exists check, new-thread-does-not-exist check.
-2. Look up the completed run_ids map for `src_thread_id`; if
-   `after_run_id` not in it → `RunNotCompletedError`.
-3. Compute the cutoff index = `completions[src][after_run_id]`.
-4. Walk `src.messages` in order. For each message: include it if
-   `m.run_id is None` OR `(completions[src][m.run_id], m.run_id) <=
-   (cutoff, after_run_id)`. Deep-copy via `model_copy(deep=True)`.
-5. Subset of `src`'s completion map filtered by the same cutoff:
-   carry under the new thread_id.
+2. Look up `runs[src][after_run_id]`; if missing or
+   `completion_seq is None` → `RunNotCompletedError`.
+3. Cutoff = `runs[src][after_run_id].completion_seq`.
+4. Walk `src.messages` in order. Include each message if
+   `m.run_id is None` OR `runs[src][m.run_id].completion_seq is not
+   None AND runs[src][m.run_id].completion_seq <= cutoff`.
+   Deep-copy via `model_copy(deep=True)`.
+5. Filter `runs[src]` to entries with `completion_seq IS NOT NULL
+   AND completion_seq <= cutoff`; deep-copy under the new thread_id.
 6. Deep-copy `src.extra`; merge `extra['fork']=metadata` per §3.4.
 7. Store `CheckpointData(messages=…, extra=…,
    parent_thread_id=src_thread_id)` under `new_thread_id`.
 
+`claim_run()` under the lock:
+
+- If `run_id in runs[thread_id]`: check
+  `runs[thread_id][run_id].completed_at` → None →
+  `RunAlreadyClaimedError`; non-None → `RunAlreadyCompletedError`.
+- Else insert `RunState(claimed_at=monotonic_now(),
+  completed_at=None, completion_seq=None)`.
+
 `mark_run_complete()` under the lock:
 
-- Check `run_id NOT IN completions[thread_id]` → else
-  `RunAlreadyCompletedError`.
-- Add `run_id` with the next monotonic counter value as the ordering
-  key.
+- `state = runs[thread_id].get(run_id)`.
+- If missing → `RunNotClaimedError`.
+- If `state.completed_at is not None` → `RunAlreadyCompletedError`.
+- Else allocate `next_seq = max((s.completion_seq for s in
+  runs[thread_id].values() if s.completion_seq is not None),
+  default=0) + 1`; update state's completed_at + completion_seq.
 
 `append()` under the lock:
 
-- Optional pre-check: if any `message.run_id is not None` and that
-  run_id is already in `completions[thread_id]` → raise
-  `RunAlreadyCompletedError` (defense in depth; agent loop already
-  pre-flights at prompt() entry, but checking here protects direct
-  `Checkpointer.append()` calls).
+- For each message with `m.run_id is not None`: if `m.run_id in
+  runs[thread_id]` and `runs[thread_id][m.run_id].completed_at is
+  not None` → raise `RunAlreadyCompletedError`. (Defense in depth;
+  Agent.prompt() pre-claim makes this rare, but protects direct
+  `Checkpointer.append()` callers.)
 - Extend the messages list.
 
 No `forked_at_seq` field — Memory has no seq.
@@ -870,8 +1034,11 @@ No `forked_at_seq` field — Memory has no seq.
 | `fork_once()` finds HITL-bearing tool/middleware (§3.8.2) | `RuntimeError("fork_once() does not support HITL: <names>")` |
 | `src_thread_id` does not exist | `ThreadNotFoundError(src_thread_id)` |
 | `new_thread_id` already exists (fork) | `ThreadAlreadyExistsError(new_thread_id)` |
-| `after_run_id` has no completion marker on the source thread | `RunNotCompletedError(thread_id=src_thread_id, run_id=after_run_id)` |
-| `prompt(run_id=R)` and `R` already has a completion marker on the thread | `RunAlreadyCompletedError(thread_id=..., run_id=R)` |
+| `after_run_id`'s `cubepi_runs` row missing or has `completion_seq IS NULL` | `RunNotCompletedError(thread_id=src_thread_id, run_id=after_run_id)` |
+| `prompt(run_id=R)` and `R` is currently claimed (completed_at IS NULL) on the thread | `RunAlreadyClaimedError(thread_id=..., run_id=R)` |
+| `prompt(run_id=R)` and `R` has completed_at IS NOT NULL on the thread | `RunAlreadyCompletedError(thread_id=..., run_id=R)` |
+| `mark_run_complete()` called without a prior `claim_run()` | `RunNotClaimedError(thread_id=..., run_id=...)` — indicates an agent-loop logic bug |
+| `mark_run_complete()` fails AFTER the run's final append succeeded | `CompletionMarkerFailedError(thread_id=..., run_id=..., cause=...)` — `run_id` is recoverable even when `prompt(run_id=None)` was used |
 | `Agent.fork_once()` child run errors | propagates (same surface as `Agent.prompt()`) |
 | `Agent.fork_once()` is cancelled mid-turn | `asyncio.CancelledError` re-raises after transient agent abort completes (best-effort; see §3.8 step 6) |
 | SQLite cannot acquire writer lock within `busy_timeout` | `CheckpointerLockTimeoutError` |
@@ -880,10 +1047,11 @@ No `forked_at_seq` field — Memory has no seq.
 ## 4. Migration / Compatibility
 
 - **Protocol change**: `Checkpointer.snapshot`, `Checkpointer.fork`,
-  `Checkpointer.mark_run_complete`, `Checkpointer.load_pending`
-  are new methods on the `runtime_checkable` Protocol. Existing
-  user-implemented checkpointers keep type-checking; they only fail
-  when the new methods are actually called.
+  `Checkpointer.claim_run`, `Checkpointer.mark_run_complete`,
+  `Checkpointer.load_pending` are new methods on the
+  `runtime_checkable` Protocol. Existing user-implemented
+  checkpointers keep type-checking; they only fail when the new
+  methods are actually called.
   `Checkpointer.load_pending_request` is kept as a thin alias for
   `load_pending()` returning only the request part — existing callers
   unchanged.
@@ -897,7 +1065,7 @@ No `forked_at_seq` field — Memory has no seq.
 - **`Agent.respond()` signature**: unchanged. Internal logic reads
   `run_id` from `pending_request`.
 - **Storage**: Postgres / MySQL — schema v3 → v4 (additive: one
-  column on `cubepi_messages`, one new table `cubepi_run_completions`,
+  column on `cubepi_messages`, one new table `cubepi_runs`,
   matching partition strategy). Alembic migration provided.
   SQLite — additive `ALTER TABLE` and `CREATE TABLE IF NOT EXISTS` at
   connect time. Memory — N/A.
@@ -929,7 +1097,7 @@ No `forked_at_seq` field — Memory has no seq.
     DOES write it once the resumed loop completes
   - fork happy path: source has 3 completed runs A, B, C →
     `fork(after_run_id=B)` produces a thread with messages of A+B
-    (in source order), `run_completions` rows for A+B, and no
+    (in source order), `runs` rows for A+B, and no
     pending_request
   - fork preserves `extra`; sets `parent_thread_id`; (PG/MySQL) sets
     `forked_at_seq` to the last copied seq
@@ -960,11 +1128,33 @@ No `forked_at_seq` field — Memory has no seq.
     copies the legacy prefix AND R's messages, in source seq order;
     `delete_run(thread_id, R)` (when implemented) removes only R's
     messages, legacy prefix untouched
-  - **`Agent.prompt(run_id=R)` pre-flight check**: if R has a
-    completion marker on the source thread, raise
-    `RunAlreadyCompletedError` BEFORE any append happens (asserted
-    by snapshotting message count, attempting prompt, asserting
-    raise + unchanged count)
+  - **`Agent.prompt(run_id=R)` atomic claim**: if R is already
+    claimed (completed_at IS NULL) on the thread, raise
+    `RunAlreadyClaimedError` BEFORE any append happens. If R is
+    already completed, raise `RunAlreadyCompletedError`. In both
+    cases assert the source message count is unchanged.
+  - **Same-run_id concurrent claim race** (regression test for v2
+    R2 HIGH #1): two coroutines call `Agent.prompt(thread, run_id=R)`
+    concurrently. Exactly one claim succeeds and proceeds to
+    completion; the other raises `RunAlreadyClaimedError` with ZERO
+    appends. After both settle, `fork(after_run_id=R)` includes only
+    the winning process's messages (none from the loser, because the
+    loser never appended).
+  - **`completion_seq` strict ordering** (regression test for v2 R2
+    HIGH #2): mark runs A, B, C complete in that order; assert
+    `runs[A].completion_seq < runs[B].completion_seq <
+    runs[C].completion_seq` strictly, regardless of wall-clock
+    timestamps. Force a wall-clock tie (mock now() to return the
+    same value) and assert ordering is still strict and matches
+    actual completion order.
+  - **`CompletionMarkerFailedError` recovery** (regression test for
+    v2 R2 HIGH #3): use `Agent.prompt(run_id=None)` to let cubepi
+    generate the run_id. Inject a failure on `mark_run_complete()`.
+    Assert the exception is `CompletionMarkerFailedError`, that
+    `exc.run_id` matches `Agent.state.active_run_id` from
+    immediately before, and that retrying
+    `checkpointer.mark_run_complete(thread_id, exc.run_id)`
+    successfully finishes the run.
   - **HITL resume run_id continuity**: prompt(run_id=R) pauses;
     pending_request stores R; respond() recovers R via
     `load_pending()` (single read), continues, every appended message
@@ -1039,7 +1229,7 @@ All closed during brainstorm:
   small change: a `DELETE WHERE thread_id=? AND run_id=?` (single-run
   surgical delete, leaves a hole; documented caveat) or a
   `DELETE WHERE thread_id=? AND seq >= min_seq_of_run` (rollback,
-  also drops subsequent run_completions).
+  also drops subsequent runs).
 - Cubebox wiring: new `Conversation.parent_conversation_id` column,
   `POST /conversations/{id}/fork` endpoint, per-assistant-message UI
   button. Lives in the cubebox repo.

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -252,7 +252,7 @@ will see.
 | `messages` `[0..message_count)` | yes | physical copy. Postgres/MySQL preserve the source seq values for the copied range. SQLite copies the JSON payloads under fresh global `id`s — its `messages.id` is a global auto-increment, not a per-thread seq, so identity is not meaningful to preserve. Memory copies in-list order. |
 | `extra` | yes | deep copy of the source JSON object (`json.loads(json.dumps(extra))`) |
 | `parent_thread_id` | written (new) | set to `src_thread_id` on new row |
-| `forked_at_seq` | written (new, Postgres/MySQL only) | seq of the last copied message. NULL for Memory and SQLite — those backends have no per-message seq column and forging a value would invite false continuation logic. The column exists in the SQLite schema for parity but is always NULL there. |
+| `forked_at_seq` | written (new, Postgres/MySQL only) | seq of the last copied message. Memory and SQLite do NOT store this — neither has a per-message seq, and forging a value would invite false continuation logic. No `forked_at_seq` column is added to SQLite's `thread_extra`, and no field is added to Memory's `CheckpointData`. Lineage for those backends comes from `parent_thread_id` alone. |
 | `extra['fork']` | written (new) when `metadata` is supplied | merge rule below |
 | `pending_request` | **no** | new thread starts clean; HITL is run-state, not history |
 | `run_id` | **no** | host-side run identifier; new thread has none |
@@ -742,8 +742,11 @@ channel) is explicit follow-up scope.
     (CheckpointData lineage round-trip)
   - `load(src_thread_id).parent_thread_id is None` for an originally
     non-forked source
-  - `forked_at_seq` assertions: equals last copied seq for
-    Postgres/MySQL; IS NULL for Memory/SQLite
+  - Lineage assertions:
+    - Postgres/MySQL: `forked_at_seq` equals the last copied seq
+    - Memory/SQLite: no `forked_at_seq` field/column exists; lineage
+      is asserted only via `load(new_thread_id).parent_thread_id ==
+      src_thread_id`
   - fork copies `extra['fork']` from `metadata` arg (and overwrites
     a pre-existing `extra['fork']` on the source — explicit test for
     the §3.5 merge rule)

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -286,10 +286,18 @@ about to be appended. **`Checkpointer.append()` signature does not
 change** — the run_id rides on the messages themselves
 (`Message.run_id` field, §3.6.5).
 
-Before any append happens, `Agent.prompt()` calls
-`Checkpointer.claim_run(thread_id, run_id)` which atomically inserts
-a row into `cubepi_runs` with `claimed_at = now()` and
-`completed_at = NULL`. The insert is the synchronization point:
+When the agent has both `self.checkpointer` and `self.thread_id`
+bound, `Agent.prompt()` calls
+`self.checkpointer.claim_run(self.thread_id, run_id)` before any
+append. **When `self.checkpointer` is None OR `self.thread_id` is
+None** (e.g., the transient agent inside `fork_once()` —
+see §3.8), `prompt()` skips the claim entirely; it still stamps
+`run_id` on every in-memory Message but no `cubepi_runs` row is
+written. `mark_run_complete()` is similarly skipped in that case.
+
+The claim INSERT atomically inserts a row into `cubepi_runs` with
+`claimed_at = now()` and `completed_at = NULL`. The insert is the
+synchronization point:
 
 - PK conflict where the existing row has `completed_at IS NULL` →
   `RunAlreadyClaimedError` (another process is currently running
@@ -397,6 +405,15 @@ A run that pauses for HITL keeps its `run_id` across the suspension.
   agent loop, continues the same run, stamps every subsequent
   appended message with `run_id=R`, and calls `mark_run_complete()`
   on terminal exit.
+
+**`respond()` does NOT call `claim_run()`.** The run was already
+claimed by the original `prompt()` call; the `cubepi_runs` row
+exists with `completed_at IS NULL`. Calling `claim_run(R)` again
+would (correctly) raise `RunAlreadyClaimedError`. The agent loop
+distinguishes "fresh prompt" (claim required) from "resume"
+(claim skipped) by which entry point was called. A single end-to-end
+HITL-bearing run calls `claim_run()` exactly once across all
+`prompt()` + N × `respond()` invocations.
 
 `Agent.respond()` signature does **not** change.
 
@@ -893,9 +910,13 @@ with defaults.**
   `RunAlreadyClaimedError`; else `RunAlreadyCompletedError`.
 - Commit.
 
-(MySQL equivalent: `INSERT IGNORE INTO cubepi_threads`. The same
-lazy-create lives in `append()` today; spec just promotes the
-pattern to `claim_run()`.)
+MySQL equivalent: `INSERT INTO cubepi_threads (thread_id) VALUES (?)
+ON DUPLICATE KEY UPDATE thread_id = thread_id` — a no-op update on
+duplicate that traps ONLY the dup-key case. **Do NOT use `INSERT
+IGNORE`**: it silently swallows non-duplicate errors (type
+coercion, FK violation if any) and would hide real bugs in the
+lazy-create path. This matches the existing `append()` lazy-create
+idiom in `cubepi/checkpointer/mysql/checkpointer.py`.
 
 `mark_run_complete()`:
 
@@ -1187,7 +1208,19 @@ No `forked_at_seq` field — Memory has no seq.
     `load_pending()` (single read), continues, every appended message
     post-resume carries `run_id=R`, `mark_run_complete()` writes R's
     marker on terminal exit. Second-pause variant: respond() pauses
-    again with same R, third respond() resumes again with same R
+    again with same R, third respond() resumes again with same R.
+    **Single-claim invariant** (regression test for v2 R4 HIGH #2):
+    `claim_run()` is called exactly once across the whole
+    prompt + N × respond chain (assert via a checkpointer spy).
+    `respond()` calling `claim_run()` would raise
+    `RunAlreadyClaimedError` — if the test ever sees that, regression
+    triggered.
+  - **fork_once no checkpointer side effects** (regression test for
+    v2 R4 HIGH #1): the transient agent inside `fork_once()` runs
+    `prompt(message, run_id=<fresh>)` with `checkpointer=None`. No
+    `claim_run()` or `mark_run_complete()` call is made (assert via
+    spying on a checkpointer instance that would have been used by
+    the parent — and observe no calls from the transient agent).
   - SQLite cross-connection: two `SQLiteCheckpointer` instances on
     the same DB file, one `fork()` and one `mark_run_complete()`
     from different processes serialize via `BEGIN IMMEDIATE`

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -440,11 +440,47 @@ assistant message with `stop_reason="error"` or `"aborted"`, and
 returns normally (see `loop.py:485` early-exit branch). A naive
 "call mark_run_complete after `_run_prompt()` returns"
 implementation would mark FAILED runs complete. To prevent that, the
-spec enumerates each loop outcome:
+spec enumerates each loop outcome AND adds a structural pre-completion
+invariant (below).
+
+#### Pre-completion invariant: no orphan tool_use
+
+**Before calling `mark_run_complete()`, the agent loop MUST verify
+that no `AssistantMessage` appended under the active run carries a
+`ToolCall` whose `id` has no matching `ToolResultMessage`
+(`tool_call_id`) later in the same run's messages.**
+
+This catches a real loop-level escape hatch: a custom
+`after_model_response` middleware can return
+`TurnAction(decision="stop")` after an assistant message that
+contains `ToolCall` blocks, in which case the loop short-circuits
+WITHOUT executing the tools or appending `ToolResultMessage`s. The
+loop then emits `AgentEndEvent` with `stop_reason="tool_use"` and
+returns normally. Without this check, a naive implementation would
+call `mark_run_complete()` on a run whose messages contain orphan
+`ToolCall`s — and `fork(after_run_id=R)` would later copy those
+orphans, reintroducing the very mid-tool-call hazard the run-based
+design claims to eliminate.
+
+The check is O(N) over the run's own messages (the ones tagged with
+this `run_id` appended since `claim_run`). On violation the loop
+treats the outcome as **"incomplete tool cycle"** — a new row in
+the outcome table below — and does NOT call `mark_run_complete`.
+The cubepi_runs row remains with `completed_at IS NULL`; fork sees
+`RunNotCompletedError`. Future `delete_run(R)` can clean up.
+
+The check is the only remaining vestige of v1's boundary validation,
+relocated to run-completion time (where it can be enforced once)
+rather than fork-cut time (where v1 had to validate at arbitrary
+positions). Because runs are by construction the only fork unit, a
+single check at completion suffices.
+
+#### Outcome table
 
 | Loop outcome | Detection signal | `mark_run_complete()` called? |
 |---|---|---|
-| **Clean success** | Final `AssistantMessage` has `stop_reason in {"end_turn", "stop", "tool_use", …}` (any non-error / non-aborted stop_reason) AND `error_message is None` AND no pending HITL on the thread | **YES** |
+| **Clean success** | Final `AssistantMessage` has `stop_reason in {"end_turn", "stop", "tool_use", …}` (any non-error / non-aborted stop_reason) AND `error_message is None` AND no pending HITL on the thread AND **the pre-completion invariant above passes** (no orphan `ToolCall`s in this run) | **YES** |
+| **Incomplete tool cycle** | Pre-completion invariant fails: some `AssistantMessage` in this run has a `ToolCall` whose `id` has no matching `ToolResultMessage` later in the run (typically caused by `after_model_response(decision="stop")` middleware short-circuit on a tool-use response) | NO — same handling as a failed run; claim row remains; `delete_run()` can clean up |
 | **HITL suspended** (normal pause) | `pending_request` row written this run; `prompt()` returns with the agent in suspended state | NO — `respond()` writes the marker on resume's clean exit |
 | **HITL detached** (`HitlDetached` caught in `loop.py:196` / `loop.py:418`) | Exception caught internally; loop returns silently, NO `AgentEndEvent` emitted. `pending_request` may still be set so `respond()` can resume later. | NO — same as normal HITL pause; resume handles completion |
 | **HITL aborted** (`HitlAborted`, via `Agent.abort_pending()`) | Exception caught internally; loop returns silently, NO `AgentEndEvent` emitted. The synthetic deny + terminal aborted assistant are appended by `abort_pending()` itself (see `agent.py:582-595`). | NO — claim row remains; the run is terminally abandoned; future `delete_run()` cleans up |
@@ -495,39 +531,65 @@ pauses for HITL. This pre-dates the spec and is preserved.
 
 The spec **adds a constraint** to make the channel's bound run_id
 agree with the agent's active run_id, so HITL recovery on resume
-finds the right value. For the constraint to be checkable,
-HITL-bearing tools/middleware must EXPOSE their bound run_id —
-`requires_hitl=True` alone tells Agent "HITL exists" but not "which
-run_id is bound to the channel". This spec therefore adds:
+finds the right value. The constraint must be checkable AND must
+distinguish in-memory HITL (no persistence, no constraint) from
+checkpointed HITL (writes pending_request.run_id, must match).
 
-- New attribute `bound_hitl_run_id: str | None = None` on
-  `cubepi.agent.types.AgentTool` and `cubepi.middleware.base.Middleware`.
+Structural change — single nested attribute replaces the prior
+`requires_hitl` + `bound_hitl_run_id` pair:
+
+```python
+@dataclass(frozen=True)
+class HitlBinding:
+    """How a tool/middleware integrates with HITL."""
+    checkpointed: bool              # True iff backed by CheckpointedChannel
+    run_id: str | None              # the channel's bound run_id (str if
+                                    # checkpointed; None for in-memory)
+
+class AgentTool:                    # cubepi.agent.types
+    ...
+    hitl: HitlBinding | None = None # None = tool has no HITL involvement
+
+class Middleware:                   # cubepi.middleware.base
+    ...
+    hitl: HitlBinding | None = None
+```
+
+`hitl is not None` replaces the v1 `requires_hitl=True` flag for
+detection purposes (§3.8.2 fork_once ban).
+
 - `cubepi.hitl.ask_user_tool(channel)` factory MUST set
-  `tool.bound_hitl_run_id = channel._run_id` on the returned
-  `AgentTool` (the channel is in the factory's closure; reading
-  `_run_id` is straightforward).
-- `cubepi.hitl.middleware.ApprovalPolicyMiddleware.__init__` MUST set
-  `self.bound_hitl_run_id = channel._run_id` from its channel
-  argument; `ConfirmToolCallMiddleware` inherits.
-- Third-party HITL tools / middleware that set `requires_hitl=True`
-  MUST also set `bound_hitl_run_id` if they bind a channel; documented
-  in the user guide.
+  `tool.hitl = HitlBinding(checkpointed=isinstance(channel,
+  CheckpointedChannel), run_id=getattr(channel, "_run_id", None))`.
+- `cubepi.hitl.middleware.ApprovalPolicyMiddleware.__init__` does the
+  same with its channel argument; `ConfirmToolCallMiddleware` inherits.
+- Third-party HITL tools / middleware MUST set `hitl=HitlBinding(...)`
+  if they bind a channel; documented in the user guide.
 
 **Enforcement at `Agent.prompt()` start, before `claim_run()`:**
 
-```
-bound = {
-    t.bound_hitl_run_id for t in self.tools if t.requires_hitl
-} | {
-    m.bound_hitl_run_id for m in self.middleware if m.requires_hitl
-}
-bound.discard(None)   # tolerate unbound HITL elements (none expected
-                      # in practice, but defensive)
+```python
+bound: set[str] = set()
+for elem in (*self.tools, *self.middleware):
+    if elem.hitl is None:
+        continue
+    if not elem.hitl.checkpointed:
+        continue  # in-memory HITL has no persistence; no run_id constraint
+    # Checkpointed HITL: run_id MUST be a non-None string
+    if elem.hitl.run_id is None:
+        raise ValueError(
+            f"Checkpointed HITL element {elem!r} has no run_id bound; "
+            "construct CheckpointedChannel(run_id=...) before passing "
+            "it to ask_user_tool/HITL middleware"
+        )
+    bound.add(elem.hitl.run_id)
+
 if bound:
     if run_id is None:
         raise ValueError(
-            "Agent has HITL-bound tools/middleware; "
-            "prompt(run_id=...) must be explicitly supplied"
+            "Agent has checkpointed HITL elements bound to "
+            f"run_ids {bound!r}; prompt(run_id=...) must be "
+            "explicitly supplied (generate-mode rejected)"
         )
     if any(b != run_id for b in bound):
         raise ValueError(
@@ -536,9 +598,13 @@ if bound:
         )
 ```
 
-- For non-HITL agents (no `requires_hitl=True` element), `Agent.prompt`
-  accepts `run_id=None` and generates; no channel binding to worry
-  about.
+- For non-HITL agents (no `hitl` attribute on any element), or for
+  agents with only in-memory HITL (no checkpointed channels),
+  `Agent.prompt` accepts `run_id=None` and generates; no constraint.
+
+- For checkpointed HITL with `CheckpointedChannel(run_id=None)`
+  (genuine config error — channel can't persist run_id because it
+  has none), Agent raises immediately, before `claim_run`.
 
 This avoids the alternative of refactoring `CheckpointedChannel` to
 take run_id at call time (a backward-incompatible HITL API change
@@ -884,8 +950,8 @@ class ForkOnceResult:
 ### 3.8 `Agent.fork_once()` execution detail
 
 1. `self._require_checkpointer()` — `RuntimeError` if no checkpointer.
-2. HITL pre-flight (§3.8.2) — `RuntimeError` if inherited tools or
-   middleware mark `requires_hitl=True`.
+2. HITL pre-flight (§3.8.2) — `RuntimeError` if any inherited tool
+   or middleware has `elem.hitl is not None`.
 3. `snapshot = await self.checkpointer.snapshot(src_thread_id,
    after_run_id=...)` — propagates
    `ThreadNotFoundError` / `RunNotCompletedError`.
@@ -951,18 +1017,21 @@ Two reasons HITL cannot work in `fork_once()`:
    persist a pending HITL request to the source thread — silent
    contamination.
 
-Detection (marker-based, bypass-proof):
+Detection (structural, bypass-proof) — uses the same
+`hitl: HitlBinding | None` attribute introduced in §3.6.3.1:
 
-- New attribute `requires_hitl: bool = False` on
-  `cubepi.agent.types.AgentTool` and `cubepi.middleware.base.Middleware`.
-- Set `True` on the `AgentTool` returned by
-  `cubepi.hitl.ask_user_tool(...)` and on
-  `cubepi.hitl.middleware.ApprovalPolicyMiddleware`
-  (`ConfirmToolCallMiddleware` inherits via subclassing).
-- Third-party HITL tools / middleware MUST set the same flag.
+- Any element with `elem.hitl is not None` is rejected from
+  fork_once. This covers both checkpointed channels (CheckpointedChannel
+  side effects on source thread) and in-memory channels
+  (InMemoryChannel blocks forever waiting for an unreachable host
+  inside a transient agent).
+- `cubepi.hitl.ask_user_tool(...)` and `ApprovalPolicyMiddleware`
+  set `hitl` per §3.6.3.1; `ConfirmToolCallMiddleware` inherits.
+- Third-party HITL tools / middleware MUST set `hitl` — same
+  contract as §3.6.3.1.
 - `fork_once()` scans `self.tools` and `self.middleware`; any
-  `requires_hitl=True` element triggers `RuntimeError` BEFORE any
-  snapshot is read.
+  element with `elem.hitl is not None` triggers `RuntimeError`
+  BEFORE any snapshot is read.
 
 ### 3.9 Per-backend implementation sketch
 
@@ -1423,14 +1492,19 @@ No `forked_at_seq` field — Memory has no seq.
     Same with `ApprovalPolicyMiddleware` instead of the tool. Non-HITL
     agents accept `run_id=None` unchanged.
   - **Loop-outcome completion enumeration** (regression test for v2
-    R7 HIGH #5): exercise each row of the §3.6.2 table — clean
-    success, HITL suspended (normal pause), HITL detached
+    R7 HIGH #5 + v2 R9 HIGH #2): exercise each row of the §3.6.2
+    table — clean success, **incomplete tool cycle** (custom
+    `after_model_response(decision="stop")` on a tool-use
+    AssistantMessage), HITL suspended (normal pause), HITL detached
     (HitlDetached caught in loop), HITL aborted (abort_pending),
     provider exception, tool exception, abort during streaming,
     propagating cancellation — and assert
     `cubepi_runs.completed_at IS NULL` for every non-success outcome
     and `IS NOT NULL` for the clean-success outcome. HITL
     suspended → respond() resume → assert marker now NOT NULL.
+    The incomplete-tool-cycle test specifically asserts: (a) the
+    pre-completion invariant rejected the run, (b) no orphan
+    tool_use ever becomes forkable via `fork(after_run_id=R)`.
   - **Legacy-degraded mode** (regression test for v2 R7 HIGH #4 +
     v2 R8 HIGH #3): construct an Agent with a checkpointer that
     implements only the v3 surface (no `claim_run` /
@@ -1458,11 +1532,15 @@ No `forked_at_seq` field — Memory has no seq.
     thread unchanged
   - turn with tool calls completes fully, returns new messages
   - raises `RuntimeError` when no checkpointer
-  - raises `RuntimeError` when `requires_hitl=True` tool in
-    `self.tools` (exercised with the actual `ask_user_tool(...)`
-    factory result)
+  - raises `RuntimeError` when any tool in `self.tools` has
+    `elem.hitl is not None` (exercised with the actual
+    `ask_user_tool(...)` factory result, asserting it populated
+    `tool.hitl` from the channel)
   - raises `RuntimeError` when `ApprovalPolicyMiddleware` (or its
     subclass `ConfirmToolCallMiddleware`) in `self.middleware`
+  - both checkpointed AND in-memory HITL channels trip the rejection
+    (HitlBinding.checkpointed=False is still rejected by fork_once
+    because the transient agent cannot drive HITL to completion)
   - cancellation: `asyncio.wait_for(agent.fork_once(...), timeout=…)`
     raises `TimeoutError`; transient agent's abort fires
   - tracing span: emits `cubepi.agent.fork_once` with the documented

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -118,10 +118,10 @@ The user-facing cut is **`message_count`: include the first N messages**.
 - Memory and SQLite backends have no native seq column; `message_count`
   reduces to "len of the first N elements" there.
 
-Storage-level `forked_at_seq` is still written for Postgres/MySQL
-(it equals the seq of the last copied message — for the in-memory and
-SQLite backends it equals `message_count` because seq == index+1 there).
-It is metadata; callers do not pass or read it directly.
+Storage-level `forked_at_seq` is written only for Postgres/MySQL
+(equal to the seq of the last copied message). It is NULL for Memory
+and SQLite — see §3.5 for the canonical rule. It is metadata; callers
+do not pass or read it directly.
 
 ### 3.3 Boundary validation
 
@@ -188,6 +188,29 @@ prefix; it is performed by `snapshot()` and reused by `fork()`.
   relies on aiosqlite's single-connection serialization within one
   process; the upgrade makes the contract explicit and
   cross-process-safe.)
+
+  **SQLITE_BUSY contract.** When the immediate-lock acquisition
+  contends with another writer, SQLite returns `SQLITE_BUSY`. The
+  spec defines a deterministic policy:
+
+  - At connect time the checkpointer sets `PRAGMA busy_timeout = 5000`
+    (5 seconds) — SQLite internally retries lock acquisition for that
+    long before raising. This is set unconditionally for all writer
+    operations, not just fork.
+  - If the 5 s window elapses without acquiring the lock, the
+    `aiosqlite.OperationalError("database is locked")` propagates as
+    a new typed error `CheckpointerLockTimeoutError(CheckpointerError)`
+    so callers can distinguish it from boundary / not-found / collision
+    errors. No further in-process retry is attempted — that's the
+    caller's policy decision.
+  - `BEGIN IMMEDIATE` (RESERVED lock) is the right strength: it lets
+    readers continue (good for UI list refresh during a fork) but
+    blocks the next writer. `BEGIN EXCLUSIVE` would needlessly stall
+    reads. The trade-off is documented in the SQLite section of
+    `website/docs/guides/checkpointing/`.
+
+  The 5 s default and the new typed error apply to fork, append,
+  save_extra, and save_pending_request uniformly.
 - **Postgres**: single transaction. Inside it:
   1. `pg_advisory_xact_lock(hashtext($src_thread_id))` — the same
      per-thread advisory lock `append()` uses, but here taken on the
@@ -324,9 +347,21 @@ Add:
 ```python
 class ThreadNotFoundError(CheckpointerError): ...
 class ThreadAlreadyExistsError(CheckpointerError): ...
+class CheckpointerLockTimeoutError(CheckpointerError):
+    """SQLite (or other locking backend) could not acquire the writer
+    lock within the configured busy_timeout. See §3.4."""
 class ForkBoundaryError(CheckpointerError):
-    """message_count cuts across an unresolved tool_call/tool_result pair."""
-    def __init__(self, message_count: int, unresolved_tool_call_ids: list[str]):
+    """The prefix violates one of the §3.3 tool-call/tool-result invariants."""
+    def __init__(
+        self,
+        message_count: int,
+        *,
+        unresolved_tool_call_ids: list[str] | None = None,
+        orphan_tool_result_ids: list[str] | None = None,
+    ):
+        # At least one of unresolved_tool_call_ids / orphan_tool_result_ids
+        # is non-empty. Both may be present for prefixes with multiple
+        # protocol violations of different kinds.
         ...
 ```
 
@@ -436,25 +471,68 @@ the same pattern applies to the new columns).
 4. Build a transient `Agent` configured with this agent's `model`,
    `system_prompt`, `tools`, `middleware`, and `convert_to_llm`, with
    `checkpointer=None` and `thread_id=None`. Pre-seed its message
-   history with `snapshot`.
+   history with `snapshot` via the new constructor argument
+   `messages=...` (see §3.7a below).
 
-   **This requires a new public Agent surface for seeding initial
-   history.** The exact form (constructor arg `messages=...` vs. a
-   dedicated `Agent.preload(messages)` method) is decided in the
-   implementation plan, but it is in scope for THIS spec — `fork_once()`
-   MUST NOT reach into private attributes of `Agent`. The plan SHOULD
-   prefer a constructor arg because it keeps the agent's "ready to run"
-   state machine single-phase; if the plan picks a separate method,
-   document that the method must be called before any `prompt()`.
+   #### 3.7a — Required public `Agent` API addition
+
+   This spec adds one new constructor argument to `Agent.__init__`:
+
+   ```python
+   class Agent(Generic[TMessage]):
+       def __init__(
+           self,
+           *,
+           # ... all existing args unchanged ...
+           messages: Sequence[Message] | None = None,
+       ):
+           ...
+   ```
+
+   Semantics:
+
+   - When `messages` is provided, `Agent` deep-copies the sequence
+     (`list(map(model_copy, messages))`) into its initial
+     `_state._messages`. The deep copy prevents external mutation of
+     the source list from corrupting agent state.
+   - When `messages` is provided AND (`thread_id` AND `checkpointer`)
+     are also set, the constructor raises `ValueError`: the lazy-load
+     contract in `prompt()` would either drop the preload or duplicate
+     history. Pre-seeding is for ephemeral agents only.
+   - When `messages` is provided AND any of the messages violates the
+     §3.3 boundary invariants, `Agent.__init__` raises
+     `ForkBoundaryError` (the same validator function powers both
+     `Checkpointer.snapshot()` and the constructor — single source of
+     truth).
+   - When `messages` is `None`, behavior is unchanged from today.
+
+   `fork_once()` uses this argument. `fork_once()` MUST NOT touch
+   any private `Agent` attribute. No `Agent.preload(...)` method is
+   added — keeping pre-seeding in `__init__` makes the agent's
+   "ready to run" lifecycle single-phase.
 
 5. Start a `cubepi.agent.fork_once` span (inheriting the surrounding
    OTel context per §3.6). Capture the pre-seed length.
-6. Cancellation is propagated: if the surrounding task is cancelled
-   (or `asyncio.CancelledError` is raised), the transient agent's
-   abort signal fires and the cancellation re-raises after the agent
-   loop returns — same semantics as cancelling `Agent.prompt()`. The
-   tracing span is closed in a `finally` block with the failure
-   status set.
+6. Cancellation is **best-effort**, not bounded. If the surrounding
+   task is cancelled (or `asyncio.CancelledError` is raised), the
+   transient agent's abort signal fires; the agent loop honors the
+   signal at each tool/turn checkpoint; cancellation re-raises after
+   the agent loop returns. This matches `Agent.prompt()` cancellation.
+
+   Caveat: cubepi tools are not required to honor the abort signal
+   mid-call (a tool can run a blocking subprocess and ignore the
+   signal until it returns). In that case `fork_once()` blocks until
+   the offending tool returns, then re-raises `CancelledError`. The
+   spec does NOT add an unconditional hard timeout — that would
+   change the cancellation surface for all of `Agent.prompt()` /
+   `fork_once()` consistently and is out of scope. Callers that need
+   a hard wall-clock bound MUST wrap with `asyncio.wait_for(...)` AND
+   accept that a poorly-behaved tool will still hold the task until
+   it returns. This is documented in the user guide.
+
+   The tracing span is closed in a `finally` block with status
+   `error` and the cancellation tag set, regardless of how long the
+   cancellation actually takes to land.
 7. `await child.prompt(message)` — runs the full turn (any tool calls
    included).
 8. Read final assistant text + the messages added after the pre-seed
@@ -481,13 +559,30 @@ Two reasons HITL cannot work in `fork_once()`:
    SOURCE conversation, contaminating it. Silent failure mode.
 
 `fork_once()` therefore pre-checks `self.tools` and `self.middleware`
-for HITL involvement. Detection rule:
+for HITL involvement. Name-based detection is bypassable (anyone can
+wrap `ask_user_tool` and rename it), so the spec uses **marker-based
+detection**:
 
-- Any tool whose `name` is `ask_user` (cubepi's built-in HITL tool name).
-- Any middleware that is an instance of `cubepi.hitl.middleware.HitlMiddleware`
-  (or any subclass).
-- Any tool whose `name` matches a configurable host-supplied set —
-  the spec defers the exact extension hook to the plan.
+- This spec adds an attribute `requires_hitl: bool = False` to
+  `cubepi.agent.types.AgentTool` and an attribute
+  `requires_hitl: bool = False` to `cubepi.middleware.base.Middleware`.
+- This spec sets `requires_hitl=True` on the `AgentTool` returned by
+  the built-in `cubepi.hitl.ask_user_tool(...)` factory and on
+  `cubepi.hitl.middleware.HitlMiddleware`. Third-party HITL tools
+  and middleware MUST set the same flag — this is the documented
+  contract for "this tool/middleware requires HITL".
+- `fork_once()` scans `self.tools` and `self.middleware` and rejects
+  the call if any element has `requires_hitl is True`.
+- The detection is documented in `website/docs/guides/checkpointing/forking.md`
+  with the cross-link to the contract: third-party HITL implementers
+  must set the flag or they break `fork_once()` safety guarantees.
+
+Channel-binding inspection (walking each tool's closure to find a
+`CheckpointedChannel` pointing at the source thread) was considered
+and rejected: cubepi tools are constructed as closures or partials
+with no structural channel exposure, so the check would be
+non-portable and easy to evade. A boolean marker is uniformly
+discoverable and self-documenting.
 
 If any match, `fork_once()` raises:
 
@@ -522,7 +617,10 @@ channel) is explicit follow-up scope.
 | `message_count = None` | normalized to `len(messages_in_src)` — copy everything currently present |
 | cut violates any §3.3 invariant (unresolved tool_call, orphan tool_result, partial multi-call close, two assistants in a row with unresolved calls) | `ForkBoundaryError(message_count, unresolved_tool_call_ids=[…], orphan_tool_result_ids=[…])` |
 | `Agent.fork_once()` child run errors | propagates (same surface as `Agent.prompt()`) |
-| `Agent.fork_once()` is cancelled mid-turn | `asyncio.CancelledError` re-raises after transient agent abort completes |
+| `Agent.fork_once()` is cancelled mid-turn | `asyncio.CancelledError` re-raises after transient agent abort completes (best-effort — see §3.9 step 6) |
+| SQLite cannot acquire writer lock within `busy_timeout` | `CheckpointerLockTimeoutError` (applies to fork, append, save_extra, save_pending_request uniformly) |
+| `Agent(messages=..., thread_id=X, checkpointer=Y)` | `ValueError` — pre-seeding conflicts with lazy load |
+| `Agent(messages=...)` with a prefix that violates §3.3 | `ForkBoundaryError` (constructor uses the same validator as snapshot()) |
 
 ## 4. Migration / Compatibility
 
@@ -571,8 +669,13 @@ channel) is explicit follow-up scope.
   - concurrent fork + append on source serializes correctly (no
     half-copied state) — exercise with two concurrent tasks
   - fork-of-fork: fork A → B; fork B → C. C's `parent_thread_id`
-    points to B (not A). Walking the chain via `parent_thread_id`
-    reaches A.
+    points to B (not A). C's `forked_at_seq` is computed from the
+    snapshot of B at C's fork point — it is B's seq value at that
+    point, NOT A's original seq (Postgres/MySQL preserve source seqs
+    on copy, so if B's seqs come from A unchanged the value
+    coincides; but the spec contract is "immediate source's seq",
+    which the test asserts explicitly). Walking the chain via
+    `parent_thread_id` reaches A.
   - fork after `respond()`-injected synthetic deny: the synthetic
     messages are in the snapshot and survive the fork
   - SQLite cross-connection: open two separate `SQLiteCheckpointer`

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -311,14 +311,35 @@ about to be appended. **`Checkpointer.append()` signature does not
 change** — the run_id rides on the messages themselves
 (`Message.run_id` field, §3.6.5).
 
-When the agent has both `self.checkpointer` and `self.thread_id`
-bound, `Agent.prompt()` calls
+`Agent.prompt()` calls
 `self.checkpointer.claim_run(self.thread_id, run_id)` before any
-append. **When `self.checkpointer` is None OR `self.thread_id` is
-None** (e.g., the transient agent inside `fork_once()` —
-see §3.8), `prompt()` skips the claim entirely; it still stamps
-`run_id` on every in-memory Message but no `cubepi_runs` row is
-written. `mark_run_complete()` is similarly skipped in that case.
+append, gated by:
+
+- **Skip when the checkpointer or thread_id is absent**: when
+  `self.checkpointer is None` OR `self.thread_id is None` (e.g., the
+  transient agent inside `fork_once()` — see §3.8), `prompt()` skips
+  the claim entirely; it still stamps `run_id` on every in-memory
+  Message but no `cubepi_runs` row is written.
+  `mark_run_complete()` is similarly skipped.
+
+- **Skip when the checkpointer is run-unaware (legacy degraded
+  mode)**: when `self.checkpointer` exists but does NOT implement
+  BOTH `claim_run` AND `mark_run_complete` (a third-party v3-only
+  Protocol impl), `prompt()` skips both. Messages still get
+  `run_id` stamped; no marker is ever written; `Agent.fork()` and
+  `Agent.fork_once()` on this checkpointer raise
+  `CheckpointerError`. The detection is one capability check at
+  `prompt()` entry:
+  ```python
+  run_aware = (
+      hasattr(self.checkpointer, "claim_run")
+      and hasattr(self.checkpointer, "mark_run_complete")
+  )
+  ```
+  Partial implementations (one but not the other) are treated as
+  NOT run-aware — never call into a checkpointer that can claim
+  but not complete, or the inverse. See §4 for the full
+  compatibility story.
 
 The claim INSERT atomically inserts a row into `cubepi_runs` with
 `claimed_at = now()` and `completed_at = NULL`. The insert is the
@@ -357,13 +378,23 @@ checkpointer, etc.), no row is inserted.
 Completion is recorded by `Checkpointer.mark_run_complete(thread_id,
 run_id)`, which under the per-thread lock:
 
-1. Allocates the next per-thread `completion_seq` (see §3.2).
-2. `UPDATE cubepi_runs SET completed_at = now(), completion_seq = ?
-   WHERE thread_id = ? AND run_id = ? AND completed_at IS NULL`.
-3. If 0 rows updated: either the row doesn't exist
-   (`RunNotClaimedError`) or it is already completed
-   (`RunAlreadyCompletedError`). Backends distinguish the two by a
-   followup SELECT under the same lock.
+1. `SELECT completed_at FROM cubepi_runs WHERE thread_id=? AND
+   run_id=?`.
+2. **No row** → `RunNotClaimedError`. (Agent-loop logic bug: claim
+   was never made, or its row was lost.)
+3. **Row exists with `completed_at IS NOT NULL`** → idempotent
+   success. Return without raising and without re-allocating
+   `completion_seq`. Supports retry-after-lost-ack from
+   `CompletionMarkerFailedError`.
+4. **Row exists with `completed_at IS NULL`** →
+   - Allocate `next_seq = (SELECT COALESCE(MAX(completion_seq), 0)
+     + 1 FROM cubepi_runs WHERE thread_id=? AND completion_seq IS
+     NOT NULL)` (per-thread monotonic, §3.2).
+   - `UPDATE cubepi_runs SET completed_at = now(),
+     completion_seq = $next_seq WHERE thread_id=? AND run_id=?`.
+
+`mark_run_complete()` **never raises `RunAlreadyCompletedError`** —
+that error is reserved for `claim_run()` collisions only (see §3.6.1).
 
 `mark_run_complete()` is called by the agent loop AFTER the run's
 final `append()` and BEFORE `Agent.prompt()` returns.
@@ -414,10 +445,12 @@ spec enumerates each loop outcome:
 | Loop outcome | Detection signal | `mark_run_complete()` called? |
 |---|---|---|
 | **Clean success** | Final `AssistantMessage` has `stop_reason in {"end_turn", "stop", "tool_use", …}` (any non-error / non-aborted stop_reason) AND `error_message is None` AND no pending HITL on the thread | **YES** |
-| **HITL suspended** | `pending_request` row written this run; `prompt()` returns with the agent in suspended state | NO — `respond()` writes the marker on resume's clean exit |
+| **HITL suspended** (normal pause) | `pending_request` row written this run; `prompt()` returns with the agent in suspended state | NO — `respond()` writes the marker on resume's clean exit |
+| **HITL detached** (`HitlDetached` caught in `loop.py:196` / `loop.py:418`) | Exception caught internally; loop returns silently, NO `AgentEndEvent` emitted. `pending_request` may still be set so `respond()` can resume later. | NO — same as normal HITL pause; resume handles completion |
+| **HITL aborted** (`HitlAborted`, via `Agent.abort_pending()`) | Exception caught internally; loop returns silently, NO `AgentEndEvent` emitted. The synthetic deny + terminal aborted assistant are appended by `abort_pending()` itself (see `agent.py:582-595`). | NO — claim row remains; the run is terminally abandoned; future `delete_run()` cleans up |
 | **Provider / tool error** | Final assistant message has `stop_reason="error"` OR `error_message is not None` (set on the message by the loop's exception handler) | NO — claim row remains; future `delete_run()` cleans up |
-| **Abort** (`agent.abort()` or `agent.abort_pending()`) | Final assistant message has `stop_reason="aborted"` | NO — claim row remains |
-| **Cancellation** (`asyncio.CancelledError`, `HitlDetached`, `HitlAborted`) | Exception propagates out of `prompt()`; no `AgentEndEvent` emitted | NO — claim row remains; `active_run_id` left set (§3.7) |
+| **Abort during streaming** (`agent.abort()`) | Final assistant message has `stop_reason="aborted"` | NO — claim row remains |
+| **Cancellation** (`asyncio.CancelledError` propagates out — i.e. the caller's task is cancelled and no internal catch swallowed it) | Exception propagates out of `prompt()`; no `AgentEndEvent` emitted; `active_run_id` left set (§3.7) | NO — claim row remains |
 
 The agent loop's existing `if message.stop_reason in ("error",
 "aborted"): … return early` branch (`loop.py:485`) is the natural
@@ -462,20 +495,46 @@ pauses for HITL. This pre-dates the spec and is preserved.
 
 The spec **adds a constraint** to make the channel's bound run_id
 agree with the agent's active run_id, so HITL recovery on resume
-finds the right value:
+finds the right value. For the constraint to be checkable,
+HITL-bearing tools/middleware must EXPOSE their bound run_id —
+`requires_hitl=True` alone tells Agent "HITL exists" but not "which
+run_id is bound to the channel". This spec therefore adds:
 
-- When the agent has both a `checkpointer` AND any tool/middleware
-  with `requires_hitl=True` (§3.8.2) bound that holds a
-  `CheckpointedChannel`, `Agent.prompt(run_id=...)` MUST be
-  host-supplied (NOT generate-mode) and MUST equal the channel's
-  `_run_id`. Mismatch / `None` raises `ValueError` at the start of
-  `prompt()`, before `claim_run()`.
+- New attribute `bound_hitl_run_id: str | None = None` on
+  `cubepi.agent.types.AgentTool` and `cubepi.middleware.base.Middleware`.
+- `cubepi.hitl.ask_user_tool(channel)` factory MUST set
+  `tool.bound_hitl_run_id = channel._run_id` on the returned
+  `AgentTool` (the channel is in the factory's closure; reading
+  `_run_id` is straightforward).
+- `cubepi.hitl.middleware.ApprovalPolicyMiddleware.__init__` MUST set
+  `self.bound_hitl_run_id = channel._run_id` from its channel
+  argument; `ConfirmToolCallMiddleware` inherits.
+- Third-party HITL tools / middleware that set `requires_hitl=True`
+  MUST also set `bound_hitl_run_id` if they bind a channel; documented
+  in the user guide.
 
-- This is the existing cubebox pattern: `RunManager` generates a
-  `uuid7()` run_id per request, constructs
-  `CheckpointedChannel(checkpointer=cp, thread_id=conv_id,
-  run_id=run_id)`, then calls `Agent.prompt(run_id=run_id)`. Same
-  value in both places, no change needed at the host.
+**Enforcement at `Agent.prompt()` start, before `claim_run()`:**
+
+```
+bound = {
+    t.bound_hitl_run_id for t in self.tools if t.requires_hitl
+} | {
+    m.bound_hitl_run_id for m in self.middleware if m.requires_hitl
+}
+bound.discard(None)   # tolerate unbound HITL elements (none expected
+                      # in practice, but defensive)
+if bound:
+    if run_id is None:
+        raise ValueError(
+            "Agent has HITL-bound tools/middleware; "
+            "prompt(run_id=...) must be explicitly supplied"
+        )
+    if any(b != run_id for b in bound):
+        raise ValueError(
+            f"prompt(run_id={run_id!r}) does not match "
+            f"HITL-bound run_ids {bound!r}"
+        )
+```
 
 - For non-HITL agents (no `requires_hitl=True` element), `Agent.prompt`
   accepts `run_id=None` and generates; no channel binding to worry
@@ -484,7 +543,7 @@ finds the right value:
 This avoids the alternative of refactoring `CheckpointedChannel` to
 take run_id at call time (a backward-incompatible HITL API change
 beyond this spec's scope) while still making the binding semantics
-unambiguous.
+unambiguous AND mechanically checkable.
 
 **Protocol change required to support this.** Today,
 `Checkpointer.load_pending_request(thread_id) -> HitlRequest | None`
@@ -1199,9 +1258,10 @@ No `forked_at_seq` field — Memory has no seq.
   fail **ordinary `Agent.prompt()` calls** once `claim_run()` is
   invoked at the start of every run — not just fork API calls.
 
-  Mitigation: `Agent.prompt()` checks `hasattr(self.checkpointer,
-  "claim_run")` at the start. If the method is absent, `prompt()`
-  runs in **legacy degraded mode**:
+  Mitigation: `Agent.prompt()` checks both `hasattr(self.checkpointer,
+  "claim_run")` AND `hasattr(self.checkpointer, "mark_run_complete")`
+  at the start. If EITHER is absent, `prompt()` runs in **legacy
+  degraded mode**:
 
   - No `claim_run()` / `mark_run_complete()` call.
   - `Message.run_id` is still stamped on appended messages (purely
@@ -1351,27 +1411,40 @@ No `forked_at_seq` field — Memory has no seq.
     HIGH #3): call mark_run_complete twice on the same
     `(thread_id, run_id)`; second call returns success (no raise),
     `completion_seq` unchanged from the first call.
-  - **HITL channel run_id binding** (regression test for v2 R7 HIGH
-    #2): construct Agent with a `requires_hitl=True` tool whose
-    `CheckpointedChannel(run_id="R1")` is bound at construction.
-    Then call `Agent.prompt(message, run_id=None)` → raises
-    `ValueError` (generate-mode rejected). Then call
+  - **HITL channel run_id binding** (regression test for v2 R7
+    HIGH #2 + v2 R8 HIGH #2): construct Agent with
+    `ask_user_tool(CheckpointedChannel(checkpointer=cp,
+    thread_id=t, run_id="R1"))`. Assert the returned tool has
+    `tool.bound_hitl_run_id == "R1"` (the factory MUST set this).
+    Then `Agent.prompt(message, run_id=None)` → raises `ValueError`
+    (generate-mode rejected, error message names the bound run_id).
     `Agent.prompt(message, run_id="R2")` (mismatch) → raises
-    `ValueError`. Then `Agent.prompt(message, run_id="R1")` →
-    succeeds. Non-HITL agents accept `run_id=None` unchanged.
+    `ValueError`. `Agent.prompt(message, run_id="R1")` → succeeds.
+    Same with `ApprovalPolicyMiddleware` instead of the tool. Non-HITL
+    agents accept `run_id=None` unchanged.
   - **Loop-outcome completion enumeration** (regression test for v2
     R7 HIGH #5): exercise each row of the §3.6.2 table — clean
-    success, HITL pause, provider exception, tool exception, abort,
-    cancellation, HitlDetached — and assert
+    success, HITL suspended (normal pause), HITL detached
+    (HitlDetached caught in loop), HITL aborted (abort_pending),
+    provider exception, tool exception, abort during streaming,
+    propagating cancellation — and assert
     `cubepi_runs.completed_at IS NULL` for every non-success outcome
-    and `IS NOT NULL` for the success outcome.
-  - **Legacy-degraded mode** (regression test for v2 R7 HIGH #4):
-    construct an Agent with a checkpointer that implements only the
-    v3 surface (no `claim_run` / `mark_run_complete`). Vanilla
-    `Agent.prompt(msg)` succeeds (no claim attempted; messages
-    stamped with run_id but no marker written). Calling
-    `Agent.fork(...)` or `Agent.fork_once(...)` raises
-    `CheckpointerError` explaining the missing methods.
+    and `IS NOT NULL` for the clean-success outcome. HITL
+    suspended → respond() resume → assert marker now NOT NULL.
+  - **Legacy-degraded mode** (regression test for v2 R7 HIGH #4 +
+    v2 R8 HIGH #3): construct an Agent with a checkpointer that
+    implements only the v3 surface (no `claim_run` /
+    `mark_run_complete`). Vanilla `Agent.prompt(msg)` succeeds (no
+    claim attempted; messages stamped with run_id but no marker
+    written). Calling `Agent.fork(...)` or `Agent.fork_once(...)`
+    raises `CheckpointerError`.
+
+    Partial-implementation variant: checkpointer has `claim_run`
+    but NOT `mark_run_complete` (or the inverse). Agent.prompt()
+    treats it the same as fully-missing: no claim attempted, no
+    marker attempted. This protects against the
+    "claim-but-can't-complete" hazard where vanilla prompt() would
+    leave orphan claim rows on every call.
   - SQLite cross-connection: two `SQLiteCheckpointer` instances on
     the same DB file, one `fork()` and one `mark_run_complete()`
     from different processes serialize via `BEGIN IMMEDIATE`

--- a/dev/specs/2026-06-05-conversation-fork.md
+++ b/dev/specs/2026-06-05-conversation-fork.md
@@ -342,14 +342,31 @@ class Checkpointer(Protocol):
 
 #### `cubepi.checkpointer.exceptions`
 
-Add:
+Today, `cubepi/checkpointer/exceptions.py` only defines schema-related
+errors (`CubepiSchemaError`, `CubepiSchemaUninitialized`,
+`CubepiSchemaMismatch`). There is no shared base for runtime-operation
+errors. This spec adds one alongside the new fork errors so callers
+have a single `except` surface:
 
 ```python
+class CheckpointerError(Exception):
+    """Base class for cubepi checkpointer runtime errors.
+
+    Separate from CubepiSchemaError: schema errors are about the DB
+    being incompatible with the library; CheckpointerError is about
+    runtime operation outcomes (missing thread, lock timeout, fork
+    boundary violations, etc.).
+    """
+
+
 class ThreadNotFoundError(CheckpointerError): ...
 class ThreadAlreadyExistsError(CheckpointerError): ...
+
 class CheckpointerLockTimeoutError(CheckpointerError):
     """SQLite (or other locking backend) could not acquire the writer
     lock within the configured busy_timeout. See §3.4."""
+
+
 class ForkBoundaryError(CheckpointerError):
     """The prefix violates one of the §3.3 tool-call/tool-result invariants."""
     def __init__(
@@ -365,7 +382,9 @@ class ForkBoundaryError(CheckpointerError):
         ...
 ```
 
-`CheckpointerError` is the existing base in `cubepi/checkpointer/exceptions.py`.
+`CheckpointerError` is a NEW base added by this spec; it does NOT
+subclass `CubepiSchemaError` (different concern). Tests assert that
+all four new errors are catchable via `except CheckpointerError`.
 
 #### `cubepi.agent.agent`
 
@@ -721,6 +740,13 @@ channel) is explicit follow-up scope.
   - error pass-through (`ThreadNotFoundError`, `ThreadAlreadyExistsError`,
     `ForkBoundaryError`, `RuntimeError` for missing checkpointer)
   - does NOT mutate `self.thread_id`
+
+- **Exception hierarchy** (`tests/checkpointer/test_exceptions.py`):
+  - `ThreadNotFoundError`, `ThreadAlreadyExistsError`,
+    `ForkBoundaryError`, `CheckpointerLockTimeoutError` are all
+    catchable via `except CheckpointerError`
+  - `CheckpointerError` is NOT a subclass of `CubepiSchemaError`
+    (schema vs. runtime concerns stay separate)
 
 - **`Agent(messages=...)` constructor (§3.7a)** — a dedicated test
   group, distinct from `fork_once()` tests, so the new constructor

--- a/examples/checkpointing_mysql.py
+++ b/examples/checkpointing_mysql.py
@@ -32,7 +32,9 @@ from cubepi.agent.agent import Agent
 from cubepi.checkpointer.mysql import MySQLCheckpointer
 from cubepi.checkpointer.mysql.alembic_helpers import (
     add_pending_request_column_op,
+    add_run_id_column_op,
     messages_partition_clause,
+    upgrade_v3_to_v4_op,
     write_schema_version_op,
 )
 from cubepi.checkpointer.mysql.checkpointer import _parse_dsn
@@ -70,6 +72,7 @@ async def bootstrap_schema(dsn: str) -> None:
                 ) ENGINE=InnoDB
             """)
             await cur.execute(add_pending_request_column_op())  # v1 -> v2 column
+            await cur.execute(add_run_id_column_op())  # v2 -> v3 column
             await cur.execute(
                 """
                 CREATE TABLE cubepi_messages (
@@ -87,6 +90,12 @@ async def bootstrap_schema(dsn: str) -> None:
                 "CREATE TABLE cubepi_schema_version (version INT PRIMARY KEY) "
                 "ENGINE=InnoDB"
             )
+            # v3 -> v4: run_id on cubepi_messages + cubepi_runs partitioned table.
+            # upgrade_v3_to_v4_op() returns multiple ';'-separated statements;
+            # MySQL runs one per call, so split before executing.
+            for stmt in upgrade_v3_to_v4_op().split(";"):
+                if stmt.strip():
+                    await cur.execute(stmt)
             # write_schema_version_op() returns two ';'-separated statements;
             # MySQL runs one per call, so split before executing.
             for stmt in write_schema_version_op().split(";"):

--- a/examples/checkpointing_postgres.py
+++ b/examples/checkpointing_postgres.py
@@ -32,7 +32,9 @@ from cubepi.agent.agent import Agent
 from cubepi.checkpointer.postgres import PostgresCheckpointer
 from cubepi.checkpointer.postgres.alembic_helpers import (
     add_pending_request_column_op,
+    add_run_id_column_op,
     create_message_partitions_op,
+    upgrade_v3_to_v4_op,
     write_schema_version_op,
 )
 from cubepi.providers.faux import FauxProvider, faux_assistant_message
@@ -65,6 +67,7 @@ async def bootstrap_schema(dsn: str) -> None:
             );
         """)
         await conn.execute(add_pending_request_column_op())  # v1 -> v2 column
+        await conn.execute(add_run_id_column_op())  # v2 -> v3 column
         await conn.execute("""
             CREATE TABLE cubepi_messages (
                 thread_id TEXT NOT NULL
@@ -85,6 +88,8 @@ async def bootstrap_schema(dsn: str) -> None:
         await conn.execute(
             "CREATE TABLE cubepi_schema_version (version INTEGER PRIMARY KEY);"
         )
+        # v3 -> v4: run_id on cubepi_messages + cubepi_runs partitioned table.
+        await conn.execute(upgrade_v3_to_v4_op())
         await conn.execute(write_schema_version_op())  # record EXPECTED_SCHEMA_VERSION
     finally:
         await conn.close()

--- a/tests/agent/test_agent_claim_run.py
+++ b/tests/agent/test_agent_claim_run.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from cubepi.agent.agent import Agent
@@ -81,3 +83,37 @@ async def test_degraded_mode_v3_only_checkpointer():
     # Vanilla prompt works (degraded mode skips claim).
     got = await a.prompt("hi")
     assert isinstance(got, str)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_cold_prompts_second_raises_fast():
+    """Two concurrent cold prompt() calls — the second must raise immediately
+    instead of serializing on the run-lock behind the first's claim_run I/O.
+
+    Regression for codex P1: claim_run used to run BEFORE the lock was
+    acquired, so two callers could both pass the fail-fast `.locked()` check
+    while the first was awaiting claim_run.
+    """
+
+    class _SlowClaimCheckpointer(MemoryCheckpointer):
+        async def claim_run(self, thread_id, run_id):  # type: ignore[override]
+            await asyncio.sleep(0.05)
+            return await super().claim_run(thread_id, run_id)
+
+    cp = _SlowClaimCheckpointer()
+    a = _agent(checkpointer=cp, thread_id="t")
+
+    results = await asyncio.gather(
+        a.prompt("first", run_id="R1"),
+        a.prompt("second", run_id="R2"),
+        return_exceptions=True,
+    )
+    # Exactly one succeeded; the other raised "already processing".
+    runtime_errs = [r for r in results if isinstance(r, RuntimeError)]
+    successes = [r for r in results if isinstance(r, str)]
+    assert len(runtime_errs) == 1
+    assert len(successes) == 1
+    assert "already processing" in str(runtime_errs[0]).lower()
+    # The loser's run_id was NOT claimed (claim_run only runs inside the lock).
+    claimed = set(cp._runs.get("t", {}).keys())
+    assert claimed == {successes[0]}

--- a/tests/agent/test_agent_claim_run.py
+++ b/tests/agent/test_agent_claim_run.py
@@ -86,6 +86,80 @@ async def test_degraded_mode_v3_only_checkpointer():
 
 
 @pytest.mark.asyncio
+async def test_resume_claims_run_and_stamps_messages():
+    """Regression for codex R3 P1: `resume()` must claim a run, set
+    `active_run_id`, and dispatch completion — otherwise messages emitted
+    by the resumed turn land with `run_id=None` and fork queries (which
+    treat NULL as legacy / always-copy) would copy them into forks even
+    if the resumed work is still in flight or later abandoned.
+    """
+    from cubepi.providers.base import TextContent, UserMessage
+
+    cp = MemoryCheckpointer()
+    a = _agent(checkpointer=cp, thread_id="t")
+    # Hydrate state from a persisted UserMessage (the documented
+    # checkpointed-resume pattern: host reloads from checkpointer, then
+    # calls resume()).
+    a._state._messages = [
+        UserMessage(content=[TextContent(text="hi")], run_id="R_seed"),
+    ]
+
+    effective = await a.resume(run_id="R_resume")
+    assert effective == "R_resume"
+    # The run was claimed AND completed.
+    assert "R_resume" in cp._runs["t"]
+    assert cp._runs["t"]["R_resume"].completed_at is not None
+    # Messages emitted by the resumed turn carry the resume run_id.
+    appended = a.state.messages[1:]
+    assert appended  # the faux provider yielded an assistant message
+    for m in appended:
+        assert m.run_id == "R_resume", (
+            f"message emitted by resume() left with run_id={m.run_id!r} "
+            "(would be treated as legacy by fork queries)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_resume_auto_generates_run_id_when_not_supplied():
+    """resume() without an explicit run_id auto-generates one."""
+    from cubepi.providers.base import TextContent, UserMessage
+
+    cp = MemoryCheckpointer()
+    a = _agent(checkpointer=cp, thread_id="t")
+    a._state._messages = [
+        UserMessage(content=[TextContent(text="hi")], run_id="R_seed"),
+    ]
+    effective = await a.resume()
+    assert isinstance(effective, str) and len(effective) > 0
+    assert effective in cp._runs["t"]
+    assert cp._runs["t"][effective].completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_resume_precondition_failure_does_not_claim():
+    """Precondition failure ('Cannot continue from message role: assistant')
+    must NOT call claim_run — otherwise a dangling claimed run would
+    block re-resume with the same run_id.
+    """
+    from cubepi.providers.base import AssistantMessage, TextContent
+
+    cp = MemoryCheckpointer()
+    a = _agent(checkpointer=cp, thread_id="t")
+    # Last message is AssistantMessage with no queued steering/follow-up.
+    a._state._messages = [
+        AssistantMessage(
+            content=[TextContent(text="done")],
+            stop_reason="end_turn",
+            run_id="R_prev",
+        ),
+    ]
+    with pytest.raises(RuntimeError, match="Cannot continue"):
+        await a.resume(run_id="R_new")
+    # R_new was NOT claimed — the precondition raised before the claim.
+    assert "R_new" not in cp._runs.get("t", {})
+
+
+@pytest.mark.asyncio
 async def test_concurrent_cold_prompts_second_raises_fast():
     """Two concurrent cold prompt() calls — the second must raise immediately
     instead of serializing on the run-lock behind the first's claim_run I/O.

--- a/tests/agent/test_agent_claim_run.py
+++ b/tests/agent/test_agent_claim_run.py
@@ -1,0 +1,83 @@
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+)
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_faux() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses(
+        [AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")]
+    )
+    return p
+
+
+def _agent(**kw):
+    return Agent(model=_ok_faux().model("faux-model"), **kw)
+
+
+@pytest.mark.asyncio
+async def test_prompt_calls_claim_run_before_append():
+    cp = MemoryCheckpointer()
+    a = _agent(checkpointer=cp, thread_id="t")
+    await a.prompt("hi", run_id="R1")
+    # Run row exists.
+    assert "R1" in cp._runs["t"]
+
+
+@pytest.mark.asyncio
+async def test_prompt_rejects_already_claimed_run_id():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "R1")
+    a = _agent(checkpointer=cp, thread_id="t")
+    with pytest.raises(RunAlreadyClaimedError):
+        await a.prompt("hi", run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_prompt_rejects_already_completed_run_id():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "R1")
+    await cp.mark_run_complete("t", "R1")
+    a = _agent(checkpointer=cp, thread_id="t")
+    with pytest.raises(RunAlreadyCompletedError):
+        await a.prompt("hi", run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_no_checkpointer_no_claim_call():
+    a = _agent()  # checkpointer=None
+    got = await a.prompt("hi")
+    assert isinstance(got, str)  # works fine; no claim attempted
+
+
+@pytest.mark.asyncio
+async def test_degraded_mode_v3_only_checkpointer():
+    class _V3Only:
+        async def load(self, thread_id):
+            return None
+
+        async def append(self, thread_id, msgs):
+            pass
+
+        async def save_extra(self, thread_id, extra):
+            pass
+
+        async def save_pending_request(self, thread_id, req, *, run_id=None):
+            pass
+
+        async def load_pending_request(self, thread_id):
+            return None
+
+        # No claim_run / mark_run_complete.
+
+    a = _agent(checkpointer=_V3Only(), thread_id="t")
+    # Vanilla prompt works (degraded mode skips claim).
+    got = await a.prompt("hi")
+    assert isinstance(got, str)

--- a/tests/agent/test_agent_completion.py
+++ b/tests/agent/test_agent_completion.py
@@ -115,7 +115,7 @@ def _two_turn_bash_responses():
 @pytest.mark.asyncio
 async def test_hitl_detached_outcome_suspended_no_mark():
     cp = MemoryCheckpointer()
-    ch = CheckpointedChannel(checkpointer=cp, thread_id="t")
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
     provider = FauxProvider(provider_id="faux")
     provider.set_responses(_two_turn_bash_responses())
     a = Agent(
@@ -155,7 +155,7 @@ async def test_hitl_detached_outcome_suspended_no_mark():
 @pytest.mark.asyncio
 async def test_hitl_aborted_via_abort_pending_does_not_mark():
     cp = MemoryCheckpointer()
-    ch = CheckpointedChannel(checkpointer=cp, thread_id="t")
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
     provider = FauxProvider(provider_id="faux")
     provider.set_responses(_two_turn_bash_responses())
     a = Agent(
@@ -194,7 +194,7 @@ async def test_hitl_aborted_via_abort_pending_does_not_mark():
 @pytest.mark.asyncio
 async def test_propagating_cancel_does_not_mark():
     cp = MemoryCheckpointer()
-    ch = CheckpointedChannel(checkpointer=cp, thread_id="t")
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
     provider = FauxProvider(provider_id="faux")
     provider.set_responses(_two_turn_bash_responses())
     a = Agent(

--- a/tests/agent/test_agent_completion.py
+++ b/tests/agent/test_agent_completion.py
@@ -1,0 +1,264 @@
+"""Task 26 tests — outcome enumeration + mark_run_complete dispatch.
+
+The contract under test: ``Agent.prompt()`` writes the completion marker
+(via ``Checkpointer.mark_run_complete``) IFF the loop reached a terminal
+``AgentEndEvent`` with a non-error/aborted stop_reason. Every other exit
+(provider error, HITL detach, HITL abort, propagating cancel) must NOT
+mark the run as complete, leaving the row resumable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import BaseModel
+
+from cubepi.agent.agent import Agent
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.checkpointer.exceptions import (
+    CompletionMarkerFailedError,
+    RunNotClaimedError,
+)
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl import AskUser
+from cubepi.hitl.channel import CheckpointedChannel
+from cubepi.hitl.middleware import ApprovalPolicyMiddleware
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import (
+    FauxProvider,
+    faux_assistant_message,
+    faux_text,
+    faux_tool_call,
+)
+
+
+class _Params(BaseModel):
+    cmd: str
+
+
+def _bash_tool() -> AgentTool:
+    async def execute(call_id, args, *, signal=None, on_update=None):
+        return AgentToolResult(content=[TextContent(text=f"ran {args.cmd}")])
+
+    return AgentTool(
+        name="bash",
+        description="run a shell command",
+        parameters=_Params,
+        execute=execute,
+        execution_mode="sequential",
+    )
+
+
+def _ok_faux() -> FauxProvider:
+    p = FauxProvider(provider_id="faux")
+    p.set_responses(
+        [AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")]
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Clean success path → mark_run_complete IS called.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clean_success_marks_complete():
+    cp = MemoryCheckpointer()
+    a = Agent(model=_ok_faux().model("faux-m"), checkpointer=cp, thread_id="t")
+    got = await a.prompt("hi", run_id="R1")
+    assert got == "R1"
+    assert a.state.last_outcome == "complete"
+    assert a.state.active_run_id is None
+    # mark_run_complete actually ran — row has completion_seq set.
+    state = cp._runs["t"]["R1"]
+    assert state.completed_at is not None
+    assert state.completion_seq is not None
+
+
+# ---------------------------------------------------------------------------
+# Provider error → loop emits stop_reason="error" → outcome="abandoned" → no mark.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_error_does_not_mark():
+    """FauxProvider with no queued responses surfaces stop_reason=error."""
+    cp = MemoryCheckpointer()
+    provider = FauxProvider(provider_id="faux")
+    # Empty response queue → faux returns AssistantMessage(stop_reason="error").
+    a = Agent(model=provider.model("faux-m"), checkpointer=cp, thread_id="t")
+    got = await a.prompt("hi", run_id="R1")  # _handle_run_failure swallows
+    assert got == "R1"
+    assert a.state.last_outcome == "abandoned"
+    # Run row claimed but NOT completed — still resumable.
+    state = cp._runs["t"]["R1"]
+    assert state.completed_at is None
+
+
+# ---------------------------------------------------------------------------
+# HITL detach → outcome="suspended" → no mark.
+# ---------------------------------------------------------------------------
+
+
+def _two_turn_bash_responses():
+    return [
+        faux_assistant_message(
+            [faux_text("ok"), faux_tool_call("bash", {"cmd": "ls"}, id="tc-1")],
+            stop_reason="tool_use",
+        ),
+        faux_assistant_message("done"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hitl_detached_outcome_suspended_no_mark():
+    cp = MemoryCheckpointer()
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t")
+    provider = FauxProvider(provider_id="faux")
+    provider.set_responses(_two_turn_bash_responses())
+    a = Agent(
+        model=provider.model("faux-m"),
+        tools=[_bash_tool()],
+        middleware=[ApprovalPolicyMiddleware(ch, policy=lambda c: AskUser())],
+        channel=ch,
+        checkpointer=cp,
+        thread_id="t",
+    )
+
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    # Wait for pending HITL request.
+    for _ in range(200):
+        if ch.pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("agent did not suspend on HITL")
+
+    await a.detach()
+    await task
+
+    assert a.state.last_outcome == "suspended"
+    # Row claimed, NOT completed.
+    state = cp._runs["t"]["R1"]
+    assert state.completed_at is None
+    # active_run_id cleared on clean else: branch (suspended is NOT an error).
+    assert a.state.active_run_id is None
+
+
+# ---------------------------------------------------------------------------
+# HITL abort_pending → outcome="abandoned" → no mark.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hitl_aborted_via_abort_pending_does_not_mark():
+    cp = MemoryCheckpointer()
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t")
+    provider = FauxProvider(provider_id="faux")
+    provider.set_responses(_two_turn_bash_responses())
+    a = Agent(
+        model=provider.model("faux-m"),
+        tools=[_bash_tool()],
+        middleware=[ApprovalPolicyMiddleware(ch, policy=lambda c: AskUser())],
+        channel=ch,
+        checkpointer=cp,
+        thread_id="t",
+    )
+
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    for _ in range(200):
+        if ch.pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("agent did not suspend on HITL")
+
+    # abort_pending: Phase 1 sets the agent signal — _BaseChannel._await_answer
+    # raises HitlAborted, which surfaces from the loop as outcome="abandoned".
+    await a.abort_pending(reason="user closed")
+    await task
+
+    assert a.state.last_outcome == "abandoned"
+    # Row claimed, NOT completed.
+    state = cp._runs["t"]["R1"]
+    assert state.completed_at is None
+
+
+# ---------------------------------------------------------------------------
+# Propagating asyncio.CancelledError → outcome stays None → no mark.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_propagating_cancel_does_not_mark():
+    cp = MemoryCheckpointer()
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t")
+    provider = FauxProvider(provider_id="faux")
+    provider.set_responses(_two_turn_bash_responses())
+    a = Agent(
+        model=provider.model("faux-m"),
+        tools=[_bash_tool()],
+        middleware=[ApprovalPolicyMiddleware(ch, policy=lambda c: AskUser())],
+        channel=ch,
+        checkpointer=cp,
+        thread_id="t",
+    )
+
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    for _ in range(200):
+        if ch.pending is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:
+        pytest.fail("agent did not suspend on HITL")
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Cancel propagates through prompt()'s `except BaseException: raise` —
+    # active_run_id stays SET; no mark_run_complete call.
+    assert a.state.active_run_id == "R1"
+    state = cp._runs["t"]["R1"]
+    assert state.completed_at is None
+    # last_outcome may remain None (no loop terminal path fired).
+    assert a.state.last_outcome != "complete"
+
+
+# ---------------------------------------------------------------------------
+# CompletionMarkerFailedError path: when mark_run_complete raises, the wrapped
+# error propagates UP through prompt() carrying the generated run_id, and
+# active_run_id stays SET so the host can introspect it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completion_marker_failed_carries_run_id_when_generated():
+    cp = MemoryCheckpointer()
+
+    boom_raised: dict[str, bool] = {}
+
+    async def _boom_mark(thread_id: str, run_id: str) -> None:
+        boom_raised["called"] = True
+        boom_raised["run_id"] = run_id
+        raise RunNotClaimedError("simulated DB hiccup")
+
+    # Monkey-patch mark_run_complete on this checkpointer instance.
+    cp.mark_run_complete = _boom_mark  # type: ignore[method-assign]
+
+    a = Agent(model=_ok_faux().model("faux-m"), checkpointer=cp, thread_id="t")
+    # run_id=None → cubepi generates one. Test that the generated value is
+    # carried on the raised CompletionMarkerFailedError.
+    with pytest.raises(CompletionMarkerFailedError) as excinfo:
+        await a.prompt("hi")
+
+    assert boom_raised.get("called") is True
+    err = excinfo.value
+    assert err.thread_id == "t"
+    assert err.run_id == boom_raised["run_id"]
+    # active_run_id stays SET — the clear line is unreachable past the raise.
+    assert a.state.active_run_id == err.run_id
+    # Outcome was "complete" before dispatch failed.
+    assert a.state.last_outcome == "complete"

--- a/tests/agent/test_agent_fork.py
+++ b/tests/agent/test_agent_fork.py
@@ -1,0 +1,48 @@
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_faux() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses(
+        [AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")]
+    )
+    return p
+
+
+@pytest.mark.asyncio
+async def test_agent_fork_delegates_to_checkpointer():
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.prompt("hello", run_id="R1")  # creates src + R1 marker
+    await a.fork("src", "dst", after_run_id="R1")
+    loaded = await cp.load("dst")
+    assert loaded.parent_thread_id == "src"
+
+
+@pytest.mark.asyncio
+async def test_agent_fork_no_checkpointer_raises():
+    a = Agent(model=_ok_faux().model("faux-model"))
+    with pytest.raises(RuntimeError, match="checkpointer"):
+        await a.fork("src", "dst", after_run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_agent_fork_does_not_mutate_self_thread_id():
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.prompt("hello", run_id="R1")
+    await a.fork("src", "dst", after_run_id="R1")
+    assert a.thread_id == "src"

--- a/tests/agent/test_agent_fork.py
+++ b/tests/agent/test_agent_fork.py
@@ -46,3 +46,38 @@ async def test_agent_fork_does_not_mutate_self_thread_id():
     await a.prompt("hello", run_id="R1")
     await a.fork("src", "dst", after_run_id="R1")
     assert a.thread_id == "src"
+
+
+@pytest.mark.asyncio
+async def test_agent_fork_v3_only_checkpointer_raises_CheckpointerError():
+    """A pre-v4 checkpointer (no claim_run / mark_run_complete) is in
+    'degraded mode': vanilla prompt() works but fork() must surface
+    CheckpointerError so callers know the backend cannot support fork.
+    """
+    from cubepi.checkpointer.exceptions import CheckpointerError
+
+    class _V3Only:
+        async def load(self, thread_id):
+            return None
+
+        async def append(self, thread_id, msgs):
+            pass
+
+        async def save_extra(self, thread_id, extra):
+            pass
+
+        async def save_pending_request(self, thread_id, req, *, run_id=None):
+            pass
+
+        async def load_pending_request(self, thread_id):
+            return None
+
+        # No claim_run / mark_run_complete → not _run_aware.
+
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=_V3Only(),
+        thread_id="src",
+    )
+    with pytest.raises(CheckpointerError, match="does not support fork"):
+        await a.fork("src", "dst", after_run_id="R1")

--- a/tests/agent/test_agent_fork_once.py
+++ b/tests/agent/test_agent_fork_once.py
@@ -1,0 +1,213 @@
+import asyncio
+
+import pytest
+from pydantic import BaseModel
+
+from cubepi.agent.agent import Agent
+from cubepi.agent.types import AgentTool, ForkOnceResult
+from cubepi.checkpointer.exceptions import CheckpointerError
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.binding import HitlBinding
+from cubepi.middleware.base import Middleware
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_faux() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses(
+        [AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")]
+    )
+    return p
+
+
+class _NoArgs(BaseModel):
+    pass
+
+
+async def _noop(tool_call_id, args, *, signal=None, on_update=None):
+    raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_fork_once_simple_text_returns_final_text():
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.prompt("hello", run_id="R1")
+    before = await cp.load("src")
+    before_msgs = list(before.messages)
+    # New faux for the fork_once probe.
+    a2 = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    result = await a2.fork_once("src", "what next?", after_run_id="R1")
+    assert isinstance(result, ForkOnceResult)
+    assert result.text == "ok"
+    after = await cp.load("src")
+    assert list(after.messages) == before_msgs
+
+
+@pytest.mark.asyncio
+async def test_fork_once_no_checkpointer_raises():
+    a = Agent(model=_ok_faux().model("faux-model"))
+    with pytest.raises(RuntimeError, match="checkpointer"):
+        await a.fork_once("src", "msg", after_run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_fork_once_v3_only_checkpointer_raises_CheckpointerError():
+    class _V3Only:
+        async def load(self, thread_id):
+            return None
+
+        async def append(self, thread_id, msgs):
+            pass
+
+        async def save_extra(self, thread_id, extra):
+            pass
+
+        async def save_pending_request(self, thread_id, req, *, run_id=None):
+            pass
+
+        async def load_pending_request(self, thread_id):
+            return None
+
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=_V3Only(),
+        thread_id="src",
+    )
+    with pytest.raises(CheckpointerError):
+        await a.fork_once("src", "msg", after_run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_fork_once_rejects_checkpointed_hitl_tool():
+    cp = MemoryCheckpointer()
+    hitl_tool = AgentTool(
+        name="ask_user",
+        description="ask user",
+        parameters=_NoArgs,
+        execute=_noop,
+        hitl=HitlBinding(checkpointed=True, run_id="R1"),
+    )
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+        tools=[hitl_tool],
+    )
+    # Seed a completed run so snapshot would succeed if we reached it.
+    await cp.claim_run("src", "R1")
+    await cp.mark_run_complete("src", "R1")
+    with pytest.raises(RuntimeError, match="does not support HITL"):
+        await a.fork_once("src", "msg", after_run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_fork_once_rejects_in_memory_hitl_tool():
+    cp = MemoryCheckpointer()
+    hitl_tool = AgentTool(
+        name="ask_user",
+        description="ask user",
+        parameters=_NoArgs,
+        execute=_noop,
+        hitl=HitlBinding(checkpointed=False, run_id=None),
+    )
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+        tools=[hitl_tool],
+    )
+    await cp.claim_run("src", "R1")
+    await cp.mark_run_complete("src", "R1")
+    with pytest.raises(RuntimeError, match="does not support HITL"):
+        await a.fork_once("src", "msg", after_run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_fork_once_rejects_hitl_middleware():
+    cp = MemoryCheckpointer()
+
+    class _HitlMw(Middleware):
+        def __init__(self) -> None:
+            self.hitl = HitlBinding(checkpointed=True, run_id="R1")
+
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+        middleware=[_HitlMw()],
+    )
+    await cp.claim_run("src", "R1")
+    await cp.mark_run_complete("src", "R1")
+    with pytest.raises(RuntimeError, match="does not support HITL"):
+        await a.fork_once("src", "msg", after_run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_fork_once_cancellation_propagates():
+    cp = MemoryCheckpointer()
+    # Seed src with a quick run.
+    seed_agent = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await seed_agent.prompt("hello", run_id="R1")
+
+    # Build a slow FauxProvider for the probe.
+    async def _slow_factory(messages, model, system_prompt, tools):
+        await asyncio.sleep(5)
+        return AssistantMessage(
+            content=[TextContent(text="never")], stop_reason="end_turn"
+        )
+
+    slow_p = FauxProvider()
+    slow_p.set_responses([_slow_factory])
+
+    a = Agent(
+        model=slow_p.model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(
+            a.fork_once("src", "msg", after_run_id="R1"), timeout=0.05
+        )
+
+
+@pytest.mark.asyncio
+async def test_fork_once_source_thread_byte_identical():
+    cp = MemoryCheckpointer()
+    seed_agent = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await seed_agent.prompt("hello", run_id="R1")
+    before = await cp.load("src")
+    before_dump = [m.model_dump() for m in before.messages]
+    before_extra = dict(before.extra)
+    before_runs = dict(cp._runs.get("src", {}))
+
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.fork_once("src", "probe", after_run_id="R1")
+
+    after = await cp.load("src")
+    after_dump = [m.model_dump() for m in after.messages]
+    assert after_dump == before_dump
+    assert dict(after.extra) == before_extra
+    # Source thread's run state untouched.
+    assert dict(cp._runs.get("src", {})) == before_runs

--- a/tests/agent/test_agent_fork_once.py
+++ b/tests/agent/test_agent_fork_once.py
@@ -211,3 +211,83 @@ async def test_fork_once_source_thread_byte_identical():
     assert dict(after.extra) == before_extra
     # Source thread's run state untouched.
     assert dict(cp._runs.get("src", {})) == before_runs
+
+
+@pytest.mark.asyncio
+async def test_fork_once_forwards_parent_execution_options():
+    """fork_once() child must inherit the parent's execution options
+    (tool_execution, thinking, response hook) — not silently fall back
+    to defaults.
+
+    Regression for codex P2: the child was only receiving
+    {model, system_prompt, tools, middleware, convert_to_llm, messages}.
+    """
+    cp = MemoryCheckpointer()
+    hook_calls: list[str] = []
+
+    async def _after_response(response, ctx, *, signal=None):
+        # Proves the parent's after_model_response was forwarded to the child.
+        hook_calls.append("after_response")
+        return None
+
+    seed_agent = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await seed_agent.prompt("hello", run_id="R1")
+
+    parent = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+        tool_execution="sequential",
+        thinking="medium",
+        after_model_response=_after_response,
+    )
+    await parent.fork_once("src", "probe", after_run_id="R1")
+
+    # The hook ran in the child (proves the parent's hook was forwarded).
+    assert hook_calls == ["after_response"]
+
+
+@pytest.mark.asyncio
+async def test_fork_once_forwards_tool_execution_and_thinking():
+    """fork_once() child must inherit tool_execution and thinking settings."""
+    cp = MemoryCheckpointer()
+    captured: dict[str, object] = {}
+
+    # Patch Agent.__init__ briefly to capture the child's kwargs.
+    real_init = Agent.__init__
+
+    def _spy_init(self, *args, **kwargs):
+        # Skip the parent constructor call: only capture the second Agent()
+        # (the child built by fork_once).
+        captured.setdefault("calls", 0)
+        captured["calls"] = captured["calls"] + 1  # type: ignore[operator]
+        if captured["calls"] >= 3:  # 1=seed, 2=parent, 3=child
+            captured["thinking"] = kwargs.get("thinking")
+            captured["tool_execution"] = kwargs.get("tool_execution")
+        return real_init(self, *args, **kwargs)
+
+    Agent.__init__ = _spy_init  # type: ignore[method-assign]
+    try:
+        seed_agent = Agent(
+            model=_ok_faux().model("faux-model"),
+            checkpointer=cp,
+            thread_id="src",
+        )
+        await seed_agent.prompt("hello", run_id="R1")
+        parent = Agent(
+            model=_ok_faux().model("faux-model"),
+            checkpointer=cp,
+            thread_id="src",
+            tool_execution="sequential",
+            thinking="medium",
+        )
+        await parent.fork_once("src", "probe", after_run_id="R1")
+    finally:
+        Agent.__init__ = real_init  # type: ignore[method-assign]
+
+    assert captured["thinking"] == "medium"
+    assert captured["tool_execution"] == "sequential"

--- a/tests/agent/test_agent_messages_kw.py
+++ b/tests/agent/test_agent_messages_kw.py
@@ -45,8 +45,10 @@ def test_messages_kw_deep_copies_all_three_variants():
         metadata={},
     )
     tool = ToolResultMessage(
-        tool_call_id="c1", tool_name="t",
-        content=[TextContent(text="r")], metadata={"x": 1},
+        tool_call_id="c1",
+        tool_name="t",
+        content=[TextContent(text="r")],
+        metadata={"x": 1},
     )
     a = _agent(messages=[user, assistant, tool])
     # Mutate originals.

--- a/tests/agent/test_agent_messages_kw.py
+++ b/tests/agent/test_agent_messages_kw.py
@@ -1,0 +1,62 @@
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+from cubepi.providers.faux import FauxProvider
+
+
+def _agent(**kw):
+    return Agent(model=FauxProvider().model("faux-model"), **kw)
+
+
+def test_messages_kw_none_keeps_default():
+    a = _agent()
+    assert a.state.messages == []
+
+
+def test_messages_kw_seeds_initial_history():
+    msgs = [UserMessage(content=[TextContent(text="hi")])]
+    a = _agent(messages=msgs)
+    assert len(a.state.messages) == 1
+
+
+def test_messages_kw_conflicts_with_thread_id_checkpointer():
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+
+    msgs = [UserMessage(content=[TextContent(text="hi")])]
+    with pytest.raises(ValueError):
+        _agent(
+            messages=msgs,
+            thread_id="t",
+            checkpointer=MemoryCheckpointer(),
+        )
+
+
+def test_messages_kw_deep_copies_all_three_variants():
+    user = UserMessage(content=[TextContent(text="u")], metadata={"k": "v"})
+    assistant = AssistantMessage(
+        content=[ToolCall(id="c1", name="t", arguments={"k": [1, 2]})],
+        metadata={},
+    )
+    tool = ToolResultMessage(
+        tool_call_id="c1", tool_name="t",
+        content=[TextContent(text="r")], metadata={"x": 1},
+    )
+    a = _agent(messages=[user, assistant, tool])
+    # Mutate originals.
+    user.metadata["k"] = "MUT"
+    assistant.content[0].arguments["k"].append(99)
+    tool.metadata["x"] = 999
+    # Internal copies untouched.
+    assert a.state.messages[0].metadata["k"] == "v"
+    assert a.state.messages[1].content[0].arguments["k"] == [1, 2]
+    assert a.state.messages[2].metadata["x"] == 1
+    # Mutate agent's copies; originals untouched.
+    a.state.messages[0].metadata["k"] = "AGENT"
+    assert user.metadata["k"] == "MUT"

--- a/tests/agent/test_agent_run_id.py
+++ b/tests/agent/test_agent_run_id.py
@@ -1,0 +1,54 @@
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_faux() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses(
+        [AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")]
+    )
+    return p
+
+
+def _agent(**kw):
+    return Agent(model=_ok_faux().model("faux-model"), **kw)
+
+
+@pytest.mark.asyncio
+async def test_prompt_returns_supplied_run_id():
+    a = _agent()
+    got = await a.prompt("hello", run_id="R1")
+    assert got == "R1"
+
+
+@pytest.mark.asyncio
+async def test_prompt_generates_run_id_when_none():
+    a = _agent()
+    got = await a.prompt("hello")
+    assert isinstance(got, str) and len(got) >= 8
+
+
+@pytest.mark.asyncio
+async def test_prompt_sets_then_clears_active_run_id_on_clean_return():
+    a = _agent()
+    assert a.state.active_run_id is None
+    await a.prompt("hello", run_id="R1")
+    assert a.state.active_run_id is None  # cleared on clean return
+
+
+@pytest.mark.asyncio
+async def test_prompt_leaves_active_run_id_set_on_raise(monkeypatch):
+    """Spec §3.7 + Task 22: active_run_id must be LEFT SET on any
+    propagating failure after claim."""
+    a = Agent(model=_ok_faux().model("faux-model"))
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(a, "_run_prompt", _boom)
+    with pytest.raises(RuntimeError, match="boom"):
+        await a.prompt("hello", run_id="R1")
+    assert a.state.active_run_id == "R1"

--- a/tests/agent/test_agent_run_id.py
+++ b/tests/agent/test_agent_run_id.py
@@ -94,3 +94,27 @@ async def test_prompt_rejects_mismatched_run_id_before_claim():
     assert "R1" not in cp._runs.get("t", {})
     # ... and a second prompt with the same run_id succeeds:
     await a.prompt("hi", run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_process_event_rejects_mismatched_message_run_id():
+    """`_process_event` for MessageEndEvent stamps msg.run_id with
+    state.active_run_id when msg.run_id is None, but raises if the
+    message already carries a DIFFERENT run_id (defensive — a provider
+    or middleware bug that produced the wrong stamp must not silently
+    write to the persisted history)."""
+    from cubepi.agent.types import MessageEndEvent
+    from cubepi.providers.base import (
+        AssistantMessage,
+        TextContent,
+    )
+
+    a = Agent(model=_ok_faux().model("faux-model"))
+    a._state.active_run_id = "R_active"
+    bad_msg = AssistantMessage(
+        content=[TextContent(text="bad")],
+        stop_reason="end_turn",
+        run_id="R_OTHER",
+    )
+    with pytest.raises(ValueError, match="does not match"):
+        await a._process_event(MessageEndEvent(message=bad_msg))

--- a/tests/agent/test_agent_run_id.py
+++ b/tests/agent/test_agent_run_id.py
@@ -52,3 +52,45 @@ async def test_prompt_leaves_active_run_id_set_on_raise(monkeypatch):
     with pytest.raises(RuntimeError, match="boom"):
         await a.prompt("hello", run_id="R1")
     assert a.state.active_run_id == "R1"
+
+
+@pytest.mark.asyncio
+async def test_appended_messages_carry_run_id():
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+    )
+    await a.prompt("hello", run_id="R1")
+    data = await cp.load("t")
+    for m in data.messages:
+        assert m.run_id == "R1"
+
+
+@pytest.mark.asyncio
+async def test_prompt_rejects_mismatched_run_id_before_claim():
+    """Caller pre-stamps a Message with a different run_id than the
+    one supplied to prompt(). Reject BEFORE claim_run so no row is
+    written and the run_id is still reusable."""
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+    from cubepi.providers.base import TextContent, UserMessage
+
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+    )
+    bad_msg = UserMessage(content=[TextContent(text="hi")], run_id="WRONG")
+    with pytest.raises(ValueError, match="does not match"):
+        await a.prompt(bad_msg, run_id="R1")
+    # No claim row written — "R1" still freely claimable.
+    # NOTE: As of Task 23 there is no claim_run yet (Task 25 adds it),
+    # so cp._runs should be empty regardless. Once Task 25 lands,
+    # this assertion will guarantee no claim row was written.
+    assert "R1" not in cp._runs.get("t", {})
+    # ... and a second prompt with the same run_id succeeds:
+    await a.prompt("hi", run_id="R1")

--- a/tests/agent/test_agent_state.py
+++ b/tests/agent/test_agent_state.py
@@ -1,0 +1,14 @@
+from cubepi.agent.agent import AgentState
+
+
+def test_agent_state_default_active_run_id_none():
+    s = AgentState()
+    assert s.active_run_id is None
+
+
+def test_agent_state_active_run_id_settable():
+    s = AgentState()
+    s.active_run_id = "r-1"
+    assert s.active_run_id == "r-1"
+    s.active_run_id = None
+    assert s.active_run_id is None

--- a/tests/agent/test_checkpointer_integration.py
+++ b/tests/agent/test_checkpointer_integration.py
@@ -358,3 +358,30 @@ class TestCheckpointerIntegration:
         ]
         await agent._complete_cancelled_tool_calls()
         assert len(agent._state._messages) == 3
+
+    async def test_cancel_backfill_stamps_synthetic_with_owning_run_id(self):
+        """Regression for codex R2 P1: synthetic ToolResultMessages produced
+        during cancel cleanup must carry the originating assistant's run_id.
+
+        Without it, fork-snapshot queries (which treat run_id IS NULL as
+        legacy / always-copy) would copy these orphans into a later fork
+        after an EARLIER completed run, even though the cancelled run was
+        never marked complete.
+        """
+        agent = Agent(model=FauxProvider(provider_id="faux").model("faux-1"))
+        agent._state._messages = [
+            UserMessage(content=[TextContent(text="go")], run_id="R_cancel"),
+            AssistantMessage(
+                content=[
+                    ToolCall(id="orphan", name="b", arguments={}),
+                ],
+                stop_reason="tool_use",
+                run_id="R_cancel",
+            ),
+        ]
+        await agent._complete_cancelled_tool_calls()
+        backfilled = [
+            m for m in agent._state._messages if isinstance(m, ToolResultMessage)
+        ]
+        assert len(backfilled) == 1
+        assert backfilled[0].run_id == "R_cancel"

--- a/tests/agent/test_fork_once_result.py
+++ b/tests/agent/test_fork_once_result.py
@@ -1,0 +1,12 @@
+import pytest
+
+from cubepi.agent.types import ForkOnceResult
+
+
+def test_fork_once_result_constructs_and_is_frozen():
+    r = ForkOnceResult(text="hi", messages=[], stop_reason="end_turn")
+    assert r.text == "hi"
+    assert r.messages == []
+    assert r.stop_reason == "end_turn"
+    with pytest.raises((AttributeError, Exception)):
+        r.text = "mut"  # type: ignore[misc]

--- a/tests/agent/test_hitl_binding.py
+++ b/tests/agent/test_hitl_binding.py
@@ -1,0 +1,63 @@
+from cubepi.agent.types import AgentTool
+from cubepi.hitl.binding import HitlBinding
+from cubepi.middleware.base import Middleware
+from pydantic import BaseModel
+
+
+class _NoArgs(BaseModel):
+    pass
+
+
+async def _noop(tool_call_id, args, *, signal=None, on_update=None):
+    raise NotImplementedError
+
+
+def test_agent_tool_hitl_default_none():
+    t = AgentTool(
+        name="t",
+        description="d",
+        parameters=_NoArgs,
+        execute=_noop,
+    )
+    assert t.hitl is None
+
+
+def test_agent_tool_hitl_can_be_set():
+    binding = HitlBinding(checkpointed=True, run_id="r-1")
+    t = AgentTool(
+        name="t",
+        description="d",
+        parameters=_NoArgs,
+        execute=_noop,
+        hitl=binding,
+    )
+    assert t.hitl is binding
+    assert t.hitl.checkpointed is True
+    assert t.hitl.run_id == "r-1"
+
+
+def test_middleware_hitl_default_none():
+    class _Mw(Middleware):
+        pass
+
+    assert _Mw().hitl is None
+
+
+def test_middleware_hitl_can_be_set_in_subclass():
+    class _Mw(Middleware):
+        def __init__(self) -> None:
+            self.hitl = HitlBinding(checkpointed=False, run_id=None)
+
+    mw = _Mw()
+    assert mw.hitl is not None
+    assert mw.hitl.checkpointed is False
+    assert mw.hitl.run_id is None
+
+
+def test_hitl_binding_is_frozen():
+    b = HitlBinding(checkpointed=True, run_id="r-1")
+    try:
+        b.checkpointed = False  # type: ignore[misc]
+    except Exception:
+        return
+    assert False, "HitlBinding should be frozen"

--- a/tests/agent/test_hitl_binding_enforcement.py
+++ b/tests/agent/test_hitl_binding_enforcement.py
@@ -1,0 +1,82 @@
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.agent.types import AgentTool
+from cubepi.hitl.binding import HitlBinding
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+from pydantic import BaseModel
+
+
+def _ok_faux() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses(
+        [AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")]
+    )
+    return p
+
+
+class _NoArgs(BaseModel):
+    pass
+
+
+async def _noop(tool_call_id, args, *, signal=None, on_update=None):
+    raise NotImplementedError
+
+
+def _tool_with_hitl(binding):
+    return AgentTool(
+        name="ask_user",
+        description="d",
+        parameters=_NoArgs,
+        execute=_noop,
+        hitl=binding,
+    )
+
+
+def _agent(tools=None, middleware=None):
+    return Agent(
+        model=_ok_faux().model("faux-model"),
+        tools=tools or [],
+        middleware=middleware or [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_checkpointed_hitl_with_none_run_id_raises():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=True, run_id=None))
+    a = _agent(tools=[tool])
+    with pytest.raises(ValueError, match="no run_id bound"):
+        await a.prompt("hi", run_id="R1")
+
+
+@pytest.mark.asyncio
+async def test_checkpointed_hitl_requires_explicit_run_id():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=True, run_id="R1"))
+    a = _agent(tools=[tool])
+    with pytest.raises(ValueError, match="generate-mode rejected"):
+        await a.prompt("hi", run_id=None)
+
+
+@pytest.mark.asyncio
+async def test_checkpointed_hitl_run_id_mismatch_raises():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=True, run_id="R1"))
+    a = _agent(tools=[tool])
+    with pytest.raises(ValueError, match="does not match"):
+        await a.prompt("hi", run_id="R2")
+
+
+@pytest.mark.asyncio
+async def test_checkpointed_hitl_run_id_match_succeeds():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=True, run_id="R1"))
+    a = _agent(tools=[tool])
+    got = await a.prompt("hi", run_id="R1")
+    assert got == "R1"
+
+
+@pytest.mark.asyncio
+async def test_in_memory_hitl_no_constraint():
+    tool = _tool_with_hitl(HitlBinding(checkpointed=False, run_id=None))
+    a = _agent(tools=[tool])
+    got = await a.prompt("hi")  # generate-mode allowed
+    assert isinstance(got, str)

--- a/tests/agent/test_respond_resume_run_id.py
+++ b/tests/agent/test_respond_resume_run_id.py
@@ -175,6 +175,73 @@ async def test_respond_resume_with_legacy_pending_does_not_crash() -> None:
 
 
 @pytest.mark.asyncio
+async def test_respond_leaves_active_run_id_set_on_resume_raise() -> None:
+    """Spec §3.7 parity: if the HITL resume body raises, respond() must
+    NOT clear active_run_id. Callers can observe which run failed."""
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+
+    def _model():
+        return p.model("faux-model")
+
+    await _drive_pause(cp, _model)
+
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=_model(),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+
+    class _Boom(Exception):
+        pass
+
+    async def _explode():
+        raise _Boom("simulated resume failure")
+
+    # Patch the resume body to raise.
+    a2._run_hitl_resume = _explode  # type: ignore[method-assign]
+
+    loaded = await cp.load_pending("t")
+    assert loaded is not None
+    qid = loaded[0].question_id
+
+    with pytest.raises(_Boom):
+        await a2.respond(question_id=qid, answer="yes")
+    # active_run_id stays SET on raise (no else: clear ran).
+    assert a2.state.active_run_id == "R1"
+
+
+@pytest.mark.asyncio
+async def test_respond_defaults_question_id_to_pending() -> None:
+    """respond() without an explicit question_id picks it up from the
+    persisted pending row."""
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+
+    def _model():
+        return p.model("faux-model")
+
+    await _drive_pause(cp, _model)
+
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=_model(),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+    # Don't pass question_id — respond() must default to pending's id.
+    await a2.respond(answer="yes")
+    assert cp._runs["t"]["R1"].completed_at is not None
+
+
+@pytest.mark.asyncio
 async def test_respond_rejects_mismatched_channel_run_id() -> None:
     """Regression for codex R2 P2: respond() must reject a CheckpointedChannel
     whose run_id disagrees with the recovered pending row's run_id.

--- a/tests/agent/test_respond_resume_run_id.py
+++ b/tests/agent/test_respond_resume_run_id.py
@@ -172,3 +172,40 @@ async def test_respond_resume_with_legacy_pending_does_not_crash() -> None:
 
     # Legacy guard skipped dispatch — marker remains unwritten.
     assert cp._runs["t"]["R1"].completed_at is None
+
+
+@pytest.mark.asyncio
+async def test_respond_rejects_mismatched_channel_run_id() -> None:
+    """Regression for codex R2 P2: respond() must reject a CheckpointedChannel
+    whose run_id disagrees with the recovered pending row's run_id.
+
+    Otherwise a second HITL pause during resume would persist a new pending
+    row under the channel's (wrong) run_id, then the next resume would
+    stamp messages or try to complete an unclaimed run.
+    """
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+
+    def _model():
+        return p.model("faux-model")
+
+    await _drive_pause(cp, _model)
+
+    loaded = await cp.load_pending("t")
+    assert loaded is not None
+    pending_req, recovered_run_id = loaded
+    assert recovered_run_id == "R1"
+
+    # Host accidentally builds the channel with a DIFFERENT run_id.
+    ch_wrong = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R_WRONG")
+    tool_wrong = ask_user_tool(ch_wrong)
+    a_wrong = Agent(
+        model=_model(),
+        tools=[tool_wrong],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch_wrong,
+    )
+    qid = pending_req.question_id
+    with pytest.raises(ValueError, match="does not match"):
+        await a_wrong.respond(question_id=qid, answer="yes")

--- a/tests/agent/test_respond_resume_run_id.py
+++ b/tests/agent/test_respond_resume_run_id.py
@@ -1,0 +1,174 @@
+"""Task 28: respond() resumes run_id via load_pending; never reclaims.
+
+The new respond() body uses the unified ``load_pending`` Protocol method,
+which returns ``(HitlRequest, run_id | None)``. On clean resume it
+propagates the recovered run_id into AgentState.active_run_id, then runs
+the resume loop. After the loop returns successfully it dispatches the
+outcome (mark_run_complete on "complete") and clears active_run_id.
+
+A legacy guard skips dispatch when the recovered run_id is None (pending
+saved by an older save_pending_request call that didn't carry a run_id).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.ask_user import ask_user_tool
+from cubepi.hitl.channel import CheckpointedChannel
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+)
+from cubepi.providers.faux import FauxProvider
+
+
+def _pause_then_finish_provider() -> FauxProvider:
+    """Two-turn script: ask_user (pause) → final assistant on resume."""
+    p = FauxProvider()
+    p.set_responses(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="ask-1",
+                        name="ask_user",
+                        arguments={"questions": [{"key": "ans", "prompt": "?"}]},
+                    )
+                ],
+                stop_reason="tool_use",
+            ),
+            AssistantMessage(
+                content=[TextContent(text="done")],
+                stop_reason="end_turn",
+            ),
+        ]
+    )
+    return p
+
+
+async def _drive_pause(
+    cp: MemoryCheckpointer,
+    model_factory,
+) -> None:
+    """Build an Agent, kick a prompt(), wait until pending is persisted."""
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    a = Agent(
+        model=model_factory(),
+        tools=[tool],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch,
+    )
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    # Wait for pending to be persisted.
+    for _ in range(500):
+        if await cp.load_pending("t") is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:  # pragma: no cover — defensive
+        task.cancel()
+        raise AssertionError("pending never appeared")
+    await a.detach()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_respond_clears_active_run_id_on_clean_resume() -> None:
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+
+    def _model():
+        return p.model("faux-model")
+
+    await _drive_pause(cp, _model)
+
+    # Fresh Agent — emulates a new host process picking up the run.
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=_model(),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+    loaded = await cp.load_pending("t")
+    assert loaded is not None
+    qid = loaded[0].question_id
+    await a2.respond(question_id=qid, answer="yes")
+
+    assert a2.state.active_run_id is None
+
+
+@pytest.mark.asyncio
+async def test_respond_resume_writes_marker() -> None:
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+
+    def _model():
+        return p.model("faux-model")
+
+    await _drive_pause(cp, _model)
+
+    # Marker not yet written — prompt() suspended, not completed.
+    assert cp._runs["t"]["R1"].completed_at is None
+
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=_model(),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+    loaded = await cp.load_pending("t")
+    assert loaded is not None
+    qid = loaded[0].question_id
+    await a2.respond(question_id=qid, answer="yes")
+
+    # Clean resume → outcome "complete" → mark_run_complete fired.
+    assert cp._runs["t"]["R1"].completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_respond_resume_with_legacy_pending_does_not_crash() -> None:
+    """Legacy guard: pending persisted without a run_id (run_id=None)
+    must NOT crash respond() and must NOT trigger dispatch."""
+    cp = MemoryCheckpointer()
+    p = _pause_then_finish_provider()
+
+    def _model():
+        return p.model("faux-model")
+
+    await _drive_pause(cp, _model)
+
+    # Forge legacy: re-save the pending request with run_id=None so the
+    # checkpointer "forgets" the run_id binding.
+    loaded = await cp.load_pending("t")
+    assert loaded is not None
+    pending_req, _ = loaded
+    await cp.save_pending_request("t", pending_req, run_id=None)
+
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=_model(),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+    qid = pending_req.question_id
+    # Must not raise.
+    await a2.respond(question_id=qid, answer="yes")
+
+    # Legacy guard skipped dispatch — marker remains unwritten.
+    assert cp._runs["t"]["R1"].completed_at is None

--- a/tests/agent/test_tool_cycle_invariant.py
+++ b/tests/agent/test_tool_cycle_invariant.py
@@ -1,0 +1,237 @@
+import asyncio
+
+import pytest
+
+from cubepi.agent._tool_cycle import (
+    ToolCycleViolation,
+    check_tool_cycle,
+)
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.ask_user import ask_user_tool
+from cubepi.hitl.channel import CheckpointedChannel
+from cubepi.middleware.base import TurnAction
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolCall,
+    ToolResultMessage,
+    UserMessage,
+)
+from cubepi.providers.faux import FauxProvider
+
+
+def _asst(call_ids, run_id="R"):
+    return AssistantMessage(
+        content=[ToolCall(id=cid, name="t", arguments={}) for cid in call_ids],
+        run_id=run_id,
+    )
+
+
+def _res(call_id, run_id="R"):
+    return ToolResultMessage(
+        tool_call_id=call_id,
+        tool_name="t",
+        content=[TextContent(text="r")],
+        run_id=run_id,
+    )
+
+
+def test_no_tool_calls_ok():
+    check_tool_cycle(
+        [
+            UserMessage(content=[TextContent(text="hi")], run_id="R"),
+            AssistantMessage(content=[TextContent(text="hi back")], run_id="R"),
+        ]
+    )
+
+
+def test_complete_cycle_ok():
+    check_tool_cycle(
+        [
+            _asst(["c1", "c2"]),
+            _res("c1"),
+            _res("c2"),
+            AssistantMessage(content=[TextContent(text="done")], run_id="R"),
+        ]
+    )
+
+
+def test_no_results_at_all_violation():
+    try:
+        check_tool_cycle([_asst(["c1"])])
+    except ToolCycleViolation:
+        return
+    assert False, "expected ToolCycleViolation"
+
+
+def test_intervening_user_message_violation():
+    try:
+        check_tool_cycle(
+            [
+                _asst(["c1"]),
+                UserMessage(content=[TextContent(text="hi")], run_id="R"),
+                _res("c1"),
+            ]
+        )
+    except ToolCycleViolation:
+        return
+    assert False
+
+
+def test_partial_cover_violation():
+    try:
+        check_tool_cycle([_asst(["c1", "c2"]), _res("c1")])
+    except ToolCycleViolation:
+        return
+    assert False
+
+
+def test_duplicate_ids_across_turns_violation():
+    try:
+        check_tool_cycle(
+            [
+                _asst(["c1"]),
+                _asst(["c1"]),  # second assistant reuses id
+                _res("c1"),
+            ]
+        )
+    except ToolCycleViolation:
+        return
+    assert False
+
+
+def test_multiset_mismatch_within_window_violation():
+    """Assistant emits {c1, c2}; window has [c1, c1] — set-equality
+    would have failed, but the bug is multiset-specific: window length
+    matches K=2, and only the multiset check catches that c2 is missing
+    while c1 is duplicated. (A trailing extra tool_result AFTER the
+    K-window is a separate concern handled by the NEXT assistant turn's
+    adjacency check; it's not what this test covers.)"""
+    try:
+        check_tool_cycle(
+            [
+                _asst(["c1", "c2"]),
+                _res("c1"),
+                _res("c1"),  # duplicate of c1; c2 missing
+            ]
+        )
+    except ToolCycleViolation:
+        return
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_incomplete_tool_cycle_does_not_mark():
+    """after_model_response(decision='stop') on a tool-use response
+    leaves an unresolved tool_call. _dispatch_outcome filters
+    state.messages by run_id and demotes 'complete' to 'incomplete'
+    via check_tool_cycle. Marker not written."""
+    p = FauxProvider()
+    p.set_responses(
+        [
+            AssistantMessage(
+                content=[ToolCall(id="c1", name="t", arguments={})],
+                stop_reason="tool_use",
+            ),
+        ]
+    )
+
+    async def _stop_after(response, ctx, *, signal=None):
+        return TurnAction(decision="stop")
+
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=p.model("faux-model"),
+        checkpointer=cp,
+        thread_id="t",
+        after_model_response=_stop_after,
+    )
+    await a.prompt("hi", run_id="R1")
+    assert cp._runs["t"]["R1"].completed_at is None
+
+
+@pytest.mark.xfail(
+    reason="needs Task 28 load_pending recovery for run_id propagation",
+    strict=False,
+)
+@pytest.mark.asyncio
+async def test_tool_cycle_invariant_spans_hitl_resume():
+    """Pause mid-tool-use (ask_user). Resume; provider then emits an
+    assistant carrying an UNRELATED unresolved tool_call (no matching
+    ToolResultMessage will follow). The invariant filters
+    state.messages by m.run_id == 'R1' — sees the unresolved c1 →
+    outcome demoted from 'complete' to 'incomplete' → marker NOT
+    written."""
+    cp = MemoryCheckpointer()
+    p = FauxProvider()
+    p.set_responses(
+        [
+            # Turn 1: ask_user → pause.
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="ask-1",
+                        name="ask_user",
+                        arguments={"questions": [{"key": "ans", "prompt": "?"}]},
+                    )
+                ],
+                stop_reason="tool_use",
+            ),
+            # Turn 2 (resume): assistant with an unresolved tool_call
+            # that NO ToolResultMessage will satisfy. The agent loop's
+            # after_model_response forces a stop on this turn so the
+            # call never gets executed.
+            AssistantMessage(
+                content=[
+                    ToolCall(id="orphan-1", name="lookup", arguments={}),
+                ],
+                stop_reason="tool_use",
+            ),
+        ]
+    )
+
+    async def _stop_after(response, ctx, *, signal=None):
+        # Stop after the second assistant turn so the orphan tool_call
+        # is NEVER executed.
+        if any(getattr(c, "id", None) == "orphan-1" for c in response.content):
+            return TurnAction(decision="stop")
+        return None
+
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    a = Agent(
+        model=p.model("faux-model"),
+        tools=[tool],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch,
+        after_model_response=_stop_after,
+    )
+    task = asyncio.create_task(a.prompt("hi", run_id="R1"))
+    while (await cp.load_pending("t")) is None:
+        await asyncio.sleep(0.01)
+    # prompt() blocks until detach / abort / answer. Detach to
+    # surface HitlDetached → loop returns with last_outcome="suspended".
+    await a.detach()
+    await task
+
+    # Resume with a fresh Agent. The second turn emits orphan-1;
+    # the after_model_response hook stops the loop. Pre-completion
+    # invariant scans state.messages filtered by run_id=='R1' and
+    # finds the unresolved orphan-1 → outcome 'incomplete' → no mark.
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=p.model("faux-model"),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+        after_model_response=_stop_after,
+    )
+    pending = await cp.load_pending("t")
+    qid = pending[0].question_id
+    await a2.respond(question_id=qid, answer="yes")
+
+    assert cp._runs["t"]["R1"].completed_at is None

--- a/tests/agent/test_tool_cycle_invariant.py
+++ b/tests/agent/test_tool_cycle_invariant.py
@@ -151,10 +151,6 @@ async def test_incomplete_tool_cycle_does_not_mark():
     assert cp._runs["t"]["R1"].completed_at is None
 
 
-@pytest.mark.xfail(
-    reason="needs Task 28 load_pending recovery for run_id propagation",
-    strict=False,
-)
 @pytest.mark.asyncio
 async def test_tool_cycle_invariant_spans_hitl_resume():
     """Pause mid-tool-use (ask_user). Resume; provider then emits an

--- a/tests/checkpointer/conftest.py
+++ b/tests/checkpointer/conftest.py
@@ -129,3 +129,12 @@ async def clean_mysql_db(mysql_dsn: str, _mysql_available: bool):
             await cur.execute(f"DROP DATABASE IF EXISTS `{db_name}`")
     finally:
         await admin.ensure_closed()
+
+
+@pytest_asyncio.fixture
+async def mysql_v4_dsn(clean_mysql_db: str):
+    """Fresh MySQL DB with the v4 cubepi schema fully built."""
+    from tests.checkpointer.test_mysql import _setup_schema as _setup_mysql_schema
+
+    await _setup_mysql_schema(clean_mysql_db)
+    yield clean_mysql_db

--- a/tests/checkpointer/conftest.py
+++ b/tests/checkpointer/conftest.py
@@ -61,6 +61,15 @@ async def clean_db(pg_dsn: str, _pg_available: bool):
         await admin.close()
 
 
+@pytest_asyncio.fixture
+async def pg_v4_dsn(clean_db: str):
+    """Fresh Postgres DB with the v4 cubepi schema fully built."""
+    from tests.checkpointer.test_postgres import _setup_schema as _setup_pg_schema
+
+    await _setup_pg_schema(clean_db)
+    yield clean_db
+
+
 # ---------------------------------------------------------------------------
 # MySQL fixtures
 # ---------------------------------------------------------------------------

--- a/tests/checkpointer/test_base.py
+++ b/tests/checkpointer/test_base.py
@@ -1,0 +1,19 @@
+from cubepi.checkpointer.base import CheckpointData
+
+
+def test_checkpoint_data_default_parent_is_none():
+    cd = CheckpointData()
+    assert cd.parent_thread_id is None
+    assert cd.messages == []
+    assert cd.extra == {}
+
+
+def test_checkpoint_data_with_parent():
+    cd = CheckpointData(parent_thread_id="src_thread")
+    assert cd.parent_thread_id == "src_thread"
+
+
+def test_checkpoint_data_keyword_construction_unchanged():
+    cd = CheckpointData(messages=[], extra={"k": "v"})
+    assert cd.extra == {"k": "v"}
+    assert cd.parent_thread_id is None

--- a/tests/checkpointer/test_exceptions.py
+++ b/tests/checkpointer/test_exceptions.py
@@ -38,9 +38,7 @@ def test_checkpointer_error_separate_from_schema_error():
 
 def test_completion_marker_failed_error_carries_run_id():
     cause = RuntimeError("db timeout")
-    exc = CompletionMarkerFailedError(
-        thread_id="t1", run_id="r1", cause=cause
-    )
+    exc = CompletionMarkerFailedError(thread_id="t1", run_id="r1", cause=cause)
     assert exc.thread_id == "t1"
     assert exc.run_id == "r1"
     assert exc.__cause__ is cause

--- a/tests/checkpointer/test_exceptions.py
+++ b/tests/checkpointer/test_exceptions.py
@@ -1,0 +1,54 @@
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    CheckpointerError,
+    CheckpointerLockTimeoutError,
+    CompletionMarkerFailedError,
+    CubepiSchemaError,
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [
+        ThreadNotFoundError,
+        ThreadAlreadyExistsError,
+        RunNotCompletedError,
+        RunNotClaimedError,
+        RunAlreadyClaimedError,
+        RunAlreadyCompletedError,
+        CheckpointerLockTimeoutError,
+    ],
+)
+def test_runtime_errors_inherit_checkpointer_error(exc_cls):
+    assert issubclass(exc_cls, CheckpointerError)
+    assert issubclass(exc_cls, Exception)
+
+
+def test_checkpointer_error_separate_from_schema_error():
+    assert not issubclass(CheckpointerError, CubepiSchemaError)
+    assert not issubclass(CubepiSchemaError, CheckpointerError)
+
+
+def test_completion_marker_failed_error_carries_run_id():
+    cause = RuntimeError("db timeout")
+    exc = CompletionMarkerFailedError(
+        thread_id="t1", run_id="r1", cause=cause
+    )
+    assert exc.thread_id == "t1"
+    assert exc.run_id == "r1"
+    assert exc.__cause__ is cause
+    assert "t1" in str(exc) and "r1" in str(exc)
+
+
+def test_runtime_errors_constructable_with_kwargs():
+    e = ThreadNotFoundError("missing thread t1")
+    assert "t1" in str(e)
+    e = RunNotCompletedError("thread=t1 run=r1")
+    assert "r1" in str(e)

--- a/tests/checkpointer/test_memory_fork.py
+++ b/tests/checkpointer/test_memory_fork.py
@@ -1,0 +1,97 @@
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+def _msg(run_id: str | None, text: str) -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)], run_id=run_id)
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_completed_runs_only():
+    cp = MemoryCheckpointer()
+    # Two completed runs A and B.
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1"), _msg("A", "a2")])
+    await cp.mark_run_complete("src", "A")
+    await cp.claim_run("src", "B")
+    await cp.append("src", [_msg("B", "b1")])
+    await cp.mark_run_complete("src", "B")
+    # An in-flight run C — must be excluded.
+    await cp.claim_run("src", "C")
+    await cp.append("src", [_msg("C", "c1")])
+    await cp.fork("src", "dst", after_run_id="B")
+    loaded = await cp.load("dst")
+    assert loaded is not None
+    texts = [m.content[0].text for m in loaded.messages]
+    assert texts == ["a1", "a2", "b1"]
+    assert loaded.parent_thread_id == "src"
+
+
+@pytest.mark.asyncio
+async def test_fork_includes_legacy_null_run_id_prefix():
+    cp = MemoryCheckpointer()
+    # Legacy NULL-run_id message.
+    await cp.append("src", [_msg(None, "legacy")])
+    # One completed run.
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    await cp.fork("src", "dst", after_run_id="A")
+    loaded = await cp.load("dst")
+    assert [m.content[0].text for m in loaded.messages] == ["legacy", "a1"]
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_src_raises_thread_not_found():
+    cp = MemoryCheckpointer()
+    with pytest.raises(ThreadNotFoundError):
+        await cp.fork("missing", "dst", after_run_id="X")
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_run_id_raises_not_completed():
+    cp = MemoryCheckpointer()
+    await cp.append("src", [_msg(None, "x")])
+    with pytest.raises(RunNotCompletedError):
+        await cp.fork("src", "dst", after_run_id="missing")
+
+
+@pytest.mark.asyncio
+async def test_fork_destination_collision_raises_already_exists():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    await cp.fork("src", "dst", after_run_id="A")
+    with pytest.raises(ThreadAlreadyExistsError):
+        await cp.fork("src", "dst", after_run_id="A")
+
+
+@pytest.mark.asyncio
+async def test_fork_carries_extra_and_writes_metadata():
+    cp = MemoryCheckpointer()
+    await cp.save_extra("src", {"original": "x"})
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    await cp.fork("src", "dst", after_run_id="A", metadata={"source": "test"})
+    loaded = await cp.load("dst")
+    assert loaded.extra["original"] == "x"
+    assert loaded.extra["fork"] == {"source": "test"}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_matches_fork_messages():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    msgs = await cp.snapshot("src", after_run_id="A")
+    assert [m.content[0].text for m in msgs] == ["a1"]

--- a/tests/checkpointer/test_memory_fork.py
+++ b/tests/checkpointer/test_memory_fork.py
@@ -95,3 +95,44 @@ async def test_snapshot_matches_fork_messages():
     await cp.mark_run_complete("src", "A")
     msgs = await cp.snapshot("src", after_run_id="A")
     assert [m.content[0].text for m in msgs] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_unknown_thread_raises_thread_not_found():
+    cp = MemoryCheckpointer()
+    with pytest.raises(ThreadNotFoundError):
+        await cp.snapshot("missing", after_run_id="A")
+
+
+@pytest.mark.asyncio
+async def test_snapshot_uncompleted_run_raises_not_completed():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    # NOT calling mark_run_complete — run is claimed but uncompleted.
+    with pytest.raises(RunNotCompletedError):
+        await cp.snapshot("src", after_run_id="A")
+
+
+@pytest.mark.asyncio
+async def test_snapshot_includes_legacy_null_run_id_and_skips_uncompleted():
+    """Snapshot must:
+    - copy messages with run_id=None as legacy (pre-v4) history
+    - skip messages whose run_id belongs to an uncompleted later run
+    """
+    cp = MemoryCheckpointer()
+    # Pre-v4 legacy message (no run_id).
+    await cp.append("src", [_msg(None, "legacy")])
+    # Completed run A.
+    await cp.claim_run("src", "A")
+    await cp.append("src", [_msg("A", "a1")])
+    await cp.mark_run_complete("src", "A")
+    # Later uncompleted run B (claimed but not completed).
+    await cp.claim_run("src", "B")
+    await cp.append("src", [_msg("B", "b1-in-flight")])
+    # Snapshot after A should include legacy + A but NOT B.
+    msgs = await cp.snapshot("src", after_run_id="A")
+    texts = [m.content[0].text for m in msgs]
+    assert "legacy" in texts
+    assert "a1" in texts
+    assert "b1-in-flight" not in texts

--- a/tests/checkpointer/test_memory_runs.py
+++ b/tests/checkpointer/test_memory_runs.py
@@ -6,6 +6,7 @@ from cubepi.checkpointer.exceptions import (
     RunNotClaimedError,
 )
 from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
 
 
 @pytest.mark.asyncio
@@ -51,3 +52,48 @@ async def test_completion_seq_monotonic_per_thread():
     seqs = [cp._runs["t"][rid].completion_seq for rid in ("A", "B", "C")]
     assert seqs == sorted(seqs)
     assert len(set(seqs)) == 3
+
+
+@pytest.mark.asyncio
+async def test_append_on_completed_run_id_rejected():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    await cp.mark_run_complete("t", "r1")
+    msg = UserMessage(content=[TextContent(text="late")], run_id="r1")
+    with pytest.raises(RunAlreadyCompletedError):
+        await cp.append("t", [msg])
+
+
+@pytest.mark.asyncio
+async def test_append_in_flight_run_id_ok():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    msg = UserMessage(content=[TextContent(text="ok")], run_id="r1")
+    await cp.append("t", [msg])
+    data = await cp.load("t")
+    assert data is not None and len(data.messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_tuple_with_run_id():
+    from cubepi.hitl.types import ConfirmRequest, HitlRequest
+
+    cp = MemoryCheckpointer()
+    req = HitlRequest(
+        question_id="q1",
+        thread_id="t",
+        payload=ConfirmRequest(prompt="hi"),
+        created_at=0.0,
+    )
+    await cp.save_pending_request("t", req, run_id="r-1")
+    res = await cp.load_pending("t")
+    assert res is not None
+    got_req, got_run_id = res
+    assert got_req.question_id == "q1"
+    assert got_run_id == "r-1"
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_none_when_empty():
+    cp = MemoryCheckpointer()
+    assert await cp.load_pending("t") is None

--- a/tests/checkpointer/test_memory_runs.py
+++ b/tests/checkpointer/test_memory_runs.py
@@ -1,0 +1,53 @@
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+)
+from cubepi.checkpointer.memory import MemoryCheckpointer
+
+
+@pytest.mark.asyncio
+async def test_claim_then_complete_roundtrip():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    await cp.mark_run_complete("t", "r1")
+    # Idempotent: second mark is a no-op.
+    await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_in_flight_raises_claimed():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    with pytest.raises(RunAlreadyClaimedError):
+        await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_completed_raises_completed():
+    cp = MemoryCheckpointer()
+    await cp.claim_run("t", "r1")
+    await cp.mark_run_complete("t", "r1")
+    with pytest.raises(RunAlreadyCompletedError):
+        await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_mark_without_claim_raises_not_claimed():
+    cp = MemoryCheckpointer()
+    with pytest.raises(RunNotClaimedError):
+        await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_completion_seq_monotonic_per_thread():
+    cp = MemoryCheckpointer()
+    for rid in ("A", "B", "C"):
+        await cp.claim_run("t", rid)
+        await cp.mark_run_complete("t", rid)
+    # Internal inspection: completion_seq for A < B < C strictly.
+    seqs = [cp._runs["t"][rid].completion_seq for rid in ("A", "B", "C")]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == 3

--- a/tests/checkpointer/test_mysql.py
+++ b/tests/checkpointer/test_mysql.py
@@ -36,7 +36,7 @@ def test_models_import() -> None:
         cubepi_metadata,
     )
 
-    assert EXPECTED_SCHEMA_VERSION == 3
+    assert EXPECTED_SCHEMA_VERSION == 4
     assert PARTITION_COUNT == 64
     assert CubepiThread.__tablename__ == "cubepi_threads"
     assert CubepiMessage.__tablename__ == "cubepi_messages"

--- a/tests/checkpointer/test_mysql.py
+++ b/tests/checkpointer/test_mysql.py
@@ -66,10 +66,16 @@ def test_messages_has_no_foreign_keys() -> None:
 
 
 def test_messages_has_no_metadata_index() -> None:
+    """Only the v4 (thread_id, run_id) composite index is allowed.
+
+    The MySQL backend never indexes the JSON ``metadata`` column (Postgres
+    has a GIN index there; MySQL has no equivalent for the host-app cost).
+    """
     from cubepi.checkpointer.mysql.models import cubepi_metadata
 
     msgs = cubepi_metadata.tables["cubepi_messages"]
-    assert msgs.indexes == set()
+    idx_names = {idx.name for idx in msgs.indexes}
+    assert idx_names == {"ix_cubepi_messages_thread_run"}
 
 
 def test_messages_partition_clause() -> None:
@@ -225,6 +231,7 @@ async def _setup_schema(dsn: str) -> None:
             from cubepi.checkpointer.mysql.alembic_helpers import (
                 add_pending_request_column_op,
                 add_run_id_column_op,
+                upgrade_v3_to_v4_op,
             )
 
             await cur.execute(add_pending_request_column_op())
@@ -247,6 +254,10 @@ async def _setup_schema(dsn: str) -> None:
                     version INT PRIMARY KEY
                 ) ENGINE=InnoDB
             """)
+            # v3 → v4: run_id on cubepi_messages + cubepi_runs partitioned table.
+            for stmt in upgrade_v3_to_v4_op().split(";"):
+                if stmt.strip():
+                    await cur.execute(stmt)
             for stmt in write_schema_version_op().split(";"):
                 if stmt.strip():
                     await cur.execute(stmt)
@@ -378,7 +389,7 @@ async def test_version_mismatch_raises(clean_mysql_db) -> None:
     with pytest.raises(CubepiSchemaMismatch) as exc_info:
         async with MySQLCheckpointer(clean_mysql_db):
             pass
-    assert exc_info.value.expected == 3
+    assert exc_info.value.expected == 4
     assert exc_info.value.actual == 999
 
 

--- a/tests/checkpointer/test_mysql_fork.py
+++ b/tests/checkpointer/test_mysql_fork.py
@@ -1,0 +1,131 @@
+"""MySQLCheckpointer snapshot/fork tests — mirrors test_postgres_fork.py."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
+from cubepi.checkpointer.mysql import MySQLCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+def _msg(run_id: str | None, text: str) -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)], run_id=run_id)
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_completed_runs_only(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1"), _msg("A", "a2")])
+        await cp.mark_run_complete("src", "A")
+        await cp.claim_run("src", "B")
+        await cp.append("src", [_msg("B", "b1")])
+        await cp.mark_run_complete("src", "B")
+        # An in-flight run C — must be excluded.
+        await cp.claim_run("src", "C")
+        await cp.append("src", [_msg("C", "c1")])
+        await cp.fork("src", "dst", after_run_id="B")
+        loaded = await cp.load("dst")
+        assert loaded is not None
+        texts = [m.content[0].text for m in loaded.messages]
+        assert texts == ["a1", "a2", "b1"]
+        assert loaded.parent_thread_id == "src"
+
+
+@pytest.mark.asyncio
+async def test_fork_includes_legacy_null_run_id_prefix(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.append("src", [_msg(None, "legacy")])
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        await cp.fork("src", "dst", after_run_id="A")
+        loaded = await cp.load("dst")
+        assert loaded is not None
+        assert [m.content[0].text for m in loaded.messages] == ["legacy", "a1"]
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_src_raises_thread_not_found(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        with pytest.raises(ThreadNotFoundError):
+            await cp.fork("missing", "dst", after_run_id="X")
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_run_id_raises_not_completed(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.append("src", [_msg(None, "x")])
+        with pytest.raises(RunNotCompletedError):
+            await cp.fork("src", "dst", after_run_id="missing")
+
+
+@pytest.mark.asyncio
+async def test_fork_destination_collision_raises_already_exists(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        await cp.fork("src", "dst", after_run_id="A")
+        with pytest.raises(ThreadAlreadyExistsError):
+            await cp.fork("src", "dst", after_run_id="A")
+
+
+@pytest.mark.asyncio
+async def test_fork_carries_extra_and_writes_metadata(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.save_extra("src", {"original": "x"})
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        await cp.fork("src", "dst", after_run_id="A", metadata={"source": "test"})
+        loaded = await cp.load("dst")
+        assert loaded is not None
+        assert loaded.extra["original"] == "x"
+        assert loaded.extra["fork"] == {"source": "test"}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_matches_fork_messages(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        msgs = await cp.snapshot("src", after_run_id="A")
+        assert [m.content[0].text for m in msgs] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_fork_serialized_with_concurrent_append(mysql_v4_dsn) -> None:
+    """The fork's per-thread SELECT FOR UPDATE must serialize with append.
+
+    Without it, an append racing the fork could leak a partial in-flight
+    run into the destination's messages. We assert the destination ONLY
+    contains the completed prefix regardless of who runs first.
+    """
+    async with MySQLCheckpointer(mysql_v4_dsn, min_pool_size=2, max_pool_size=4) as cp:
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        # Start an in-flight run B that an append targets.
+        await cp.claim_run("src", "B")
+
+        async def do_fork() -> None:
+            await cp.fork("src", "dst", after_run_id="A")
+
+        async def do_append() -> None:
+            await cp.append("src", [_msg("B", "b1")])
+
+        await asyncio.gather(do_fork(), do_append())
+        loaded = await cp.load("dst")
+        assert loaded is not None
+        # Destination must NOT contain b1 — only the completed prefix.
+        texts = [m.content[0].text for m in loaded.messages]
+        assert texts == ["a1"]

--- a/tests/checkpointer/test_mysql_runs.py
+++ b/tests/checkpointer/test_mysql_runs.py
@@ -1,0 +1,165 @@
+"""MySQLCheckpointer run-lifecycle tests — mirrors test_postgres_runs.py."""
+
+import aiomysql
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+)
+from cubepi.checkpointer.mysql import MySQLCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+async def _connect(dsn: str):
+    from cubepi.checkpointer.mysql.checkpointer import _parse_dsn
+
+    return await aiomysql.connect(autocommit=True, **_parse_dsn(dsn))
+
+
+@pytest.mark.asyncio
+async def test_claim_run_creates_threads_row_lazily(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("t-lazy", "r1")
+    conn = await _connect(mysql_v4_dsn)
+    try:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT thread_id FROM cubepi_threads WHERE thread_id = %s",
+                ("t-lazy",),
+            )
+            row = await cur.fetchone()
+            assert row is not None
+            await cur.execute(
+                "SELECT completed_at FROM cubepi_runs "
+                "WHERE thread_id = %s AND run_id = %s",
+                ("t-lazy", "r1"),
+            )
+            run = await cur.fetchone()
+            assert run is not None
+            assert run[0] is None
+    finally:
+        await conn.ensure_closed()
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_in_flight_raises_claimed(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        with pytest.raises(RunAlreadyClaimedError):
+            await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_append_on_completed_run_id_rejected(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        await cp.mark_run_complete("t", "r1")
+        msg = UserMessage(content=[TextContent(text="late")], run_id="r1")
+        with pytest.raises(RunAlreadyCompletedError):
+            await cp.append("t", [msg])
+
+
+@pytest.mark.asyncio
+async def test_claim_then_complete_roundtrip(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        await cp.mark_run_complete("t", "r1")
+        # Idempotent: second mark is a no-op.
+        await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_completed_raises_completed(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        await cp.mark_run_complete("t", "r1")
+        with pytest.raises(RunAlreadyCompletedError):
+            await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_mark_without_claim_raises_not_claimed(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        with pytest.raises(RunNotClaimedError):
+            await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_completion_seq_monotonic_per_thread(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        for rid in ("A", "B", "C"):
+            await cp.claim_run("t", rid)
+            await cp.mark_run_complete("t", rid)
+    conn = await _connect(mysql_v4_dsn)
+    try:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT run_id, completion_seq FROM cubepi_runs "
+                "WHERE thread_id = %s ORDER BY completion_seq",
+                ("t",),
+            )
+            rows = await cur.fetchall()
+    finally:
+        await conn.ensure_closed()
+    assert [r[0] for r in rows] == ["A", "B", "C"]
+    seqs = [r[1] for r in rows]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == 3
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_tuple_with_run_id(mysql_v4_dsn) -> None:
+    from cubepi.hitl.types import ConfirmRequest, HitlRequest
+
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        req = HitlRequest(
+            question_id="q1",
+            thread_id="t",
+            payload=ConfirmRequest(prompt="hi"),
+            created_at=0.0,
+        )
+        await cp.save_pending_request("t", req, run_id="r-1")
+        res = await cp.load_pending("t")
+        assert res is not None
+        got_req, got_run_id = res
+        assert got_req.question_id == "q1"
+        assert got_run_id == "r-1"
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_none_when_empty(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        assert await cp.load_pending("t") is None
+
+
+@pytest.mark.asyncio
+async def test_append_persists_run_id_into_column(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        msg = UserMessage(content=[TextContent(text="hi")], run_id="r1")
+        await cp.append("t", [msg])
+    conn = await _connect(mysql_v4_dsn)
+    try:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT run_id FROM cubepi_messages WHERE thread_id = %s",
+                ("t",),
+            )
+            row = await cur.fetchone()
+            assert row is not None
+            assert row[0] == "r1"
+    finally:
+        await conn.ensure_closed()
+
+
+@pytest.mark.asyncio
+async def test_append_in_flight_run_id_ok(mysql_v4_dsn) -> None:
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        msg = UserMessage(content=[TextContent(text="ok")], run_id="r1")
+        await cp.append("t", [msg])
+        data = await cp.load("t")
+        assert data is not None
+        assert len(data.messages) == 1

--- a/tests/checkpointer/test_mysql_schema.py
+++ b/tests/checkpointer/test_mysql_schema.py
@@ -1,0 +1,56 @@
+"""MySQLCheckpointer v4 schema tests — mirrors test_postgres_schema.py."""
+
+import aiomysql
+import pytest
+
+from cubepi.checkpointer.mysql.models import EXPECTED_SCHEMA_VERSION
+
+
+def test_expected_schema_version_is_4() -> None:
+    assert EXPECTED_SCHEMA_VERSION == 4
+
+
+@pytest.mark.asyncio
+async def test_cubepi_runs_table_present(mysql_v4_dsn) -> None:
+    from cubepi.checkpointer.mysql.checkpointer import _parse_dsn
+
+    cfg = _parse_dsn(mysql_v4_dsn)
+    conn = await aiomysql.connect(autocommit=True, **cfg)
+    try:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = %s AND table_name = 'cubepi_runs'",
+                (cfg["db"],),
+            )
+            rows = await cur.fetchall()
+    finally:
+        await conn.ensure_closed()
+    cols = {r[0].lower() for r in rows}
+    assert {
+        "thread_id",
+        "run_id",
+        "claimed_at",
+        "completed_at",
+        "completion_seq",
+    } <= cols
+
+
+@pytest.mark.asyncio
+async def test_cubepi_messages_has_run_id_column(mysql_v4_dsn) -> None:
+    from cubepi.checkpointer.mysql.checkpointer import _parse_dsn
+
+    cfg = _parse_dsn(mysql_v4_dsn)
+    conn = await aiomysql.connect(autocommit=True, **cfg)
+    try:
+        async with conn.cursor() as cur:
+            await cur.execute(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_schema = %s AND table_name = 'cubepi_messages' "
+                "AND column_name = 'run_id'",
+                (cfg["db"],),
+            )
+            row = await cur.fetchone()
+    finally:
+        await conn.ensure_closed()
+    assert row is not None

--- a/tests/checkpointer/test_postgres.py
+++ b/tests/checkpointer/test_postgres.py
@@ -17,7 +17,7 @@ def test_models_import() -> None:
         cubepi_metadata,
     )
 
-    assert EXPECTED_SCHEMA_VERSION == 3
+    assert EXPECTED_SCHEMA_VERSION == 4
     assert PARTITION_COUNT == 64
     # All three model classes are reachable via the public model module
     assert CubepiThread.__tablename__ == "cubepi_threads"
@@ -203,6 +203,7 @@ async def _setup_schema(dsn: str) -> None:
             add_pending_request_column_op,
             add_run_id_column_op,
             create_message_partitions_op,
+            upgrade_v3_to_v4_op,
             write_schema_version_op,
         )
 
@@ -219,6 +220,8 @@ async def _setup_schema(dsn: str) -> None:
                 version INTEGER PRIMARY KEY
             );
         """)
+        # Apply v3→v4 (run_id on messages + cubepi_runs partitioned table).
+        await conn.execute(upgrade_v3_to_v4_op())
         await conn.execute(write_schema_version_op())
     finally:
         await conn.close()
@@ -327,7 +330,7 @@ async def test_version_mismatch_raises(clean_db) -> None:
     with pytest.raises(CubepiSchemaMismatch) as exc_info:
         async with PostgresCheckpointer(clean_db):
             pass
-    assert exc_info.value.expected == 3
+    assert exc_info.value.expected == 4
     assert exc_info.value.actual == 999
 
 

--- a/tests/checkpointer/test_postgres_fork.py
+++ b/tests/checkpointer/test_postgres_fork.py
@@ -1,0 +1,131 @@
+"""PostgresCheckpointer snapshot/fork tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
+from cubepi.checkpointer.postgres import PostgresCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+def _msg(run_id: str | None, text: str) -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)], run_id=run_id)
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_completed_runs_only(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1"), _msg("A", "a2")])
+        await cp.mark_run_complete("src", "A")
+        await cp.claim_run("src", "B")
+        await cp.append("src", [_msg("B", "b1")])
+        await cp.mark_run_complete("src", "B")
+        # An in-flight run C — must be excluded.
+        await cp.claim_run("src", "C")
+        await cp.append("src", [_msg("C", "c1")])
+        await cp.fork("src", "dst", after_run_id="B")
+        loaded = await cp.load("dst")
+        assert loaded is not None
+        texts = [m.content[0].text for m in loaded.messages]
+        assert texts == ["a1", "a2", "b1"]
+        assert loaded.parent_thread_id == "src"
+
+
+@pytest.mark.asyncio
+async def test_fork_includes_legacy_null_run_id_prefix(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.append("src", [_msg(None, "legacy")])
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        await cp.fork("src", "dst", after_run_id="A")
+        loaded = await cp.load("dst")
+        assert loaded is not None
+        assert [m.content[0].text for m in loaded.messages] == ["legacy", "a1"]
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_src_raises_thread_not_found(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        with pytest.raises(ThreadNotFoundError):
+            await cp.fork("missing", "dst", after_run_id="X")
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_run_id_raises_not_completed(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.append("src", [_msg(None, "x")])
+        with pytest.raises(RunNotCompletedError):
+            await cp.fork("src", "dst", after_run_id="missing")
+
+
+@pytest.mark.asyncio
+async def test_fork_destination_collision_raises_already_exists(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        await cp.fork("src", "dst", after_run_id="A")
+        with pytest.raises(ThreadAlreadyExistsError):
+            await cp.fork("src", "dst", after_run_id="A")
+
+
+@pytest.mark.asyncio
+async def test_fork_carries_extra_and_writes_metadata(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.save_extra("src", {"original": "x"})
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        await cp.fork("src", "dst", after_run_id="A", metadata={"source": "test"})
+        loaded = await cp.load("dst")
+        assert loaded is not None
+        assert loaded.extra["original"] == "x"
+        assert loaded.extra["fork"] == {"source": "test"}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_matches_fork_messages(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        msgs = await cp.snapshot("src", after_run_id="A")
+        assert [m.content[0].text for m in msgs] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_fork_serialized_with_concurrent_append(pg_v4_dsn):
+    """The fork's per-thread advisory lock must serialize with append.
+
+    Without it, an append racing the fork could leak a partial in-flight
+    run into the destination's messages. We assert the destination ONLY
+    contains the completed prefix regardless of who runs first.
+    """
+    async with PostgresCheckpointer(pg_v4_dsn, min_pool_size=2, max_pool_size=4) as cp:
+        await cp.claim_run("src", "A")
+        await cp.append("src", [_msg("A", "a1")])
+        await cp.mark_run_complete("src", "A")
+        # Start an in-flight run B that an append targets.
+        await cp.claim_run("src", "B")
+
+        async def do_fork() -> None:
+            await cp.fork("src", "dst", after_run_id="A")
+
+        async def do_append() -> None:
+            await cp.append("src", [_msg("B", "b1")])
+
+        await asyncio.gather(do_fork(), do_append())
+        loaded = await cp.load("dst")
+        assert loaded is not None
+        # Destination must NOT contain b1 — only the completed prefix.
+        texts = [m.content[0].text for m in loaded.messages]
+        assert texts == ["a1"]

--- a/tests/checkpointer/test_postgres_runs.py
+++ b/tests/checkpointer/test_postgres_runs.py
@@ -1,0 +1,92 @@
+"""PostgresCheckpointer run-lifecycle tests."""
+
+import asyncpg
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+)
+from cubepi.checkpointer.postgres import PostgresCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+@pytest.mark.asyncio
+async def test_claim_run_creates_threads_row_lazily(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("t-lazy", "r1")
+    conn = await asyncpg.connect(pg_v4_dsn)
+    try:
+        row = await conn.fetchrow(
+            "SELECT thread_id FROM cubepi_threads WHERE thread_id = $1",
+            "t-lazy",
+        )
+        assert row is not None
+        run = await conn.fetchrow(
+            "SELECT completed_at FROM cubepi_runs "
+            "WHERE thread_id = $1 AND run_id = $2",
+            "t-lazy",
+            "r1",
+        )
+        assert run is not None
+        assert run["completed_at"] is None
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_in_flight_raises_claimed(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        with pytest.raises(RunAlreadyClaimedError):
+            await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_append_on_completed_run_id_rejected(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        # Mark complete via direct UPDATE — mark_run_complete arrives in Task 16.
+        # We exercise the append pre-flight independently here.
+        conn = await asyncpg.connect(pg_v4_dsn)
+        try:
+            await conn.execute(
+                "UPDATE cubepi_runs SET completed_at = now(), completion_seq = 1 "
+                "WHERE thread_id = $1 AND run_id = $2",
+                "t",
+                "r1",
+            )
+        finally:
+            await conn.close()
+        msg = UserMessage(content=[TextContent(text="late")], run_id="r1")
+        with pytest.raises(RunAlreadyCompletedError):
+            await cp.append("t", [msg])
+
+
+@pytest.mark.asyncio
+async def test_append_persists_run_id_into_column(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        msg = UserMessage(content=[TextContent(text="hi")], run_id="r1")
+        await cp.append("t", [msg])
+    conn = await asyncpg.connect(pg_v4_dsn)
+    try:
+        row = await conn.fetchrow(
+            "SELECT run_id FROM cubepi_messages WHERE thread_id = $1",
+            "t",
+        )
+        assert row is not None
+        assert row["run_id"] == "r1"
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_append_in_flight_run_id_ok(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        msg = UserMessage(content=[TextContent(text="ok")], run_id="r1")
+        await cp.append("t", [msg])
+        data = await cp.load("t")
+        assert data is not None
+        assert len(data.messages) == 1

--- a/tests/checkpointer/test_postgres_runs.py
+++ b/tests/checkpointer/test_postgres_runs.py
@@ -24,8 +24,7 @@ async def test_claim_run_creates_threads_row_lazily(pg_v4_dsn):
         )
         assert row is not None
         run = await conn.fetchrow(
-            "SELECT completed_at FROM cubepi_runs "
-            "WHERE thread_id = $1 AND run_id = $2",
+            "SELECT completed_at FROM cubepi_runs WHERE thread_id = $1 AND run_id = $2",
             "t-lazy",
             "r1",
         )

--- a/tests/checkpointer/test_postgres_runs.py
+++ b/tests/checkpointer/test_postgres_runs.py
@@ -6,6 +6,7 @@ import pytest
 from cubepi.checkpointer.exceptions import (
     RunAlreadyClaimedError,
     RunAlreadyCompletedError,
+    RunNotClaimedError,
 )
 from cubepi.checkpointer.postgres import PostgresCheckpointer
 from cubepi.providers.base import TextContent, UserMessage
@@ -46,21 +47,81 @@ async def test_claim_collision_in_flight_raises_claimed(pg_v4_dsn):
 async def test_append_on_completed_run_id_rejected(pg_v4_dsn):
     async with PostgresCheckpointer(pg_v4_dsn) as cp:
         await cp.claim_run("t", "r1")
-        # Mark complete via direct UPDATE — mark_run_complete arrives in Task 16.
-        # We exercise the append pre-flight independently here.
-        conn = await asyncpg.connect(pg_v4_dsn)
-        try:
-            await conn.execute(
-                "UPDATE cubepi_runs SET completed_at = now(), completion_seq = 1 "
-                "WHERE thread_id = $1 AND run_id = $2",
-                "t",
-                "r1",
-            )
-        finally:
-            await conn.close()
+        await cp.mark_run_complete("t", "r1")
         msg = UserMessage(content=[TextContent(text="late")], run_id="r1")
         with pytest.raises(RunAlreadyCompletedError):
             await cp.append("t", [msg])
+
+
+@pytest.mark.asyncio
+async def test_claim_then_complete_roundtrip(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        await cp.mark_run_complete("t", "r1")
+        # Idempotent: second mark is a no-op.
+        await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_completed_raises_completed(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await cp.claim_run("t", "r1")
+        await cp.mark_run_complete("t", "r1")
+        with pytest.raises(RunAlreadyCompletedError):
+            await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_mark_without_claim_raises_not_claimed(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        with pytest.raises(RunNotClaimedError):
+            await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_completion_seq_monotonic_per_thread(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        for rid in ("A", "B", "C"):
+            await cp.claim_run("t", rid)
+            await cp.mark_run_complete("t", rid)
+    conn = await asyncpg.connect(pg_v4_dsn)
+    try:
+        rows = await conn.fetch(
+            "SELECT run_id, completion_seq FROM cubepi_runs "
+            "WHERE thread_id = $1 ORDER BY completion_seq",
+            "t",
+        )
+        assert [r["run_id"] for r in rows] == ["A", "B", "C"]
+        seqs = [r["completion_seq"] for r in rows]
+        assert seqs == sorted(seqs)
+        assert len(set(seqs)) == 3
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_tuple_with_run_id(pg_v4_dsn):
+    from cubepi.hitl.types import ConfirmRequest, HitlRequest
+
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        req = HitlRequest(
+            question_id="q1",
+            thread_id="t",
+            payload=ConfirmRequest(prompt="hi"),
+            created_at=0.0,
+        )
+        await cp.save_pending_request("t", req, run_id="r-1")
+        res = await cp.load_pending("t")
+        assert res is not None
+        got_req, got_run_id = res
+        assert got_req.question_id == "q1"
+        assert got_run_id == "r-1"
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_none_when_empty(pg_v4_dsn):
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        assert await cp.load_pending("t") is None
 
 
 @pytest.mark.asyncio

--- a/tests/checkpointer/test_postgres_schema.py
+++ b/tests/checkpointer/test_postgres_schema.py
@@ -1,0 +1,41 @@
+import asyncpg
+import pytest
+
+from cubepi.checkpointer.postgres.models import EXPECTED_SCHEMA_VERSION
+
+
+def test_expected_schema_version_is_4():
+    assert EXPECTED_SCHEMA_VERSION == 4
+
+
+@pytest.mark.asyncio
+async def test_cubepi_runs_table_present(pg_v4_dsn):
+    conn = await asyncpg.connect(pg_v4_dsn)
+    try:
+        rows = await conn.fetch(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'cubepi_runs'"
+        )
+        cols = {r["column_name"] for r in rows}
+        assert {
+            "thread_id",
+            "run_id",
+            "claimed_at",
+            "completed_at",
+            "completion_seq",
+        } <= cols
+    finally:
+        await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_cubepi_messages_has_run_id_column(pg_v4_dsn):
+    conn = await asyncpg.connect(pg_v4_dsn)
+    try:
+        row = await conn.fetchrow(
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_name = 'cubepi_messages' AND column_name = 'run_id'"
+        )
+        assert row is not None
+    finally:
+        await conn.close()

--- a/tests/checkpointer/test_postgres_schema_version_v3.py
+++ b/tests/checkpointer/test_postgres_schema_version_v3.py
@@ -27,7 +27,7 @@ async def test_postgres_v2_database_refused_with_actionable_error(clean_db) -> N
             pass
 
     msg = str(ei.value)
-    assert "expected 3" in msg or "expected=3" in msg
+    assert "expected 4" in msg or "expected=4" in msg
     assert "actual 2" in msg or "actual=2" in msg
     # Hint mentions the host alembic migration path so operators know what to do.
     assert "alembic" in msg.lower()
@@ -59,6 +59,6 @@ async def test_mysql_v2_database_refused_with_actionable_error(clean_mysql_db) -
             pass
 
     msg = str(ei.value)
-    assert "expected 3" in msg or "expected=3" in msg
+    assert "expected 4" in msg or "expected=4" in msg
     assert "actual 2" in msg or "actual=2" in msg
     assert "alembic" in msg.lower()

--- a/tests/checkpointer/test_sqlite_concurrency.py
+++ b/tests/checkpointer/test_sqlite_concurrency.py
@@ -1,0 +1,26 @@
+import tempfile
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from cubepi.checkpointer.exceptions import CheckpointerLockTimeoutError
+from cubepi.checkpointer.sqlite import SQLiteCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+@pytest.mark.asyncio
+async def test_lock_timeout_surfaces_as_typed_error(monkeypatch):
+    with tempfile.TemporaryDirectory() as d:
+        path = str(Path(d) / "x.db")
+        async with SQLiteCheckpointer(path) as cp:
+            await cp._db.execute("PRAGMA busy_timeout = 100")
+            other = await aiosqlite.connect(path)
+            try:
+                await other.execute("BEGIN IMMEDIATE")
+                msg = UserMessage(content=[TextContent(text="x")])
+                with pytest.raises(CheckpointerLockTimeoutError):
+                    await cp.append("t", [msg])
+            finally:
+                await other.rollback()
+                await other.close()

--- a/tests/checkpointer/test_sqlite_fork.py
+++ b/tests/checkpointer/test_sqlite_fork.py
@@ -1,0 +1,104 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunNotCompletedError,
+    ThreadAlreadyExistsError,
+    ThreadNotFoundError,
+)
+from cubepi.checkpointer.sqlite import SQLiteCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+def _msg(run_id: str | None, text: str) -> UserMessage:
+    return UserMessage(content=[TextContent(text=text)], run_id=run_id)
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_completed_runs_only():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("src", "A")
+            await cp.append("src", [_msg("A", "a1"), _msg("A", "a2")])
+            await cp.mark_run_complete("src", "A")
+            await cp.claim_run("src", "B")
+            await cp.append("src", [_msg("B", "b1")])
+            await cp.mark_run_complete("src", "B")
+            # An in-flight run C — must be excluded.
+            await cp.claim_run("src", "C")
+            await cp.append("src", [_msg("C", "c1")])
+            await cp.fork("src", "dst", after_run_id="B")
+            loaded = await cp.load("dst")
+            assert loaded is not None
+            texts = [m.content[0].text for m in loaded.messages]
+            assert texts == ["a1", "a2", "b1"]
+            assert loaded.parent_thread_id == "src"
+
+
+@pytest.mark.asyncio
+async def test_fork_includes_legacy_null_run_id_prefix():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.append("src", [_msg(None, "legacy")])
+            await cp.claim_run("src", "A")
+            await cp.append("src", [_msg("A", "a1")])
+            await cp.mark_run_complete("src", "A")
+            await cp.fork("src", "dst", after_run_id="A")
+            loaded = await cp.load("dst")
+            assert [m.content[0].text for m in loaded.messages] == ["legacy", "a1"]
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_src_raises_thread_not_found():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            with pytest.raises(ThreadNotFoundError):
+                await cp.fork("missing", "dst", after_run_id="X")
+
+
+@pytest.mark.asyncio
+async def test_fork_unknown_run_id_raises_not_completed():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.append("src", [_msg(None, "x")])
+            with pytest.raises(RunNotCompletedError):
+                await cp.fork("src", "dst", after_run_id="missing")
+
+
+@pytest.mark.asyncio
+async def test_fork_destination_collision_raises_already_exists():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("src", "A")
+            await cp.append("src", [_msg("A", "a1")])
+            await cp.mark_run_complete("src", "A")
+            await cp.fork("src", "dst", after_run_id="A")
+            with pytest.raises(ThreadAlreadyExistsError):
+                await cp.fork("src", "dst", after_run_id="A")
+
+
+@pytest.mark.asyncio
+async def test_fork_carries_extra_and_writes_metadata():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.save_extra("src", {"original": "x"})
+            await cp.claim_run("src", "A")
+            await cp.append("src", [_msg("A", "a1")])
+            await cp.mark_run_complete("src", "A")
+            await cp.fork("src", "dst", after_run_id="A", metadata={"source": "test"})
+            loaded = await cp.load("dst")
+            assert loaded.extra["original"] == "x"
+            assert loaded.extra["fork"] == {"source": "test"}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_matches_fork_messages():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("src", "A")
+            await cp.append("src", [_msg("A", "a1")])
+            await cp.mark_run_complete("src", "A")
+            msgs = await cp.snapshot("src", after_run_id="A")
+            assert [m.content[0].text for m in msgs] == ["a1"]

--- a/tests/checkpointer/test_sqlite_fork.py
+++ b/tests/checkpointer/test_sqlite_fork.py
@@ -102,3 +102,15 @@ async def test_snapshot_matches_fork_messages():
             await cp.mark_run_complete("src", "A")
             msgs = await cp.snapshot("src", after_run_id="A")
             assert [m.content[0].text for m in msgs] == ["a1"]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_uncompleted_run_raises_not_completed():
+    """Snapshot must mirror fork's "RunNotCompleted" behavior."""
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("src", "A")
+            await cp.append("src", [_msg("A", "a1")])
+            # NOT marking complete.
+            with pytest.raises(RunNotCompletedError):
+                await cp.snapshot("src", after_run_id="A")

--- a/tests/checkpointer/test_sqlite_runs.py
+++ b/tests/checkpointer/test_sqlite_runs.py
@@ -1,0 +1,117 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+    RunNotClaimedError,
+)
+from cubepi.checkpointer.sqlite import SQLiteCheckpointer
+from cubepi.providers.base import TextContent, UserMessage
+
+
+@pytest.mark.asyncio
+async def test_claim_then_complete_roundtrip():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("t", "r1")
+            await cp.mark_run_complete("t", "r1")
+            # Idempotent: second mark is a no-op.
+            await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_in_flight_raises_claimed():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("t", "r1")
+            with pytest.raises(RunAlreadyClaimedError):
+                await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_claim_collision_completed_raises_completed():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("t", "r1")
+            await cp.mark_run_complete("t", "r1")
+            with pytest.raises(RunAlreadyCompletedError):
+                await cp.claim_run("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_mark_without_claim_raises_not_claimed():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            with pytest.raises(RunNotClaimedError):
+                await cp.mark_run_complete("t", "r1")
+
+
+@pytest.mark.asyncio
+async def test_completion_seq_monotonic_per_thread():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            for rid in ("A", "B", "C"):
+                await cp.claim_run("t", rid)
+                await cp.mark_run_complete("t", rid)
+            cur = await cp._db.execute(
+                "SELECT run_id, completion_seq FROM runs WHERE thread_id = ? "
+                "ORDER BY completion_seq",
+                ("t",),
+            )
+            rows = await cur.fetchall()
+            assert [r[0] for r in rows] == ["A", "B", "C"]
+            seqs = [r[1] for r in rows]
+            assert seqs == sorted(seqs)
+            assert len(set(seqs)) == 3
+
+
+@pytest.mark.asyncio
+async def test_append_on_completed_run_id_rejected():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("t", "r1")
+            await cp.mark_run_complete("t", "r1")
+            msg = UserMessage(content=[TextContent(text="late")], run_id="r1")
+            with pytest.raises(RunAlreadyCompletedError):
+                await cp.append("t", [msg])
+
+
+@pytest.mark.asyncio
+async def test_append_in_flight_run_id_ok():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            await cp.claim_run("t", "r1")
+            msg = UserMessage(content=[TextContent(text="ok")], run_id="r1")
+            await cp.append("t", [msg])
+            data = await cp.load("t")
+            assert data is not None and len(data.messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_tuple_with_run_id():
+    from cubepi.hitl.types import ConfirmRequest, HitlRequest
+
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            req = HitlRequest(
+                question_id="q1",
+                thread_id="t",
+                payload=ConfirmRequest(prompt="hi"),
+                created_at=0.0,
+            )
+            await cp.save_pending_request("t", req, run_id="r-1")
+            res = await cp.load_pending("t")
+            assert res is not None
+            got_req, got_run_id = res
+            assert got_req.question_id == "q1"
+            assert got_run_id == "r-1"
+
+
+@pytest.mark.asyncio
+async def test_load_pending_returns_none_when_empty():
+    with tempfile.TemporaryDirectory() as d:
+        async with SQLiteCheckpointer(str(Path(d) / "x.db")) as cp:
+            assert await cp.load_pending("t") is None

--- a/tests/checkpointer/test_sqlite_schema.py
+++ b/tests/checkpointer/test_sqlite_schema.py
@@ -1,0 +1,40 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cubepi.checkpointer.sqlite import SQLiteCheckpointer
+
+
+@pytest.mark.asyncio
+async def test_runs_table_and_columns_exist_after_init():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "x.db"
+        async with SQLiteCheckpointer(str(path)) as cp:
+            cur = await cp._db.execute("PRAGMA table_info(runs)")
+            cols = {row[1] for row in await cur.fetchall()}
+            assert {
+                "thread_id",
+                "run_id",
+                "claimed_at",
+                "completed_at",
+                "completion_seq",
+            } <= cols
+
+            cur = await cp._db.execute("PRAGMA table_info(messages)")
+            cols = {row[1] for row in await cur.fetchall()}
+            assert "run_id" in cols
+
+            cur = await cp._db.execute("PRAGMA table_info(thread_extra)")
+            cols = {row[1] for row in await cur.fetchall()}
+            assert "parent_thread_id" in cols
+
+
+@pytest.mark.asyncio
+async def test_busy_timeout_is_set():
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "x.db"
+        async with SQLiteCheckpointer(str(path)) as cp:
+            cur = await cp._db.execute("PRAGMA busy_timeout")
+            (val,) = await cur.fetchone()
+            assert val >= 5000

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,23 @@
+"""End-to-end test fixtures.
+
+Re-exports the Postgres + MySQL DSN fixtures from
+``tests/checkpointer/conftest.py`` so the cross-backend e2e suite can use
+them without duplicating fixture setup.
+
+We avoid ``pytest_plugins`` here because pytest deprecates declaring it in
+non-top-level conftest files (it would affect the whole suite, not just
+``tests/e2e``). Direct imports are scoped to this package only.
+"""
+
+from __future__ import annotations
+
+from tests.checkpointer.conftest import (  # noqa: F401 — fixtures must be re-exported
+    _mysql_available,
+    _pg_available,
+    clean_db,
+    clean_mysql_db,
+    mysql_dsn,
+    mysql_v4_dsn,
+    pg_dsn,
+    pg_v4_dsn,
+)

--- a/tests/e2e/test_fork_concurrency_pg.py
+++ b/tests/e2e/test_fork_concurrency_pg.py
@@ -1,0 +1,123 @@
+"""Task 40: concurrent fork + claim races on Postgres E2E.
+
+Two scenarios exercise the advisory-lock serialization on the real Postgres
+backend (skipped automatically when ``CUBEPI_TEST_PG_DSN`` is unreachable):
+
+1. **Concurrent forks of the same source thread.** Two parallel ``fork(src=X)``
+   calls (different ``new_thread_id``s) both succeed; the per-thread advisory
+   lock serializes the snapshot writes.
+2. **Concurrent claim of the same run_id.** Two independent
+   ``PostgresCheckpointer`` instances pointing at the same DB both try to claim
+   ``run_id="R1"``. Exactly one wins; the loser raises
+   ``RunAlreadyClaimedError`` (or ``RunAlreadyCompletedError`` if the winner
+   finished while the loser was waiting on the lock).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.exceptions import (
+    RunAlreadyClaimedError,
+    RunAlreadyCompletedError,
+)
+from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_faux() -> FauxProvider:
+    """Faux provider with plenty of one-shot end_turn responses."""
+    p = FauxProvider()
+    p.set_responses(
+        [
+            AssistantMessage(
+                content=[TextContent(text=f"r{i}")], stop_reason="end_turn"
+            )
+            for i in range(10)
+        ]
+    )
+    return p
+
+
+@pytest.mark.asyncio
+async def test_concurrent_forks_of_same_src(pg_v4_dsn):
+    """Two parallel forks of the same source thread.
+
+    The per-thread advisory lock serializes the writes; both forks
+    succeed with identical message sets and the same parent_thread_id.
+    """
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        a = Agent(
+            model=_ok_faux().model("faux-model"),
+            checkpointer=cp,
+            thread_id="src",
+        )
+        await a.prompt("hello", run_id="R1")
+
+        async def fork_to(new_id: str) -> None:
+            await a.fork("src", new_id, after_run_id="R1")
+
+        await asyncio.gather(fork_to("dst_A"), fork_to("dst_B"))
+
+        for new_id in ("dst_A", "dst_B"):
+            loaded = await cp.load(new_id)
+            assert loaded is not None
+            assert loaded.parent_thread_id == "src"
+            assert {m.run_id for m in loaded.messages if m.run_id} == {"R1"}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_claim_of_same_run_id_raises_one(pg_v4_dsn):
+    """Two PostgresCheckpointer instances on the same DB both try to
+    claim the same run_id.
+
+    Exactly one must succeed; the other raises either
+    ``RunAlreadyClaimedError`` (loser arrived during the winner's run) or
+    ``RunAlreadyCompletedError`` (loser arrived after the winner finished).
+    Both are acceptable outcomes — what matters is that we never get two
+    "ok"s on the same run_id.
+    """
+    async with (
+        PostgresCheckpointer(pg_v4_dsn) as cp1,
+        PostgresCheckpointer(pg_v4_dsn) as cp2,
+    ):
+        a1 = Agent(
+            model=_ok_faux().model("faux-model"),
+            checkpointer=cp1,
+            thread_id="t",
+        )
+        a2 = Agent(
+            model=_ok_faux().model("faux-model"),
+            checkpointer=cp2,
+            thread_id="t",
+        )
+
+        async def run_a(agent: Agent, run_id: str) -> str:
+            try:
+                await agent.prompt("hi", run_id=run_id)
+                return "ok"
+            except (RunAlreadyClaimedError, RunAlreadyCompletedError) as e:
+                return f"claimed:{e}"
+
+        results = await asyncio.gather(
+            run_a(a1, "R1"),
+            run_a(a2, "R1"),
+            return_exceptions=False,
+        )
+
+        ok_count = sum(1 for r in results if r == "ok")
+        claimed_count = sum(1 for r in results if r.startswith("claimed:"))
+        assert ok_count >= 1, f"At least one claim should have succeeded; got {results}"
+        assert ok_count + claimed_count == 2, (
+            f"Every result must be ok-or-claimed; got {results}"
+        )
+        # Strictly speaking, only one should succeed — but two "ok"s would
+        # only be possible if both happened sequentially under the same
+        # lock without re-checking the marker. Guard against that.
+        assert ok_count == 1 or claimed_count == 1, (
+            f"Exactly one of the two outcomes should differ; got {results}"
+        )

--- a/tests/e2e/test_fork_e2e.py
+++ b/tests/e2e/test_fork_e2e.py
@@ -1,0 +1,87 @@
+"""Task 38: cross-backend fork happy path E2E.
+
+Drives ``Agent.prompt`` twice (R1 then R2) on every backend, then forks
+``after_run_id="R1"`` and verifies the destination thread contains R1's
+messages only, carries ``parent_thread_id`` and the fork metadata.
+
+The four backends (memory / sqlite / postgres / mysql) share one helper
+``_run_happy_path`` so the assertions stay identical. Postgres/MySQL share
+the DSN fixtures from ``tests/checkpointer/conftest.py`` (re-exported via
+``tests/e2e/conftest.py``'s ``pytest_plugins``) which auto-skip when the
+backend is unreachable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_faux() -> FauxProvider:
+    """Two-turn faux provider — one assistant message per prompt."""
+    p = FauxProvider()
+    p.set_responses(
+        [
+            AssistantMessage(content=[TextContent(text="r1")], stop_reason="end_turn"),
+            AssistantMessage(content=[TextContent(text="r2")], stop_reason="end_turn"),
+        ]
+    )
+    return p
+
+
+async def _run_happy_path(cp) -> None:
+    """Shared body — same assertions across all four backends."""
+    p = _ok_faux()
+    a = Agent(
+        model=p.model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    r1 = await a.prompt("first", run_id="R1")
+    assert r1 == "R1"
+    r2 = await a.prompt("second", run_id="R2")
+    assert r2 == "R2"
+
+    await a.fork("src", "dst", after_run_id="R1", metadata={"label": "branch"})
+
+    loaded = await cp.load("dst")
+    assert loaded is not None
+    assert loaded.parent_thread_id == "src"
+    assert loaded.extra["fork"] == {"label": "branch"}
+    # dst contains R1's messages only, not R2's.
+    run_ids = {m.run_id for m in loaded.messages if m.run_id}
+    assert run_ids == {"R1"}
+
+
+@pytest.mark.asyncio
+async def test_fork_e2e_memory():
+    from cubepi.checkpointer.memory import MemoryCheckpointer
+
+    await _run_happy_path(MemoryCheckpointer())
+
+
+@pytest.mark.asyncio
+async def test_fork_e2e_sqlite(tmp_path):
+    from cubepi.checkpointer.sqlite import SQLiteCheckpointer
+
+    async with SQLiteCheckpointer(str(tmp_path / "x.db")) as cp:
+        await _run_happy_path(cp)
+
+
+@pytest.mark.asyncio
+async def test_fork_e2e_postgres(pg_v4_dsn):
+    from cubepi.checkpointer.postgres.checkpointer import PostgresCheckpointer
+
+    async with PostgresCheckpointer(pg_v4_dsn) as cp:
+        await _run_happy_path(cp)
+
+
+@pytest.mark.asyncio
+async def test_fork_e2e_mysql(mysql_v4_dsn):
+    from cubepi.checkpointer.mysql.checkpointer import MySQLCheckpointer
+
+    async with MySQLCheckpointer(mysql_v4_dsn) as cp:
+        await _run_happy_path(cp)

--- a/tests/e2e/test_fork_hitl_e2e.py
+++ b/tests/e2e/test_fork_hitl_e2e.py
@@ -1,0 +1,120 @@
+"""Task 39: HITL pause + resume + fork chain E2E.
+
+Exercises the full host-facing flow:
+
+1. Provider script: turn 1 = ``ask_user`` tool_call (pauses), turn 2 = final
+   assistant text.
+2. Driver: ``prompt()`` pauses for HITL → fresh Agent ``respond()`` resumes →
+   completion marker for R1 is written.
+3. Fork on a third Agent with ``after_run_id="R1"`` → new thread carries R1's
+   messages and the fork metadata.
+
+Memory backend is sufficient — cross-backend coverage is provided by Task 38.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.ask_user import ask_user_tool
+from cubepi.hitl.channel import CheckpointedChannel
+from cubepi.providers.base import AssistantMessage, TextContent, ToolCall
+from cubepi.providers.faux import FauxProvider
+
+
+def _ask_then_finish_provider() -> FauxProvider:
+    """Turn 1 pauses via ask_user; turn 2 emits the final assistant text."""
+    p = FauxProvider()
+    p.set_responses(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="tc-1",
+                        name="ask_user",
+                        arguments={"questions": [{"key": "ans", "prompt": "?"}]},
+                    )
+                ],
+                stop_reason="tool_use",
+            ),
+            AssistantMessage(
+                content=[TextContent(text="done")],
+                stop_reason="end_turn",
+            ),
+        ]
+    )
+    return p
+
+
+@pytest.mark.asyncio
+async def test_fork_after_hitl_resume():
+    """prompt pauses for HITL → respond resumes → marker written →
+    fork succeeds and copies the resumed run."""
+    cp = MemoryCheckpointer()
+    p = _ask_then_finish_provider()
+
+    # ---- Phase 1: drive the pause. ----
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    a = Agent(
+        model=p.model("faux-model"),
+        tools=[tool],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch,
+    )
+    task = asyncio.create_task(a.prompt("hello", run_id="R1"))
+    # Wait until pending is persisted.
+    for _ in range(500):
+        if (await cp.load_pending("t")) is not None:
+            break
+        await asyncio.sleep(0.01)
+    else:  # pragma: no cover — defensive
+        task.cancel()
+        raise AssertionError("pending never appeared")
+    await a.detach()
+    await task
+
+    # Marker not yet written — prompt() suspended, not completed.
+    assert cp._runs["t"]["R1"].completed_at is None
+
+    # ---- Phase 2: resume on a fresh Agent. ----
+    ch2 = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool2 = ask_user_tool(ch2)
+    a2 = Agent(
+        model=p.model("faux-model"),
+        tools=[tool2],
+        checkpointer=cp,
+        thread_id="t",
+        channel=ch2,
+    )
+    pending = await cp.load_pending("t")
+    assert pending is not None
+    pending_req, _recovered_run_id = pending
+    await a2.respond(question_id=pending_req.question_id, answer="yes")
+
+    # Clean resume → outcome "complete" → mark_run_complete fired.
+    assert cp._runs["t"]["R1"].completed_at is not None
+
+    # ---- Phase 3: fork on a fresh Agent ----
+    a3 = Agent(
+        model=p.model("faux-model"),  # not actually invoked
+        checkpointer=cp,
+        thread_id="t",
+    )
+    await a3.fork("t", "fork_t", after_run_id="R1", metadata={"reason": "branch"})
+
+    loaded = await cp.load("fork_t")
+    assert loaded is not None
+    assert loaded.parent_thread_id == "t"
+    assert loaded.extra["fork"] == {"reason": "branch"}
+    # The forked thread contains the full resumed conversation:
+    # user message + assistant ask_user + tool_result + final assistant.
+    run_ids = {m.run_id for m in loaded.messages if m.run_id}
+    assert "R1" in run_ids
+    # Sanity: we copied more than just the user prompt.
+    assert len(loaded.messages) >= 3

--- a/tests/hitl/test_agent_abort_pending.py
+++ b/tests/hitl/test_agent_abort_pending.py
@@ -77,3 +77,9 @@ async def test_abort_pending_closes_conversation():
     assert msgs[-1].stop_reason == "aborted"
     # pending is cleared
     assert await cp.load_pending_request("t-1") is None
+    # Regression for codex R2 P1: synthetic deny + terminal abort must
+    # carry the originating assistant's run_id so a later fork query
+    # (which treats run_id IS NULL as legacy / always-copy) cannot copy
+    # these aborted-run artifacts as if they were pre-v4 history.
+    assert msgs[-2].run_id == "R1"
+    assert msgs[-1].run_id == "R1"

--- a/tests/hitl/test_agent_abort_pending.py
+++ b/tests/hitl/test_agent_abort_pending.py
@@ -39,7 +39,7 @@ def _bash_tool() -> AgentTool:
 
 async def test_abort_pending_closes_conversation():
     cp = MemoryCheckpointer()
-    ch = CheckpointedChannel(checkpointer=cp, thread_id="t-1")
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t-1", run_id="R1")
     provider = FauxProvider(provider_id="faux")
     provider.set_responses(
         [
@@ -57,7 +57,7 @@ async def test_abort_pending_closes_conversation():
         checkpointer=cp,
         thread_id="t-1",
     )
-    task = asyncio.create_task(agent.prompt("hi"))
+    task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
     for _ in range(200):
         if ch.pending is not None:
             break

--- a/tests/hitl/test_agent_respond.py
+++ b/tests/hitl/test_agent_respond.py
@@ -61,7 +61,7 @@ def _faux_with(responses) -> FauxProvider:
 
 async def test_respond_completes_a_suspended_run():
     cp = MemoryCheckpointer()
-    ch = CheckpointedChannel(checkpointer=cp, thread_id="t-1")
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t-1", run_id="R1")
     provider = FauxProvider(provider_id="faux")
     provider.set_responses(_two_turn_bash_responses())
     agent = Agent(
@@ -77,7 +77,7 @@ async def test_respond_completes_a_suspended_run():
 
     # Start the agent — it will suspend on channel.approve.
     async def run():
-        await agent.prompt("hi")
+        await agent.prompt("hi", run_id="R1")
 
     task = asyncio.create_task(run())
 

--- a/tests/hitl/test_approval_policy_binding.py
+++ b/tests/hitl/test_approval_policy_binding.py
@@ -1,0 +1,36 @@
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.channel import CheckpointedChannel, InMemoryChannel
+from cubepi.hitl.middleware import ApprovalPolicyMiddleware, ConfirmToolCallMiddleware
+from cubepi.hitl.policy import Approve
+
+
+def _approve_policy(ctx):
+    return Approve()
+
+
+def test_approval_policy_with_checkpointed_channel_sets_binding():
+    cp = MemoryCheckpointer()
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    mw = ApprovalPolicyMiddleware(channel=ch, policy=_approve_policy)
+    assert mw.hitl is not None
+    assert mw.hitl.checkpointed is True
+    assert mw.hitl.run_id == "R1"
+
+
+def test_approval_policy_with_in_memory_channel_sets_binding():
+    ch = InMemoryChannel(thread_id="t")
+    mw = ApprovalPolicyMiddleware(channel=ch, policy=_approve_policy)
+    assert mw.hitl is not None
+    assert mw.hitl.checkpointed is False
+    assert mw.hitl.run_id is None
+
+
+def test_confirm_tool_call_middleware_inherits_binding():
+    """ConfirmToolCallMiddleware is a subclass of ApprovalPolicyMiddleware.
+    It should inherit the same binding behavior."""
+    cp = MemoryCheckpointer()
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    mw = ConfirmToolCallMiddleware(channel=ch)
+    assert mw.hitl is not None
+    assert mw.hitl.checkpointed is True
+    assert mw.hitl.run_id == "R1"

--- a/tests/hitl/test_ask_user_binding.py
+++ b/tests/hitl/test_ask_user_binding.py
@@ -1,0 +1,20 @@
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.ask_user import ask_user_tool
+from cubepi.hitl.channel import CheckpointedChannel, InMemoryChannel
+
+
+def test_ask_user_tool_with_checkpointed_channel_sets_binding():
+    cp = MemoryCheckpointer()
+    ch = CheckpointedChannel(checkpointer=cp, thread_id="t", run_id="R1")
+    tool = ask_user_tool(ch)
+    assert tool.hitl is not None
+    assert tool.hitl.checkpointed is True
+    assert tool.hitl.run_id == "R1"
+
+
+def test_ask_user_tool_with_in_memory_channel_sets_binding():
+    ch = InMemoryChannel(thread_id="t")
+    tool = ask_user_tool(ch)
+    assert tool.hitl is not None
+    assert tool.hitl.checkpointed is False
+    assert tool.hitl.run_id is None

--- a/tests/hitl/test_edge_cases.py
+++ b/tests/hitl/test_edge_cases.py
@@ -108,7 +108,7 @@ def test_respond_raises_when_checkpointer_lacks_hitl():
         checkpointer=_BareCP(),
         thread_id="t-1",
     )
-    with pytest.raises(HitlError, match="load_pending_request"):
+    with pytest.raises(HitlError, match="load_pending"):
         asyncio.get_event_loop().run_until_complete(
             agent.respond(answer=ApproveAnswer(decision="approve"))
         )

--- a/tests/hitl/test_resume_cache_prefix.py
+++ b/tests/hitl/test_resume_cache_prefix.py
@@ -49,7 +49,7 @@ def _two_turn_bash_responses():
 
 
 async def _suspend_resume_and_capture(checkpointer):
-    ch = CheckpointedChannel(checkpointer=checkpointer, thread_id="t-1")
+    ch = CheckpointedChannel(checkpointer=checkpointer, thread_id="t-1", run_id="R1")
     provider = FauxProvider(provider_id="faux")
     provider.set_responses(_two_turn_bash_responses())
 
@@ -64,7 +64,7 @@ async def _suspend_resume_and_capture(checkpointer):
         checkpointer=checkpointer,
         thread_id="t-1",
     )
-    task = asyncio.create_task(agent.prompt("hi"))
+    task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
     for _ in range(200):
         if ch.pending is not None:
             break

--- a/tests/providers/test_message_run_id.py
+++ b/tests/providers/test_message_run_id.py
@@ -1,0 +1,37 @@
+from cubepi.providers.base import (
+    AssistantMessage,
+    TextContent,
+    ToolResultMessage,
+    UserMessage,
+)
+
+
+def test_user_message_run_id_default_none():
+    m = UserMessage(content=[TextContent(text="hi")])
+    assert m.run_id is None
+
+
+def test_assistant_message_run_id_default_none():
+    m = AssistantMessage(content=[])
+    assert m.run_id is None
+
+
+def test_tool_result_message_run_id_default_none():
+    m = ToolResultMessage(
+        tool_call_id="tc1", tool_name="foo", content=[]
+    )
+    assert m.run_id is None
+
+
+def test_run_id_round_trip_serialization():
+    src = AssistantMessage(content=[], run_id="r-1")
+    blob = src.model_dump_json()
+    dst = AssistantMessage.model_validate_json(blob)
+    assert dst.run_id == "r-1"
+
+
+def test_run_id_is_keyword_only_in_practice():
+    # All existing call sites pass content positionally / by keyword;
+    # adding run_id as a defaulted field at the end is non-breaking.
+    m = UserMessage(content=[TextContent(text="hi")], run_id="r-2")
+    assert m.run_id == "r-2"

--- a/tests/providers/test_message_run_id.py
+++ b/tests/providers/test_message_run_id.py
@@ -17,9 +17,7 @@ def test_assistant_message_run_id_default_none():
 
 
 def test_tool_result_message_run_id_default_none():
-    m = ToolResultMessage(
-        tool_call_id="tc1", tool_name="foo", content=[]
-    )
+    m = ToolResultMessage(tool_call_id="tc1", tool_name="foo", content=[])
     assert m.run_id is None
 
 

--- a/tests/tracing/conftest.py
+++ b/tests/tracing/conftest.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def in_memory_exporter():
+    """Attach a fresh InMemorySpanExporter to the global TracerProvider for
+    the duration of one test.
+
+    OTel forbids replacing the global TracerProvider once set, so we attach
+    a fresh exporter to whatever provider is already installed (installing
+    one if none is). Returns the exporter so tests can call
+    `get_finished_spans()`.
+
+    Skips the test if `opentelemetry` isn't installed (it's part of the
+    optional `tracing` extra).
+    """
+    pytest.importorskip("opentelemetry")
+
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    current = trace.get_tracer_provider()
+    if not isinstance(current, TracerProvider):
+        current = TracerProvider()
+        trace.set_tracer_provider(current)
+    exporter = InMemorySpanExporter()
+    current.add_span_processor(SimpleSpanProcessor(exporter))
+    yield exporter
+    exporter.clear()

--- a/tests/tracing/test_fork_once_span.py
+++ b/tests/tracing/test_fork_once_span.py
@@ -1,0 +1,39 @@
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.providers.base import AssistantMessage, TextContent
+from cubepi.providers.faux import FauxProvider
+
+
+def _ok_faux() -> FauxProvider:
+    p = FauxProvider()
+    p.set_responses(
+        [AssistantMessage(content=[TextContent(text="ok")], stop_reason="end_turn")]
+    )
+    return p
+
+
+@pytest.mark.asyncio
+async def test_fork_once_emits_named_span(in_memory_exporter):
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.prompt("hello", run_id="R1")
+    # Fresh agent for the fork_once probe (mirrors existing fork_once tests).
+    a2 = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a2.fork_once("src", "follow up?", after_run_id="R1")
+    spans = in_memory_exporter.get_finished_spans()
+    names = [s.name for s in spans]
+    assert "cubepi.agent.fork_once" in names
+    span = next(s for s in spans if s.name == "cubepi.agent.fork_once")
+    attrs = dict(span.attributes)
+    assert attrs["cubepi.fork.src_thread_id"] == "src"
+    assert attrs["cubepi.fork.after_run_id"] == "R1"

--- a/tests/tracing/test_fork_once_span.py
+++ b/tests/tracing/test_fork_once_span.py
@@ -37,3 +37,37 @@ async def test_fork_once_emits_named_span(in_memory_exporter):
     attrs = dict(span.attributes)
     assert attrs["cubepi.fork.src_thread_id"] == "src"
     assert attrs["cubepi.fork.after_run_id"] == "R1"
+
+
+@pytest.mark.asyncio
+async def test_fork_once_span_falls_back_to_nullcontext_when_otel_missing(
+    monkeypatch,
+):
+    """When the optional `tracing` extra isn't installed, the span helper
+    must fall back to contextlib.nullcontext so fork_once still works."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_otel(name, *args, **kwargs):
+        if name == "opentelemetry" or name.startswith("opentelemetry."):
+            raise ImportError("simulated: opentelemetry not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_otel)
+
+    cp = MemoryCheckpointer()
+    a = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    await a.prompt("hello", run_id="R1")
+    a2 = Agent(
+        model=_ok_faux().model("faux-model"),
+        checkpointer=cp,
+        thread_id="src",
+    )
+    # Must not raise — the helper falls back to a no-op nullcontext.
+    result = await a2.fork_once("src", "follow up?", after_run_id="R1")
+    assert result is not None

--- a/website/docs/guides/checkpointing/forking.md
+++ b/website/docs/guides/checkpointing/forking.md
@@ -1,0 +1,250 @@
+---
+title: Conversation Forking
+description: "Branch a conversation at a completed-run boundary — persistent forks for new threads, ephemeral one-shot probes, and the HITL binding rules that keep them safe."
+---
+
+# Conversation Forking
+
+A **fork** branches a conversation at a completed-run boundary. CubePi
+gives you two variants:
+
+- **`Agent.fork(...)`** — a *persistent* fork. Copies messages from the
+  source thread up to and including a chosen `run_id` into a brand-new
+  thread you can continue to converse with.
+- **`Agent.fork_once(...)`** — an *ephemeral* one-shot probe. Loads a
+  snapshot in memory, runs one prompt, and returns the result without
+  writing anything back to the source thread.
+
+Both APIs key off `run_id` — a stable identifier for one
+`prompt() → final assistant message` cycle. Every message produced
+during a prompt carries the same `run_id`, so "the boundary after
+run R" is an unambiguous, reproducible cut.
+
+## The cubebox copy-button UX
+
+The driving use case is the cubebox "branch this reply" button: under
+every assistant message in the UI there is a small affordance that
+forks the conversation into a fresh thread starting from the message
+above it. Users use it to explore "what if the assistant had answered
+this differently?" without polluting the original thread.
+
+In that flow:
+
+- the host generates the new thread's id (cubebox uses uuid7),
+- calls `Agent.fork(src, new, after_run_id=...)` to materialise the
+  branch, and
+- opens a fresh agent against the new thread.
+
+The features below — explicit `run_id`, `active_run_id`, fork APIs,
+and the HITL binding rules — are exactly what that UX needs.
+
+## `Agent.prompt(run_id=...)` — accept-or-generate
+
+`Agent.prompt()` now returns the `run_id` it used for the call:
+
+```python
+run_id = await agent.prompt("hello")
+print(run_id)  # → "8c0b…" — server-generated
+```
+
+Hosts that want to control the id (cubebox, multi-machine relays,
+anything that needs the id *before* the call completes) can supply it:
+
+```python
+import uuid_extensions   # or whatever uuid7 source you prefer
+
+my_run_id = uuid_extensions.uuid7str()
+run_id = await agent.prompt("hello", run_id=my_run_id)
+assert run_id == my_run_id
+```
+
+While the run is in flight, the id is available on
+`Agent.state.active_run_id`:
+
+```python
+async def watch(agent: Agent) -> None:
+    while agent.state.is_streaming:
+        print("running:", agent.state.active_run_id)
+        await asyncio.sleep(0.1)
+```
+
+`active_run_id` is `None` between runs; it's set on entry to
+`prompt()` and cleared on clean exit. If a prompt fails mid-flight
+it stays set so `respond()` can resume the same run after a HITL
+suspension or process restart.
+
+## `Agent.fork(...)` — persistent branch
+
+```python
+await agent.fork(
+    src_thread_id="conv_123",
+    new_thread_id="conv_456",
+    after_run_id="R1",
+    metadata={"label": "branch experiment"},
+)
+```
+
+What it does:
+
+1. **Copies messages.** Every message on `conv_123` whose `run_id`
+   belongs to a *completed* run up to and including `R1` is appended
+   verbatim to `conv_456` (with new `seq` numbers). Pending or
+   aborted runs after `R1` are not included.
+2. **Records lineage.** The new thread row is written with
+   `parent_thread_id = "conv_123"` and `forked_at_seq` equal to the
+   source-thread seq of the last copied message, so you can trace
+   parent/child relationships later.
+3. **Stamps fork metadata.** `metadata` is written under
+   `extra["fork"]` on the new thread (merged with `save_extra`
+   semantics — existing keys survive).
+
+After `fork` returns, `conv_456` exists as a fresh thread that
+shares history with `conv_123` up to R1; further prompts on either
+thread are independent. The source thread is untouched.
+
+`fork` requires the checkpointer to implement the v4 Protocol
+methods (`claim_run`, `mark_run_complete`, `fork`); on a v3-only
+backend it raises `CheckpointerError`.
+
+## `Agent.fork_once(...)` — ephemeral one-shot probe
+
+```python
+result = await agent.fork_once(
+    src_thread_id="conv_123",
+    message="What if you had said yes?",
+    after_run_id="R1",
+)
+
+print(result.text)         # final assistant text
+print(result.stop_reason)  # "stop" | "max_tokens" | "error" | ...
+for m in result.messages:  # only the new messages added during the probe
+    ...
+```
+
+`fork_once` returns a `ForkOnceResult` dataclass:
+
+```python
+@dataclass(frozen=True)
+class ForkOnceResult:
+    text: str               # final assistant text content joined to one string
+    messages: list[Message] # messages emitted during the probe (no history prefix)
+    stop_reason: str        # final assistant stop_reason
+```
+
+Under the hood it builds a transient `Agent` seeded with a snapshot
+of the source thread up to `R1`, runs your prompt against it once,
+and discards everything when the call returns. The probe gets its
+own fresh `run_id` (you don't supply one).
+
+### Isolation contract
+
+`fork_once` is isolated **only at the checkpointer layer**:
+
+- Nothing the probe does is written to the source thread, the new
+  thread, or any thread — the transient agent has no `thread_id`.
+- **Tool side effects are NOT isolated.** If your tool sends an
+  email, calls an HTTP API, or writes a file, it will do so during a
+  `fork_once`. Design tools to be safe to invoke during a probe, or
+  skip `fork_once` for tools that aren't.
+- **HITL is banned outright.** If any tool or middleware on the
+  agent carries a `HitlBinding`, `fork_once` raises `RuntimeError`
+  immediately. Build a separate agent (without `ask_user_tool` /
+  `ApprovalPolicyMiddleware`) for ephemeral probes.
+
+## HITL binding requirement
+
+When you use `ask_user_tool` or `ApprovalPolicyMiddleware` with a
+**checkpointed** HITL channel, the channel must be bound to the same
+`run_id` you pass to `prompt()`:
+
+```python
+import uuid
+from cubepi import Agent
+from cubepi.hitl import CheckpointedChannel, ask_user_tool
+
+run_id = uuid.uuid4().hex
+channel = CheckpointedChannel(checkpointer=cp, thread_id="conv_123", run_id=run_id)
+
+agent = Agent(
+    model=provider.model("claude-sonnet-4-5-20250929"),
+    checkpointer=cp,
+    thread_id="conv_123",
+    tools=[ask_user_tool(channel)],
+    channel=channel,
+)
+
+# run_id MUST be supplied — it's the same id the channel is bound to
+result_run_id = await agent.prompt("…", run_id=run_id)
+```
+
+`prompt()` enforces this on entry:
+
+- If a checkpointed HITL element is present and you omit `run_id`,
+  it raises `ValueError` (no auto-generation — you have to pin it).
+- If the supplied `run_id` doesn't match the channel's bound id, it
+  raises `ValueError` with both ids in the message.
+
+The reason: a HITL request persists across process restarts, and
+when you later `agent.respond(answer)` the framework needs to know
+which `run_id` to resume under. Binding it up front makes that
+deterministic.
+
+In-memory (`InMemoryChannel`) HITL doesn't have this requirement —
+nothing is persisted, so there's no resume contract to honour.
+
+## Schema v3 → v4 migration
+
+The fork feature requires the v4 schema. Each backend has its own
+upgrade path:
+
+- **Postgres** — see [Postgres → Schema v3→v4](./postgres#schema-v3--v4-migration).
+- **MySQL** — see [MySQL → Schema v3→v4](./mysql#schema-v3--v4-migration).
+- **SQLite** — auto-migrated at `__aenter__`; no host action.
+- **Memory** — no schema; works out of the box.
+
+## Legacy data behaviour
+
+CubePi treats messages from before this feature (no `run_id`
+column populated, i.e. `run_id IS NULL`) gracefully:
+
+- **Mixed threads** — a thread that already has legacy messages and
+  then receives a post-upgrade `prompt()` is fully forkable from any
+  post-upgrade `run_id`. The fork carries the legacy messages
+  through as a prefix to the new thread; they remain `run_id=NULL`
+  on the copy.
+- **All-legacy threads** — a thread with no post-upgrade runs has no
+  `run_id` markers, so there is nothing to point `after_run_id=` at.
+  `fork` / `fork_once` against such a thread raise
+  `CheckpointerError`. To make a legacy thread forkable, send one
+  post-upgrade `prompt()` and then fork after its run id.
+
+`Agent.prompt()` continues to work on legacy threads either way —
+the new schema is fully backwards-compatible for normal use.
+
+## Known limitation: cross-process concurrent prompts
+
+If two processes drive `prompt()` against the same `thread_id` at
+the same time, the per-thread row lock makes message rows
+linearisable, but the *semantic* snapshot a fork captures can miss
+context from a sibling run that interleaved. Specifically:
+
+- Process A starts run `Ra`, appends `[user, assistant, ...]`.
+- Before `Ra` finishes, Process B starts run `Rb`, appends its own
+  messages, and completes.
+- A `fork(..., after_run_id=Ra)` may copy Rb's messages too,
+  depending on interleaving.
+
+The rows are correct; the conversation slice may not be what you
+intended. Avoid concurrent prompts on the same thread or coordinate
+at the application layer if you need strict slicing. Single-process
+deployments (cubebox's default) aren't affected.
+
+## See also
+
+- [Postgres Checkpointing](./postgres) — production backend with v4 schema.
+- [MySQL Checkpointing](./mysql) — MySQL sibling with v4 schema.
+- [SQLite Checkpointing](./sqlite) — single-process backend with auto-migration.
+- [Custom Backends](./custom) — Protocol details, including the new
+  `snapshot`, `fork`, `claim_run`, `mark_run_complete`, `load_pending`
+  methods you need to implement for fork support.
+- [HITL Overview](../hitl/overview) — channel/binding mechanics.

--- a/website/docs/guides/checkpointing/mysql.md
+++ b/website/docs/guides/checkpointing/mysql.md
@@ -195,6 +195,35 @@ claim/completion state.
 See the [Conversation Forking](./forking) guide for the user-facing
 API and semantics.
 
+## Schema v3 → v4 migration
+
+The fork feature bumps `EXPECTED_SCHEMA_VERSION` from 3 to 4. The
+upgrade adds the `run_id` column + composite index to
+`cubepi_messages` and creates the `cubepi_runs` table. Use the
+provided alembic helper — MySQL/pymysql executes one statement per
+call, so split before executing:
+
+```python
+# In a migration's upgrade():
+from cubepi.checkpointer.mysql.alembic_helpers import (
+    upgrade_v3_to_v4_op,
+    write_schema_version_op,
+)
+
+def upgrade():
+    for stmt in upgrade_v3_to_v4_op().split(";"):
+        if stmt.strip():
+            op.execute(stmt)
+    for stmt in write_schema_version_op().split(";"):
+        if stmt.strip():
+            op.execute(stmt)
+```
+
+`upgrade_v3_to_v4_op()` is idempotent under repeated execution.
+Pre-feature messages keep `run_id = NULL` and remain readable; see
+[Legacy data behaviour](./forking#legacy-data-behaviour) for the
+fork-eligibility rules on mixed threads.
+
 ## Common pitfalls
 
 - **`CubepiSchemaUninitialized`** — Your DB is empty, your migrations

--- a/website/docs/guides/checkpointing/mysql.md
+++ b/website/docs/guides/checkpointing/mysql.md
@@ -183,6 +183,18 @@ under a row lock and writes the merged dict, rather than using
 `JSON_MERGE_PATCH`, whose null-deletion and deep-merge semantics differ
 from `dict.update`.)
 
+## Forks
+
+`MySQLCheckpointer` implements the v4 `snapshot` / `fork` /
+`claim_run` / `mark_run_complete` / `load_pending` Protocol methods,
+so it supports both `Agent.fork(...)` and `Agent.fork_once(...)`. The
+`parent_thread_id` / `forked_at_seq` columns on `cubepi_threads`
+record fork lineage; `cubepi_runs` (added in v4) tracks per-run
+claim/completion state.
+
+See the [Conversation Forking](./forking) guide for the user-facing
+API and semantics.
+
 ## Common pitfalls
 
 - **`CubepiSchemaUninitialized`** — Your DB is empty, your migrations

--- a/website/docs/guides/checkpointing/postgres.md
+++ b/website/docs/guides/checkpointing/postgres.md
@@ -187,6 +187,32 @@ per-run claim/completion state.
 See the [Conversation Forking](./forking) guide for the user-facing
 API and semantics.
 
+## Schema v3 → v4 migration
+
+The fork feature bumps `EXPECTED_SCHEMA_VERSION` from 3 to 4. The
+upgrade adds the `run_id` column + index to `cubepi_messages` and
+creates a partitioned `cubepi_runs` parent table with its child
+partitions. Use the provided alembic helper:
+
+```python
+# In a migration's upgrade():
+from cubepi.checkpointer.postgres.alembic_helpers import (
+    upgrade_v3_to_v4_op,
+    write_schema_version_op,
+)
+
+def upgrade():
+    op.execute(upgrade_v3_to_v4_op())
+    op.execute(write_schema_version_op())  # bumps cubepi_schema_version to 4
+```
+
+`upgrade_v3_to_v4_op()` is idempotent under repeated execution
+(`IF NOT EXISTS` guards on every DDL statement).
+
+Pre-feature messages keep `run_id = NULL` and remain readable; see
+[Legacy data behaviour](./forking#legacy-data-behaviour) for the
+fork-eligibility rules on mixed threads.
+
 ## Common pitfalls
 
 - **`CubepiSchemaUninitialized`** — Your DB is empty or your

--- a/website/docs/guides/checkpointing/postgres.md
+++ b/website/docs/guides/checkpointing/postgres.md
@@ -177,9 +177,15 @@ keys.
 
 ## Forks
 
-The `parent_thread_id` + `forked_at_seq` columns exist for future fork
-support. CubePi v0.3 doesn't expose a fork API yet — they're written
-to so the schema is forward-compatible.
+`PostgresCheckpointer` implements the v4 `snapshot` / `fork` /
+`claim_run` / `mark_run_complete` / `load_pending` Protocol methods,
+so it supports both `Agent.fork(...)` and `Agent.fork_once(...)`. The
+`parent_thread_id` and `forked_at_seq` columns on `cubepi_threads`
+record fork lineage; `cubepi_runs` (the v4 partitioned table) tracks
+per-run claim/completion state.
+
+See the [Conversation Forking](./forking) guide for the user-facing
+API and semantics.
 
 ## Common pitfalls
 

--- a/website/docs/guides/checkpointing/sqlite.md
+++ b/website/docs/guides/checkpointing/sqlite.md
@@ -146,6 +146,18 @@ If you need multi-process writers on shared threads, jump to
 so it supports both `Agent.fork(...)` and `Agent.fork_once(...)`. See
 the [Conversation Forking](./forking) guide for the user-facing API.
 
+## Schema v3 → v4 migration
+
+Unlike Postgres and MySQL, SQLite's schema is managed by CubePi
+itself: the v3→v4 upgrade (adding `run_id` to `messages` and
+creating a `cubepi_runs` table) runs automatically on `__aenter__`
+the first time a v4 CubePi connects to a v3 file. No host action is
+required.
+
+Pre-feature messages keep `run_id = NULL` and remain readable; see
+[Legacy data behaviour](./forking#legacy-data-behaviour) for the
+fork-eligibility rules on mixed threads.
+
 ## Where the file lives
 
 Use an absolute path in production:

--- a/website/docs/guides/checkpointing/sqlite.md
+++ b/website/docs/guides/checkpointing/sqlite.md
@@ -139,6 +139,13 @@ have multiple processes writing the same `agent.db`:
 If you need multi-process writers on shared threads, jump to
 [Postgres](./postgres) which uses an advisory lock per thread.
 
+## Forks
+
+`SQLiteCheckpointer` implements the v4 `snapshot` / `fork` /
+`claim_run` / `mark_run_complete` / `load_pending` Protocol methods,
+so it supports both `Agent.fork(...)` and `Agent.fork_once(...)`. See
+the [Conversation Forking](./forking) guide for the user-facing API.
+
 ## Where the file lives
 
 Use an absolute path in production:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/checkpointing/mysql.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/checkpointing/mysql.md
@@ -147,6 +147,45 @@ cubepi_schema_version
 
 `save_extra` 执行浅层顶级合并，而非替换——与 Postgres 和 SQLite 的行为相同。先写入 `{"foo": 1}` 再写入 `{"bar": 2}` 后，结果为 `{"foo": 1, "bar": 2}`。（内部实现是在行锁保护下读取当前 `extra`，然后写入合并后的字典，而非使用 `JSON_MERGE_PATCH`——后者的 null 删除和深度合并语义与 `dict.update` 不同。）
 
+## Forks
+
+`MySQLCheckpointer` 实现了 v4 的 `snapshot` / `fork` /
+`claim_run` / `mark_run_complete` / `load_pending` 协议方法，
+因此同时支持 `Agent.fork(...)` 和 `Agent.fork_once(...)`。
+`cubepi_threads` 上的 `parent_thread_id` / `forked_at_seq` 列
+用于记录 fork 谱系；v4 新增的 `cubepi_runs` 表用于追踪每个 run
+的 claim/completion 状态。
+
+用户层 API 与语义详见
+[会话 Fork 指南](./forking)。
+
+## Schema v3 → v4 migration {#schema-v3--v4-migration}
+
+Fork 功能将 `EXPECTED_SCHEMA_VERSION` 从 3 升到 4。升级会向
+`cubepi_messages` 添加 `run_id` 列 + 复合索引，并创建
+`cubepi_runs` 表。使用提供的 alembic helper —— MySQL/pymysql
+每次调用只执行一条语句，因此需要先拆分再执行：
+
+```python
+# 在迁移的 upgrade() 中：
+from cubepi.checkpointer.mysql.alembic_helpers import (
+    upgrade_v3_to_v4_op,
+    write_schema_version_op,
+)
+
+def upgrade():
+    for stmt in upgrade_v3_to_v4_op().split(";"):
+        if stmt.strip():
+            op.execute(stmt)
+    for stmt in write_schema_version_op().split(";"):
+        if stmt.strip():
+            op.execute(stmt)
+```
+
+`upgrade_v3_to_v4_op()` 在重复执行下是幂等的。升级前的旧消息
+保留 `run_id = NULL`，仍然可读；关于混合数据的 fork 资格规则，
+请参阅 [旧数据行为](./forking#legacy-data-behaviour)。
+
 ## 常见陷阱
 
 - **`CubepiSchemaUninitialized`** —— 数据库为空、迁移未执行，或 `cubepi_schema_version` 表结构有误。请先应用宿主的 alembic upgrade。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/checkpointing/postgres.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/checkpointing/postgres.md
@@ -157,9 +157,36 @@ extra = cubepi_threads.extra || EXCLUDED.extra
 
 ## Fork
 
-`parent_thread_id` + `forked_at_seq` 列是为将来的 fork 支持预留的。
-CubePi v0.3 尚未暴露 fork API——现在写入它们是为了保持 schema
-的前向兼容性。
+`parent_thread_id` + `forked_at_seq` 列用于支持
+[会话 Fork](./forking)：fork 会创建一个新的 thread，并在其
+`cubepi_threads` 行中写入指向源 thread 的 `parent_thread_id`，
+以及拷贝时源 thread 末尾的 `forked_at_seq`（最后一条已拷贝消息的
+`seq`）。
+
+## Schema v3 → v4 migration {#schema-v3--v4-migration}
+
+Fork 功能将 `EXPECTED_SCHEMA_VERSION` 从 3 升到 4。升级会向
+`cubepi_messages` 添加 `run_id` 列 + 索引，并创建分区父表
+`cubepi_runs` 及其子分区。使用 alembic helper：
+
+```python
+# 在迁移的 upgrade() 中：
+from cubepi.checkpointer.postgres.alembic_helpers import (
+    upgrade_v3_to_v4_op,
+    write_schema_version_op,
+)
+
+def upgrade():
+    op.execute(upgrade_v3_to_v4_op())
+    op.execute(write_schema_version_op())  # 将 cubepi_schema_version 升到 4
+```
+
+`upgrade_v3_to_v4_op()` 在重复执行下是幂等的（所有 DDL 都带
+`IF NOT EXISTS`）。
+
+升级前的旧消息保留 `run_id = NULL`，仍然可读；
+关于混合数据的 fork 资格规则，请参阅
+[旧数据行为](./forking#legacy-data-behaviour)。
 
 ## 常见坑
 


### PR DESCRIPTION
## Summary

Introduces conversation forking to cubepi at completed-run boundaries — the foundation cubebox needs for its "branch from this assistant reply" button and for in-memory single-turn probes.

- **`Agent.fork(after_run_id, ...)`** — persistent physical-copy fork into a new thread. Only completed runs can be forked from; orphan tool-cycles raise `ForkBoundaryError`.
- **`Agent.fork_once(after_run_id, prompt)`** — ephemeral single-turn probe against a snapshot. No checkpointer writes. Returns `ForkOnceResult(text, messages, stop_reason)`. HITL middleware/tools are rejected at construction time.
- **Per-message `run_id`** — stamped via `prompt(message, *, run_id=None) -> str` accept-or-generate. New `runs` table tracks claim/completion state with per-thread monotonic `completion_seq`.
- **Backend support** — all four checkpointers (Memory / SQLite / Postgres / MySQL) implement `claim_run`, `mark_run_complete`, `load_pending`, `snapshot`, `fork`. Schema bumped v3→v4 on the SQL backends with alembic helpers.
- **HITL safety** — `HitlBinding(checkpointed, run_id)` structural attribute on tools and middleware; `prompt()` enforces that bound channels match the active run.
- **Tool-cycle invariant** — pre-completion strict-adjacency check: each `AssistantMessage` with `tool_calls` must be immediately followed by `ToolResultMessage`s set-equal to its `tool_call_ids` (catches orphan results, partial covers, intervening user messages, duplicate ids across turns).
- **Docs + tests** — new fork guide, per-backend migration notes, CHANGELOG 0.8.0 entry, E2E tests across all backends + PG concurrency.

## Design + plan

- Spec: \`dev/specs/2026-06-05-conversation-fork.md\` (V2 R11 — codex-clean)
- Plan: \`dev/plans/2026-06-05-conversation-fork.md\` (R14 — codex-clean)

## Stats

- 73 commits (18 spec + 14 plan + 41 implementation)
- 73 files changed: +12015 / -121
- 1490 unit/integration tests passing (45 skipped — MySQL/PG infra-dependent)

## Breaking changes

None for default usage. New \`run_id\` field on Message variants defaults to \`None\`. Old v3 SQL checkpointers run in "degraded mode" (fork operations fail with \`CheckpointerError\`) until migrated; migration helpers ship in this PR.

## Test plan

- [ ] Codex review pass clean
- [ ] CI passes (pytest 3.11–3.14 + ruff + mypy)
- [ ] Postgres concurrency E2E green in CI
- [ ] MySQL E2E green against test server