### PR TITLE
refactor(agent): thread BoundModel through loop, oneshot, recorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kwargs. Direct callers (rare — this is internal to `CompactionMiddleware`)
   must wrap the pair. The public `CompactionMiddleware(summary_model=...)`
   API is unchanged.
+- **`cubepi.run_agent_loop` and `cubepi.run_agent_loop_continue` take
+  `model: BoundModel`** instead of separate `provider: Provider, model: Model`
+  kwargs. Stateless-loop callers driving the loop outside of `Agent` must
+  update. The `Agent` API is unchanged — it already took `model: BoundModel`.
 
 ### Migration
 
@@ -67,6 +71,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   # After
   await summarize(model=BoundModel(provider=provider, spec=model_spec), ...)
+  ```
+
+- Stateless-loop callers (uncommon — most users build an `Agent`):
+
+  ```python
+  # Before
+  await run_agent_loop(
+      prompts=[...],
+      context=ctx,
+      provider=provider,
+      model=model_spec,
+      convert_to_llm=...,
+      emit=...,
+  )
+
+  # After
+  await run_agent_loop(
+      prompts=[...],
+      context=ctx,
+      model=provider.model("id", ...),
+      convert_to_llm=...,
+      emit=...,
+  )
   ```
 
 ## [0.8.0] - 2026-06-06

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -37,7 +37,6 @@ from cubepi.providers.base import (
     Model,
     OnPayloadCallback,
     OnResponseCallback,
-    Provider,
     StreamOptions,
     TextContent,
     ThinkingLevel,
@@ -162,7 +161,6 @@ class Agent(Generic[TMessage]):
         channel: HitlChannel | None = None,
         messages: Sequence[Message] | None = None,
     ) -> None:
-        self._provider: Provider = model.provider
         self._model = model
         self._state = AgentState(
             system_prompt=system_prompt,
@@ -661,8 +659,7 @@ class Agent(Generic[TMessage]):
             lambda signal: run_agent_loop(
                 prompts=messages,
                 context=self._create_context_snapshot(),
-                provider=self._provider,
-                model=self._state.model,
+                model=self._model,
                 convert_to_llm=self.convert_to_llm,
                 transform_context=self.transform_context,
                 transform_system_prompt=self.transform_system_prompt,
@@ -685,8 +682,7 @@ class Agent(Generic[TMessage]):
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop_continue(
                 context=self._create_context_snapshot(),
-                provider=self._provider,
-                model=self._state.model,
+                model=self._model,
                 convert_to_llm=self.convert_to_llm,
                 transform_context=self.transform_context,
                 transform_system_prompt=self.transform_system_prompt,
@@ -956,8 +952,7 @@ class Agent(Generic[TMessage]):
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop_resume(
                 context=self._create_context_snapshot(),
-                provider=self._provider,
-                model=self._state.model,
+                model=self._model,
                 convert_to_llm=self.convert_to_llm,
                 transform_context=self.transform_context,
                 transform_system_prompt=self.transform_system_prompt,

--- a/cubepi/agent/loop.py
+++ b/cubepi/agent/loop.py
@@ -20,9 +20,8 @@ from cubepi.hitl.exceptions import HitlAborted, HitlDetached
 from cubepi.utils import emit_event
 from cubepi.providers.base import (
     AssistantMessage,
+    BoundModel,
     Message,
-    Model,
-    Provider,
     StreamOptions,
     ToolCall,
     ToolResultMessage,
@@ -33,8 +32,7 @@ async def run_agent_loop(
     *,
     prompts: list[Message],
     context: AgentContext,
-    provider: Provider,
-    model: Model,
+    model: BoundModel,
     convert_to_llm: Callable,
     emit: Callable,
     transform_context: Callable | None = None,
@@ -70,7 +68,6 @@ async def run_agent_loop(
     await _run_loop(
         current_context=current_context,
         new_messages=new_messages,
-        provider=provider,
         model=model,
         convert_to_llm=convert_to_llm,
         transform_context=transform_context,
@@ -93,8 +90,7 @@ async def run_agent_loop(
 async def run_agent_loop_continue(
     *,
     context: AgentContext,
-    provider: Provider,
-    model: Model,
+    model: BoundModel,
     convert_to_llm: Callable,
     emit: Callable,
     transform_context: Callable | None = None,
@@ -130,7 +126,6 @@ async def run_agent_loop_continue(
     await _run_loop(
         current_context=current_context,
         new_messages=new_messages,
-        provider=provider,
         model=model,
         convert_to_llm=convert_to_llm,
         transform_context=transform_context,
@@ -153,8 +148,7 @@ async def run_agent_loop_continue(
 async def run_agent_loop_resume(
     *,
     context: AgentContext,
-    provider: Provider,
-    model: Model,
+    model: BoundModel,
     convert_to_llm: Callable,
     emit: Callable,
     transform_context: Callable | None = None,
@@ -178,7 +172,6 @@ async def run_agent_loop_resume(
     try:
         return await _run_agent_loop_resume_body(
             context=context,
-            provider=provider,
             model=model,
             convert_to_llm=convert_to_llm,
             emit=emit,
@@ -218,7 +211,6 @@ async def run_agent_loop_resume(
 async def _run_agent_loop_resume_body(  # pragma: no cover — E2E tested
     *,
     context,
-    provider,
     model,
     convert_to_llm,
     emit,
@@ -372,7 +364,6 @@ async def _run_agent_loop_resume_body(  # pragma: no cover — E2E tested
     await _run_loop(
         current_context=current_context,
         new_messages=new_messages,
-        provider=provider,
         model=model,
         convert_to_llm=convert_to_llm,
         transform_context=transform_context,
@@ -396,8 +387,7 @@ async def _run_loop(
     *,
     current_context: AgentContext,
     new_messages: list[Message],
-    provider: Provider,
-    model: Model,
+    model: BoundModel,
     convert_to_llm: Callable,
     transform_context: Callable | None,
     transform_system_prompt: Callable | None,
@@ -417,7 +407,6 @@ async def _run_loop(
         await _run_loop_inner(
             current_context=current_context,
             new_messages=new_messages,
-            provider=provider,
             model=model,
             convert_to_llm=convert_to_llm,
             transform_context=transform_context,
@@ -454,8 +443,7 @@ async def _run_loop_inner(
     *,
     current_context: AgentContext,
     new_messages: list[Message],
-    provider: Provider,
-    model: Model,
+    model: BoundModel,
     convert_to_llm: Callable,
     transform_context: Callable | None,
     transform_system_prompt: Callable | None,
@@ -496,7 +484,6 @@ async def _run_loop_inner(
 
             message = await _stream_assistant_response(
                 current_context,
-                provider,
                 model,
                 convert_to_llm,
                 transform_context,
@@ -696,8 +683,7 @@ async def _run_loop_inner(
 
 async def _stream_assistant_response(
     context: AgentContext,
-    provider: Provider,
-    model: Model,
+    model: BoundModel,
     convert_to_llm: Callable,
     transform_context: Callable | None,
     transform_system_prompt: Callable | None,
@@ -720,8 +706,7 @@ async def _stream_assistant_response(
     if transform_system_prompt:
         sp = await transform_system_prompt(sp, ctx=context, signal=options.signal)
 
-    stream = await provider.stream(
-        model,
+    stream = await model.stream(
         llm_messages,
         system_prompt=sp,
         tools=tools_defs,

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -103,9 +103,15 @@ class BoundModel:
         tools: list[ToolDefinition] | None = None,
         options: StreamOptions | None = None,
     ) -> MessageStream:
+        # Forward ``model`` and ``messages`` positionally so a custom
+        # provider that follows the protocol shape but uses different
+        # parameter names (e.g. ``model_spec``, ``msgs``) keeps working —
+        # the pre-BoundModel loop also called ``provider.stream(model,
+        # messages, ...)`` positionally. The remaining args sit after
+        # ``*`` in the protocol so they must stay keyword.
         return await self.provider.stream(
-            model=self.spec,
-            messages=messages,
+            self.spec,
+            messages,
             system_prompt=system_prompt,
             tools=tools,
             options=options,
@@ -123,9 +129,10 @@ class BoundModel:
         thinking: ThinkingLevel | None = None,
         thinking_budgets: ThinkingBudgets | None = None,
     ) -> AssistantMessage:
+        # Same positional-forwarding rationale as ``stream`` above.
         return await self.provider.generate(
-            model=self.spec,
-            messages=messages,
+            self.spec,
+            messages,
             system_prompt=system_prompt,
             tools=tools,
             options=options,

--- a/cubepi/tracing/meter.py
+++ b/cubepi/tracing/meter.py
@@ -174,7 +174,12 @@ class Meter:
             self._handle_provider_response(state, body, model, exc)
 
         unsub_agent = agent.subscribe(_on_agent_event)
-        provider = getattr(agent, "_provider", None) or getattr(agent, "provider", None)
+        agent_model = getattr(agent, "_model", None)
+        provider = (
+            agent_model.provider
+            if agent_model is not None
+            else getattr(agent, "provider", None)
+        )
         detachers: list[Callable[[], None]] = []
         if isinstance(provider, BaseProvider):
             detachers.append(provider.subscribe_request(_on_request))

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -236,10 +236,15 @@ class Recorder:
 
         self._agent = agent
         unsub_agent = agent.subscribe(self._on_agent_event)
-        # ``Agent`` stores the provider as a private attribute; accept
-        # either the (private) ``_provider`` or a public ``provider``
+        # ``Agent`` holds the bound model on ``_model``; the provider is
+        # reached via ``_model.provider``. Fall back to a public ``provider``
         # alias should one be added later.
-        provider = getattr(agent, "_provider", None) or getattr(agent, "provider", None)
+        agent_model = getattr(agent, "_model", None)
+        provider = (
+            agent_model.provider
+            if agent_model is not None
+            else getattr(agent, "provider", None)
+        )
         provider_detachers: list[Callable[[], None]] = []
 
         def _subscribe(p: Any) -> None:
@@ -289,12 +294,12 @@ class Recorder:
                     extra = list(mw.extra_llm_calls())
                 except Exception:
                     extra = []
-                for bound in extra:
-                    spec = bound.spec
+                for model in extra:
+                    spec = model.spec
                     key = (spec.provider_id, spec.id)
                     if key != agent_key:
                         self._extra_call_models.add(key)
-                    provider = bound.provider
+                    provider = model.provider
                     if id(provider) in seen:
                         continue
                     seen.add(id(provider))

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -30,7 +30,7 @@ from cubepi.tracing.schema import SCHEMA_URL, SCOPE_NAME
 
 if TYPE_CHECKING:
     from cubepi.agent.agent import Agent
-    from cubepi.providers.base import BoundModel, Message, Model, Provider
+    from cubepi.providers.base import BoundModel, Message
 
 
 class _OneShotSession:
@@ -43,11 +43,9 @@ class _OneShotSession:
 
     def __init__(
         self,
-        provider: "Provider",
-        model: "Model",
+        model: "BoundModel",
         run: Any,
     ) -> None:
-        self._provider = provider
         self._model = model
         self._run = run
 
@@ -87,8 +85,7 @@ class _OneShotSession:
         abort_signal = _asyncio.Event()
 
         try:
-            response = await self._provider.generate(
-                model=self._model,
+            response = await self._model.generate(
                 messages=messages,
                 system_prompt=system,
                 options=_StreamOptions(signal=abort_signal),
@@ -474,7 +471,6 @@ class Tracer:
         )
         run_id = str(uuid.uuid4())
         provider = model.provider
-        model_spec = model.spec
 
         root_attrs: dict[str, Any] = {
             GEN_AI_OPERATION_NAME: OP_INVOKE_AGENT,
@@ -570,7 +566,7 @@ class Tracer:
         # calls that belong to this oneshot session.
         token = _active_run.set(run)
         try:
-            yield _OneShotSession(provider=provider, model=model_spec, run=run)
+            yield _OneShotSession(model=model, run=run)
         except BaseException as _exc:
             # Mark the root span as failed so `cubepi trace ls` (which
             # reads status off the root) lists this run as an error

--- a/dev/plans/2026-06-08-loop-boundmodel.md
+++ b/dev/plans/2026-06-08-loop-boundmodel.md
@@ -1,0 +1,358 @@
+# Loop BoundModel Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans or superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Push `BoundModel` through `cubepi/agent/loop.py` and its consumers (`Agent`, `tracer.oneshot`'s `_OneShotSession`, the recorder cleanup, the loop tests) in one atomic refactor, so the only places that still see a bare `Model` are the `Provider` protocol / impls and the serializable `AgentState.model` field.
+
+**Architecture:** Collapse `provider: Provider, model: Model` → `model: BoundModel` across six loop function signatures (`run_agent_loop`, `run_agent_loop_continue`, `run_agent_loop_resume`, `_run_loop`, `_run_loop_inner`, `_stream_assistant_response`). The single in-body provider call (`provider.stream(...)` at `loop.py:723`) becomes `model.stream(...)` via the `BoundModel.stream` convenience added in #154. All consumers (`Agent.__init__` + three loop call sites, `_OneShotSession` and `tracer.oneshot`, the `recorder.py for bound in extra` rename, `tests/agent/test_loop.py` direct call sites) flip in the same commit. Tests stay green at every commit boundary.
+
+**Tech Stack:** Python 3.11+, dataclasses, `BoundModel` (added in #154), pytest with `asyncio_mode=auto`, `FauxProvider` for deterministic tests, ruff, mypy.
+
+---
+
+## File Structure
+
+- **Modify** `cubepi/agent/loop.py` — six function signatures lose `provider: Provider`, gain `model: BoundModel`; one body call (line 723) flips to `model.stream(...)`; `Provider` / `Model` imports drop.
+- **Modify** `cubepi/agent/agent.py` — remove `self._provider: Provider = model.provider` (line 165); the three loop call sites (664, 688, 959) replace `provider=self._provider, model=self._state.model` with `model=self._model`; `Provider` import drops if unused.
+- **Modify** `cubepi/tracing/tracer.py` — `_OneShotSession` dataclass (~line 36) holds `BoundModel` instead of split `provider` + `model`; `_OneShotSession.generate` calls `bound.generate(...)`; the `oneshot()` body (`provider = model.provider; model_spec = model.spec`; `_OneShotSession(provider=..., model=model_spec, ...)`) simplifies to pass the `BoundModel` through.
+- **Modify** `cubepi/tracing/recorder.py:292` — rename `for bound in extra` → `for model in extra`, plus the local `spec = bound.spec` / `provider = bound.provider` → `spec = model.spec` / `provider = model.provider`. (Cosmetic, per `feedback_boundmodel_naming` convention.)
+- **Modify** `tests/agent/test_loop.py` — delete the `make_model()` helper; every `provider = FauxProvider(); ... provider=provider, model=make_model()` block becomes `provider = FauxProvider(provider_id="faux"); ... model=provider.model("faux-1")`. Drop unused `Model` import if applicable.
+- **Modify** `CHANGELOG.md` `[Unreleased]` — Breaking + Migration entries for the two publicly exported functions (`cubepi.run_agent_loop`, `cubepi.run_agent_loop_continue`).
+- **Modify** `website/docs/api/*.mdx` — regenerate via `pnpm apiref` since the `cubepi` top-level surface changed.
+
+---
+
+## Task 1: Atomic BoundModel migration (loop + agent + tracer + recorder + tests)
+
+**Why atomic:** `loop.py` is the producer of the new signature; `Agent`, `_OneShotSession`, the loop tests, and (cosmetically) the recorder all consume. Splitting these commits would leave any intermediate commit with broken tests. Same rationale as Task 3 in the #154 plan.
+
+- [ ] **Step 0: Confirm scope by greppping for any external callers we'd miss**
+
+```bash
+cd /home/chris/cubepi/.worktrees/2026-06-08-loop-boundmodel
+grep -rn "run_agent_loop\|_run_loop\|_stream_assistant_response\|_OneShotSession" cubepi/ tests/ examples/ --include="*.py"
+```
+
+Expected hits: `cubepi/__init__.py` (re-exports), `cubepi/agent/__init__.py` (re-exports), `cubepi/agent/agent.py` (callers), `cubepi/agent/loop.py` (definitions), `cubepi/tracing/tracer.py` (`_OneShotSession`), `tests/agent/test_loop.py` (direct callers). If anything else shows up (e.g. an example script using `run_agent_loop` directly), fold it into the migration.
+
+- [ ] **Step 1: Baseline test run**
+
+```bash
+uv run pytest tests/ -x 2>&1 | tail -3
+```
+
+Expected: PASS. Record the totals — must be the same after Task 1.
+
+- [ ] **Step 2: Migrate `cubepi/agent/loop.py` signatures + body**
+
+Edit each of the six functions: replace `provider: Provider,` + `model: Model,` (two lines) with `model: BoundModel,` (one line). Then in `_stream_assistant_response` (around line 723), replace:
+
+```python
+stream = await provider.stream(
+    model=model,
+    messages=messages,
+    system_prompt=system_prompt,
+    tools=tools,
+    options=options,
+)
+```
+
+with:
+
+```python
+stream = await model.stream(
+    messages=messages,
+    system_prompt=system_prompt,
+    tools=tools,
+    options=options,
+)
+```
+
+Update imports at the top of the file: drop `Model` and `Provider` from the `cubepi.providers.base` import line, add `BoundModel`. Verify with `grep -n "Provider\b\|Model\b" cubepi/agent/loop.py` — after editing, neither bare name should appear in the file body (only as `BoundModel`).
+
+Internal call sites between the six functions: each `_run_loop`/`_run_loop_inner` call previously passed `provider=provider, model=model` — switch to `model=model` (the BoundModel parameter).
+
+- [ ] **Step 3: Migrate `cubepi/agent/agent.py`**
+
+Three changes in `agent.py`:
+
+**(a)** Drop `self._provider: Provider = model.provider` (line 165). The `self._model` field already holds the same provider via `self._model.provider`.
+
+**(b)** Update the three loop call sites (around lines 664, 688, 959). Currently each looks like:
+
+```python
+lambda signal: run_agent_loop(
+    ...
+    provider=self._provider,
+    model=self._state.model,
+    ...
+)
+```
+
+Replace with:
+
+```python
+lambda signal: run_agent_loop(
+    ...
+    model=self._model,
+    ...
+)
+```
+
+(`self._state.model` was the spec; `self._model` is the `BoundModel` — that's the source of truth post-migration.)
+
+**(c)** Drop `Provider` from imports if no longer used (verify with `grep -n "Provider\b" cubepi/agent/agent.py` — only `BaseProvider`-style names should remain, if any).
+
+`self._state.model = model.spec` at construction (around line 169) stays as-is. The `AgentState.model: Model` field stays as-is. (Design point 1 in the spec.)
+
+- [ ] **Step 4: Migrate `_OneShotSession` + `tracer.oneshot()`**
+
+In `cubepi/tracing/tracer.py`, `_OneShotSession` (around line 36) is a dataclass holding `provider` + `model` + `run`. Change to hold a single `model: BoundModel` + `run`. Find the call sites:
+
+- `_OneShotSession.generate(...)` body: replace internal `provider.generate(...)` (currently passes `model=self.model`) with `self.model.generate(...)`.
+- `Tracer.oneshot()` (around line 419): the lines `provider = model.provider; model_spec = model.spec` and the `_OneShotSession(provider=provider, model=model_spec, run=run)` instantiation. Replace with `_OneShotSession(model=model, run=run)`. Drop the two local variables.
+
+The public `Tracer.oneshot(*, model: BoundModel, ...)` signature is unchanged — only internals migrate.
+
+- [ ] **Step 5: Rename `for bound in extra` → `for model in extra` in recorder**
+
+In `cubepi/tracing/recorder.py:292`, the current block:
+
+```python
+for bound in extra:
+    spec = bound.spec
+    key = (spec.provider_id, spec.id)
+    if key != agent_key:
+        self._extra_call_models.add(key)
+    provider = bound.provider
+    if id(provider) in seen:
+        continue
+    seen.add(id(provider))
+    _subscribe(provider)
+```
+
+becomes:
+
+```python
+for model in extra:
+    spec = model.spec
+    key = (spec.provider_id, spec.id)
+    if key != agent_key:
+        self._extra_call_models.add(key)
+    provider = model.provider
+    if id(provider) in seen:
+        continue
+    seen.add(id(provider))
+    _subscribe(provider)
+```
+
+Pure cosmetic — no behavior change. Matches the `feedback_boundmodel_naming` convention. No imports change.
+
+- [ ] **Step 6: Migrate `tests/agent/test_loop.py` to the new signature**
+
+Two edits:
+
+**(a)** Delete the `make_model()` helper (lines 29–30).
+
+**(b)** Every test method has a block like:
+
+```python
+provider = FauxProvider()
+# ...
+result = await run_agent_loop(
+    ...
+    provider=provider,
+    model=make_model(),
+    ...
+)
+```
+
+Change to:
+
+```python
+provider = FauxProvider(provider_id="faux")
+# ...
+result = await run_agent_loop(
+    ...
+    model=provider.model("faux-1"),
+    ...
+)
+```
+
+Drop `Model` from the top-level `cubepi.providers.base` import if it's no longer referenced elsewhere in the file (verify with `grep -n "\bModel\b" tests/agent/test_loop.py`).
+
+- [ ] **Step 7: Run the affected suites, then the full sweep + lint + types**
+
+```bash
+uv run pytest tests/agent/ tests/tracing/ -v 2>&1 | tail -10
+```
+
+Expected: PASS. Specifically `tests/agent/test_loop.py` should report the same number of tests passing as before.
+
+```bash
+uv run pytest tests/ -x 2>&1 | tail -3
+uv run ruff check cubepi/ tests/
+uv run ruff format --check cubepi/ tests/
+uv run mypy cubepi
+```
+
+Expected: all green. If ruff format flags reformatting, run `uv run ruff format cubepi/ tests/` then re-check.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cubepi/agent/loop.py cubepi/agent/agent.py cubepi/tracing/tracer.py cubepi/tracing/recorder.py tests/agent/test_loop.py
+git commit -m "refactor(agent): thread BoundModel through loop, agent, oneshot, recorder"
+```
+
+---
+
+## Task 2: CHANGELOG
+
+- [ ] **Step 1: Add Breaking + Migration entries under `[Unreleased]`**
+
+In `CHANGELOG.md`, extend the existing `[Unreleased]` block (which already contains the BoundModel.generate/stream + extra_llm_calls entries from #154) with one new `Breaking` bullet:
+
+```markdown
+- **`cubepi.run_agent_loop` and `cubepi.run_agent_loop_continue` take
+  `model: BoundModel`** instead of separate `provider: Provider, model: Model`
+  kwargs. The stateless-loop entry points used by callers who drive the loop
+  outside of `Agent` must update. The `Agent` API is unchanged — it has always
+  taken `model: BoundModel`.
+```
+
+And one new `Migration` example:
+
+```markdown
+- Stateless-loop callers (uncommon — most users build an `Agent`):
+
+  ```python
+  # Before
+  await run_agent_loop(
+      prompts=[...],
+      context=ctx,
+      provider=provider,
+      model=model_spec,
+      convert_to_llm=...,
+      emit=...,
+  )
+
+  # After
+  await run_agent_loop(
+      prompts=[...],
+      context=ctx,
+      model=provider.model("id", ...),
+      convert_to_llm=...,
+      emit=...,
+  )
+  ```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): record run_agent_loop BoundModel migration"
+```
+
+---
+
+## Task 3: Regenerate API reference docs
+
+- [ ] **Step 1: Run apiref**
+
+```bash
+cd website && pnpm apiref 2>&1 | tail -10 && cd -
+```
+
+Expected: a handful of `website/docs/api/*.mdx` files update — at minimum `cubepi.mdx` (signature of `run_agent_loop` / `run_agent_loop_continue`) and `cubepi-middleware.mdx` (which had a stale `extra_llm_calls() -> Iterable[tuple[Provider, Model]]` line from #154 that this regen also fixes).
+
+- [ ] **Step 2: Verify the stale references are gone**
+
+```bash
+grep -rn "extra_llm_calls.*tuple\|tuple\[Provider, Model\]\|provider: Provider,\s*model: Model" website/docs/api/
+```
+
+Expected: no hits.
+
+- [ ] **Step 3: Diff sanity check + commit**
+
+```bash
+git status website/docs/api/
+git diff --stat website/docs/api/
+```
+
+Confirm the diff only touches the expected mdx files (signatures involving `run_agent_loop*`, `extra_llm_calls`, and possibly `oneshot`).
+
+```bash
+git add website/docs/api/
+git commit -m "docs(apiref): regenerate after BoundModel loop migration"
+```
+
+---
+
+## Task 4: Open PR + PR codex review loop
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin 2026-06-08-loop-boundmodel
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "refactor(agent): thread BoundModel through loop, oneshot, recorder" --body "$(cat <<'EOF'
+## Summary
+
+- Migrate `cubepi/agent/loop.py` (6 function signatures) from `provider: Provider, model: Model` → `model: BoundModel`. The single in-body `provider.stream(...)` flips to `model.stream(...)` via the convenience added in #154.
+- `Agent.__init__` drops the redundant `self._provider` field; three loop call sites pass `model=self._model` instead of the split pair. `AgentState.model: Model` field unchanged — it stays serializable for the checkpointer.
+- `_OneShotSession` (used by `tracer.oneshot()`) holds a `BoundModel` internally; `oneshot()` no longer extracts `provider` / `model_spec` separately.
+- Recorder cleanup: `for bound in extra` → `for model in extra` per the `feedback_boundmodel_naming` convention.
+- `tests/agent/test_loop.py` migrated; `make_model()` helper removed in favor of inline `provider.model("faux-1")`.
+- API reference regenerated.
+
+## Workflow
+
+- Spec at `dev/specs/2026-06-08-loop-boundmodel.md` (user-confirmed design: AgentState.model stays Model, resume trusts caller, OneShot migrates lock-step).
+- Plan at `dev/plans/2026-06-08-loop-boundmodel.md`.
+- Per user direction, skipped local codex review on spec/plan/code — going straight to PR codex review.
+
+## Breaking
+
+`cubepi.run_agent_loop` and `cubepi.run_agent_loop_continue` change signature. See `CHANGELOG.md` Breaking + Migration sections under `[Unreleased]`.
+
+## Test plan
+
+- [x] `uv run pytest tests/`
+- [x] `uv run ruff check cubepi/ tests/`
+- [x] `uv run ruff format --check cubepi/ tests/`
+- [x] `uv run mypy cubepi`
+EOF
+)"
+```
+
+- [ ] **Step 3: Enter PR codex review loop**
+
+Poll the PR every ~2 minutes; for every codex finding, evaluate against project policy (`feedback_breaking_no_shim`, `feedback_boundmodel_naming`), fix or push back with rationale, push commit(s), reply `@codex review again`. Repeat until clean. Merge after CI + codex both green.
+
+---
+
+## Self-Review
+
+1. **Spec coverage** — every spec scope item maps to a Task 1 step:
+   - Loop six function migration → Step 2.
+   - Agent: drop `_provider`, three call sites → Step 3.
+   - `_OneShotSession` + `tracer.oneshot()` → Step 4.
+   - Recorder rename → Step 5.
+   - `tests/agent/test_loop.py` migration → Step 6.
+   - CHANGELOG → Task 2.
+   - apiref → Task 3.
+2. **Atomicity** — Task 1 is one commit covering loop + agent + tracer + recorder + tests; producer/consumer flip together so `pytest -x` stays green at every commit boundary.
+3. **Placeholders** — none. Every step has the actual code change or a concrete grep / pytest / commit command.
+4. **Naming convention** — every variable rename and parameter name uses `model: BoundModel` per `feedback_boundmodel_naming`. No leftover `bound` / `bound_model`.
+5. **Out of scope** — Provider protocol & impls, `AgentState` shape, `Model` rename, mid-run model swap. All match the spec.
+
+## Follow-ups (out of scope)
+
+None for this work. The original Follow-up #2 from the #154 plan is what this plan executes; no further follow-ups required.

--- a/dev/specs/2026-06-08-loop-boundmodel.md
+++ b/dev/specs/2026-06-08-loop-boundmodel.md
@@ -1,0 +1,179 @@
+# Spec: Thread `BoundModel` through the agent loop
+
+**Status:** Draft → user-confirmed design points 2026-06-08.
+
+## Goal
+
+Make `cubepi/agent/loop.py` (and its callers in `Agent` and
+`cubepi/tracing/tracer.py`) take a single `BoundModel` instead of a
+`provider: Provider, model: Model` pair. After this change, the only
+places that still see a bare `Model` are:
+
+- `Provider` protocol / built-in provider implementations (correctly so —
+  providers are below the binding layer).
+- `AgentState.model` field (serialized; provider can't be pickled).
+- Tracing recorder reading `model.id` / `model.provider_id` off bound
+  models or state.
+
+User-facing code (Agent construction, middleware, examples, custom loop
+drivers) can stop carrying the unwrapped pair.
+
+## Why now
+
+The 2026-06-08 BoundModel-methods PR (#154, merged as `e917128`) added
+`BoundModel.generate()` / `BoundModel.stream()` and migrated
+`Middleware.extra_llm_calls()` to return `Iterable[BoundModel]`. That left
+`agent/loop.py` as the last load-bearing surface still threading the
+unwrapped pair. The follow-up note in
+`dev/plans/2026-06-08-boundmodel-convenience-methods.md` flagged this
+explicitly.
+
+## Prior art notes
+
+- **langgraph** and **claude-code** use string ids + a global provider
+  registry ("anthropic:claude-3-5-sonnet"). cubepi 0.8 deliberately chose
+  the opposite — explicit `provider.model("id")` binding, no registry — so
+  spec stays serializable and there's no global state. This spec preserves
+  that choice; we only push the existing `BoundModel` deeper into the
+  internals.
+- **pi-agent-core** has no analog of `BoundModel`; its loop takes a
+  pre-bound callable. cubepi keeps explicit types instead of opaque
+  closures, but the runtime effect is similar.
+
+## Design points (user-confirmed 2026-06-08)
+
+1. **`AgentState.model: Model` stays as-is.** State is part of the
+   checkpointer schema; changing its shape forces a schema migration.
+   Loop call sites in `Agent` switch from `model=self._state.model` to
+   passing `self._model` (the `BoundModel`). The state's `model` field
+   remains as a historical / debug record of which spec was used.
+
+2. **Resume trusts the caller.** When the Agent restores from
+   checkpointer, `self._state.model` carries the original spec but
+   `self._model: BoundModel` (set at `__init__`) is the source of truth
+   for the next loop iteration. No mismatch check — the Agent's current
+   `BoundModel` runs; the state's spec is treated as an archived value.
+   If a caller reconstructs an Agent with a different model after
+   restart, that's an intentional model swap and the loop honors it.
+
+3. **`_OneShotSession` migrates in lock-step.** `tracer.oneshot()` already
+   takes a `BoundModel` at its public boundary; finish the migration by
+   making `_OneShotSession` itself hold a `BoundModel` (drops the
+   `provider=..., model=model_spec` constructor split inside
+   `tracer.py:573`).
+
+## Scope
+
+### In scope
+
+- `cubepi/agent/loop.py`: collapse `provider: Provider, model: Model`
+  into `model: BoundModel` across the six function surfaces:
+  - `run_agent_loop` (public)
+  - `run_agent_loop_continue` (public)
+  - `run_agent_loop_resume` (internal — not in top-level `__all__`)
+  - `_run_loop` (private)
+  - `_run_loop_inner` (private)
+  - `_stream_assistant_response` (private)
+  - Bodies: replace `await provider.stream(model=spec, ...)` etc. with
+    `await model.stream(...)` / `await model.generate(...)`.
+- `cubepi/agent/agent.py`:
+  - Remove `self._provider: Provider = model.provider` (line 165) — the
+    field becomes redundant once loop takes `BoundModel`.
+  - Replace three loop call sites (664, 688, 959): drop
+    `provider=self._provider, model=self._state.model`, pass
+    `model=self._model` instead.
+  - Keep `self._state.model = model.spec` at construction (line 169) and
+    leave `AgentState.model` typed `Model` — see Design point 1.
+- `cubepi/tracing/tracer.py:573`:
+  - Migrate `_OneShotSession` (defined at `tracer.py:36`) to hold
+    `BoundModel`. `_OneShotSession.generate` switches from internal
+    `provider.generate(model=spec, ...)` to `bound.generate(...)`.
+  - `oneshot()` no longer needs `provider = model.provider; model_spec =
+    model.spec` (lines 477, 573).
+- `cubepi/tracing/recorder.py:292`: rename `for bound in extra` to
+  `for model in extra` per the BoundModel naming convention recorded in
+  the `feedback_boundmodel_naming` memory. Update the local variables
+  (`spec = model.spec`, `provider = model.provider`) to match.
+- `tests/agent/test_loop.py`: migrate direct `run_agent_loop(...)` /
+  `run_agent_loop_continue(...)` call sites to the new signature
+  (`provider=..., model=...` → `model=bound`).
+- `CHANGELOG.md` `[Unreleased]`: Breaking + Migration entries for the two
+  publicly exported functions (`run_agent_loop`,
+  `run_agent_loop_continue`).
+- Docs: regenerate API reference (`pnpm apiref`) since the `cubepi`
+  top-level module surface changed.
+
+### Out of scope
+
+- `Provider` protocol and built-in provider implementations
+  (`anthropic.py`, `openai.py`, `openai_responses.py`, `faux.py`) — they
+  correctly take `model: Model` (the spec) because providers operate
+  below the binding layer.
+- `cubepi/providers/models.py` helpers — operate on `Model` (the spec).
+- `AgentState` shape / checkpointer schema — Design point 1.
+- Mid-run model swap APIs (e.g., `agent.set_model(...)`) — out of
+  scope; `self._model` remains set-once at `__init__`.
+- Provider registry / string-id resolution (langgraph style) — explicitly
+  rejected at 0.8 and reaffirmed here.
+
+## Breaking surface
+
+Two publicly exported functions change signature:
+
+- `cubepi.run_agent_loop`
+- `cubepi.run_agent_loop_continue`
+
+Both lose the `provider: Provider` keyword and replace `model: Model`
+with `model: BoundModel`. Callers using these stateless-loop entry
+points (uncommon — most users build `Agent` instances) must update.
+This is the same shape of breakage as the
+`Middleware.extra_llm_calls() -> Iterable[BoundModel]` change in #154:
+documented in `CHANGELOG.md` under Breaking + Migration, no
+backwards-compat shim per project policy
+(`feedback_breaking_no_shim`).
+
+Migration for callers:
+
+```python
+# Before
+await run_agent_loop(
+    prompts=[...],
+    context=ctx,
+    provider=provider,
+    model=model_spec,
+    convert_to_llm=...,
+    emit=...,
+    ...
+)
+
+# After
+await run_agent_loop(
+    prompts=[...],
+    context=ctx,
+    model=provider.model("id", ...),
+    convert_to_llm=...,
+    emit=...,
+    ...
+)
+```
+
+(`run_agent_loop_resume` also changes signature but is not in
+`cubepi/__init__.py`'s top-level `__all__`, so it's not a public API
+break — internal callers in `agent.py` migrate together.)
+
+## Naming convention
+
+Per `feedback_boundmodel_naming`: inside the framework, name `BoundModel`
+parameters and locals `model` (not `bound`). Call sites read
+`await model.generate(...)` / `await model.stream(...)`, matching the
+public `Agent(model=...)` / `provider.model(...)` ergonomics. This
+includes the `recorder.py` `for bound in extra` cleanup.
+
+## Non-goals / explicitly-not-changing
+
+- `Model` (the spec class) name. Renaming to `ModelSpec` for clarity
+  was discussed and deferred — the churn cost outweighs the naming
+  benefit, and `Model` / `BoundModel` is a recognizable "data class vs
+  runtime handle" pair (cf. `URL` vs `URLConnection`).
+- Public `Model` constructor — direct use of `Model(...)` remains
+  valid (custom providers, test fixtures, advanced flows).

--- a/tests/agent/test_loop.py
+++ b/tests/agent/test_loop.py
@@ -13,6 +13,7 @@ from cubepi.agent.types import (
 )
 from cubepi.providers.base import (
     AssistantMessage,
+    BoundModel,
     Message,
     MessageStream,
     Model,
@@ -24,10 +25,6 @@ from cubepi.providers.base import (
     UserMessage,
 )
 from cubepi.providers.faux import FauxProvider, faux_assistant_message, faux_tool_call
-
-
-def make_model() -> Model:
-    return Model(id="faux-1", provider_id="faux")
 
 
 def make_user_message(text: str) -> UserMessage:
@@ -62,7 +59,7 @@ def make_echo_tool(*, execution_mode=None, execute_fn=None) -> AgentTool:
 
 class TestAgentLoop:
     async def test_emit_events_with_agent_message_types(self):
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses([faux_assistant_message("Hi there!")])
         context = AgentContext(system_prompt="You are helpful.", messages=[], tools=[])
         user_prompt = make_user_message("Hello")
@@ -71,8 +68,7 @@ class TestAgentLoop:
         messages = await run_agent_loop(
             prompts=[user_prompt],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             emit=lambda e: events.append(e),
         )
@@ -90,7 +86,7 @@ class TestAgentLoop:
         assert "agent_end" in event_types
 
     async def test_custom_message_types_via_convert_to_llm(self):
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses([faux_assistant_message("Response")])
 
         notification = {"role": "notification", "text": "info"}
@@ -116,8 +112,7 @@ class TestAgentLoop:
         await run_agent_loop(
             prompts=[user_prompt],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=converter,
             emit=lambda e: None,
         )
@@ -126,7 +121,7 @@ class TestAgentLoop:
         assert converted[0].role == "user"
 
     async def test_transform_context_before_convert_to_llm(self):
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses([faux_assistant_message("Response")])
 
         context = AgentContext(
@@ -157,8 +152,7 @@ class TestAgentLoop:
         await run_agent_loop(
             prompts=[make_user_message("new")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=converter,
             transform_context=transform,
             emit=lambda e: None,
@@ -177,7 +171,7 @@ class TestAgentLoop:
             )
 
         tool = make_echo_tool(execute_fn=echo_execute)
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses(
             [
                 faux_assistant_message(
@@ -194,8 +188,7 @@ class TestAgentLoop:
         await run_agent_loop(
             prompts=[make_user_message("echo something")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             emit=lambda e: events.append(e),
         )
@@ -215,7 +208,7 @@ class TestAgentLoop:
         from cubepi.providers.base import ToolCall
 
         tool = make_echo_tool()
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses(
             [
                 faux_assistant_message(
@@ -239,8 +232,7 @@ class TestAgentLoop:
         result = await run_agent_loop(
             prompts=[make_user_message("echo something")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             emit=lambda e: None,
             after_model_response=inject_on_toolcall,
@@ -265,7 +257,7 @@ class TestAgentLoop:
 
     async def test_should_stop_after_turn(self):
         tool = make_echo_tool()
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses(
             [
                 faux_assistant_message(
@@ -287,8 +279,7 @@ class TestAgentLoop:
         messages = await run_agent_loop(
             prompts=[make_user_message("echo something")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             should_stop_after_turn=should_stop,
             emit=lambda e: events.append(e),
@@ -307,7 +298,7 @@ class TestAgentLoop:
             return AgentToolResult(content=[TextContent(text=f"ok:{params.value}")])
 
         tool = make_echo_tool(execute_fn=echo_execute)
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses(
             [
                 faux_assistant_message(
@@ -335,8 +326,7 @@ class TestAgentLoop:
         await run_agent_loop(
             prompts=[make_user_message("start")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             get_steering_messages=get_steering,
             tool_execution="sequential",
@@ -350,7 +340,7 @@ class TestAgentLoop:
             return AgentToolResult(content=[TextContent(text="done")], terminate=True)
 
         tool = make_echo_tool(execute_fn=term_execute)
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses(
             [
                 faux_assistant_message(
@@ -364,8 +354,7 @@ class TestAgentLoop:
         messages = await run_agent_loop(
             prompts=[make_user_message("echo something")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             emit=lambda e: None,
         )
@@ -375,7 +364,7 @@ class TestAgentLoop:
         assert roles == ["user", "assistant", "tool_result"]
 
     async def test_steering_messages_polled_before_first_turn(self):
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses([faux_assistant_message("Got it")])
 
         context = AgentContext(system_prompt="", messages=[], tools=[])
@@ -392,8 +381,7 @@ class TestAgentLoop:
         messages = await run_agent_loop(
             prompts=[make_user_message("Hello")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             get_steering_messages=get_steering,
             emit=lambda e: events.append(e),
@@ -414,7 +402,7 @@ class TestAgentLoop:
     async def test_steering_drained_at_turn_boundary_when_no_more_tools(self):
         # Pre-loop poll returns nothing; the steer arrives at the turn boundary
         # of a tool-less turn. Without the boundary drain it would be dropped.
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses(
             [
                 faux_assistant_message("first answer"),
@@ -435,8 +423,7 @@ class TestAgentLoop:
         messages = await run_agent_loop(
             prompts=[make_user_message("start")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             get_steering_messages=get_steering,
             emit=lambda e: events.append(e),
@@ -446,7 +433,7 @@ class TestAgentLoop:
         assert roles == ["user", "assistant", "user", "assistant"]
 
     async def test_error_stop_reason_ends_loop(self):
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses(
             [
                 faux_assistant_message(
@@ -461,8 +448,7 @@ class TestAgentLoop:
         messages = await run_agent_loop(
             prompts=[make_user_message("hello")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             emit=lambda e: events.append(e),
         )
@@ -475,14 +461,13 @@ class TestAgentLoop:
 
 class TestAgentLoopContinue:
     async def test_raises_when_no_messages(self):
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         context = AgentContext(system_prompt="", messages=[], tools=[])
 
         try:
             await run_agent_loop_continue(
                 context=context,
-                provider=provider,
-                model=make_model(),
+                model=provider.model("faux-1"),
                 convert_to_llm=identity_converter,
                 emit=lambda e: None,
             )
@@ -491,7 +476,7 @@ class TestAgentLoopContinue:
             assert "no messages" in str(e).lower()
 
     async def test_continue_without_user_message_events(self):
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses([faux_assistant_message("Response")])
 
         context = AgentContext(
@@ -503,8 +488,7 @@ class TestAgentLoopContinue:
         events: list[AgentEvent] = []
         messages = await run_agent_loop_continue(
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             emit=lambda e: events.append(e),
         )
@@ -520,7 +504,7 @@ class TestAgentLoopContinue:
 class TestFollowUpMessages:
     async def test_follow_up_messages_trigger_second_turn(self):
         """Lines 238-244: get_follow_up_messages injects messages and continues loop."""
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses(
             [
                 faux_assistant_message("first response"),
@@ -542,8 +526,7 @@ class TestFollowUpMessages:
         messages = await run_agent_loop(
             prompts=[make_user_message("Hello")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=identity_converter,
             get_follow_up_messages=get_follow_ups,
             emit=lambda e: events.append(e),
@@ -571,7 +554,7 @@ class TestFollowUpMessages:
 class TestAsyncConvertToLlm:
     async def test_async_converter_awaited_correctly(self):
         """Line 266: convert_to_llm returning a coroutine is awaited."""
-        provider = FauxProvider()
+        provider = FauxProvider(provider_id="faux")
         provider.set_responses([faux_assistant_message("Response")])
 
         context = AgentContext(system_prompt="", messages=[], tools=[])
@@ -595,8 +578,7 @@ class TestAsyncConvertToLlm:
         messages = await run_agent_loop(
             prompts=[make_user_message("Hello")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=provider.model("faux-1"),
             convert_to_llm=async_converter,
             emit=lambda e: events.append(e),
         )
@@ -712,8 +694,10 @@ class TestStreamFallback:
         messages = await run_agent_loop(
             prompts=[make_user_message("Hello")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=BoundModel(
+                provider=provider,
+                spec=Model(id="faux-1", provider_id="faux"),
+            ),
             convert_to_llm=identity_converter,
             emit=lambda e: events.append(e),
         )
@@ -741,8 +725,10 @@ class TestStreamFallback:
         messages = await run_agent_loop(
             prompts=[make_user_message("Hello")],
             context=context,
-            provider=provider,
-            model=make_model(),
+            model=BoundModel(
+                provider=provider,
+                spec=Model(id="faux-1", provider_id="faux"),
+            ),
             convert_to_llm=identity_converter,
             emit=lambda e: events.append(e),
         )

--- a/tests/providers/test_bound_model_calls.py
+++ b/tests/providers/test_bound_model_calls.py
@@ -105,3 +105,55 @@ async def test_bound_model_stream_forwards_to_provider() -> None:
     assert "done" in events
     assert result.model_id == "faux-1"
     assert result.provider_id == "faux"
+
+
+class _MangledNamesProvider(BaseProvider):
+    """A custom provider that follows the Provider protocol shape but uses
+    different parameter names for ``model`` and ``messages``. Pre-BoundModel,
+    cubepi/agent/loop.py called ``provider.stream(model, messages, ...)``
+    positionally, so this kind of provider worked. ``BoundModel.stream`` /
+    ``BoundModel.generate`` must keep forwarding those two args positionally
+    so this still works.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(provider_id="mangled")
+        self.captured_model: Model | None = None
+        self.captured_messages: list[Message] | None = None
+
+    async def generate(  # type: ignore[override]
+        self,
+        spec_in,  # NOT ``model=``
+        msg_in,  # NOT ``messages=``
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        options: StreamOptions | None = None,
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        thinking: Any = None,
+        thinking_budgets: Any = None,
+    ) -> AssistantMessage:
+        self.captured_model = spec_in
+        self.captured_messages = msg_in
+        return AssistantMessage(
+            content=[TextContent(text="ok")],
+            provider_id=spec_in.provider_id,
+            model_id=spec_in.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_bound_model_generate_forwards_positionally_for_mangled_provider() -> (
+    None
+):
+    provider = _MangledNamesProvider()
+    bound = provider.model("model-x")
+    messages = [UserMessage(content=[TextContent(text="hi")])]
+
+    response = await bound.generate(messages=messages, system_prompt="x")
+
+    assert response.provider_id == "mangled"
+    assert response.model_id == "model-x"
+    assert provider.captured_model is bound.spec
+    assert provider.captured_messages is messages

--- a/tests/tracing/test_meter.py
+++ b/tests/tracing/test_meter.py
@@ -235,8 +235,8 @@ class TestConcurrentAgents:
         # Walk the agents' provider listener registries directly so
         # we control the ordering. Each agent has its own listener
         # callable bound to its own _MeterState.
-        prov_a = agent_a._provider
-        prov_b = agent_b._provider
+        prov_a = agent_a._model.provider
+        prov_b = agent_b._model.provider
         req_a = next(iter(prov_a._request_listeners))
         req_b = next(iter(prov_b._request_listeners))
         resp_a = next(iter(prov_a._response_listeners))


### PR DESCRIPTION
## Summary

Last load-bearing surface still threading the unwrapped `(Provider, Model)` pair flips to `BoundModel`. Follow-up to #154.

- `cubepi/agent/loop.py` — 7 function signatures (`run_agent_loop`, `run_agent_loop_continue`, `run_agent_loop_resume`, `_run_loop`, `_run_loop_inner`, `_stream_assistant_response`, `_run_agent_loop_resume_body`) collapse `provider: Provider, model: Model` → `model: BoundModel`. The single in-body `provider.stream(...)` flips to `model.stream(...)` via the convenience added in #154.
- `cubepi/agent/agent.py` — drop the redundant `self._provider` field; three loop call sites pass `model=self._model` instead of the split pair. `AgentState.model: Model` field unchanged (still serializable for checkpointer; the spec is a historical record, the loop drives off `self._model`).
- `cubepi/tracing/tracer.py` — `_OneShotSession` holds a `BoundModel` internally; `oneshot()` no longer extracts `model_spec` separately.
- `cubepi/tracing/recorder.py` + `meter.py` — reach the agent's provider via `agent._model.provider` instead of `agent._provider`. Recorder loop rename: `for bound in extra` → `for model in extra` per the new `BoundModel` naming convention.
- `tests/agent/test_loop.py` — delete `make_model()` helper; replace the `provider=..., model=...` boilerplate with `model=provider.model("faux-1")`. Two custom test providers that don't subclass `BaseProvider` use `BoundModel(provider=..., spec=Model(...))` directly.
- `tests/tracing/test_meter.py` — `agent._provider` → `agent._model.provider`.

## Workflow

- Spec: `dev/specs/2026-06-08-loop-boundmodel.md`. User-confirmed design points: `AgentState.model` stays `Model`, resume trusts caller, OneShot migrates lock-step.
- Plan: `dev/plans/2026-06-08-loop-boundmodel.md`.
- Per user direction, skipped local codex review on spec/plan/code — going straight to PR codex review.

## Breaking

`cubepi.run_agent_loop` and `cubepi.run_agent_loop_continue` change signature. Per project policy (CLAUDE.md "Avoid backwards-compatibility hacks", reaffirmed in #154), no compat shim — see CHANGELOG.md `[Unreleased]` Breaking + Migration sections.

## Test plan

- [x] `uv run pytest tests/` — 1534 passed, 45 skipped
- [x] `uv run ruff check cubepi/ tests/` — All checks passed
- [x] `uv run ruff format --check cubepi/ tests/` — 246 files already formatted
- [x] `uv run mypy cubepi` — Success, no issues in 87 source files

## Out of scope

- `Provider` protocol and built-in provider implementations — they correctly take `model: Model` (the spec).
- `AgentState.model` shape — kept as `Model` to avoid a checkpointer schema migration.