### PR TITLE
fix(subagents): strip checkpointed-HITL tools/middleware from child agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   )
   ```
 
+### Fixed
+
+- **`SubagentMiddleware` now strips checkpointed-HITL elements from a child
+  agent's inherited tools / middleware.** Previously, passing the parent
+  agent's `ask_user_tool(channel)` in `shared_tools` (the common pattern
+  when the host wants tools shared between parent and children) caused
+  the child's first `prompt()` to raise `Agent has checkpointed HITL
+  elements bound to run_ids ...` because the binding's parent `run_id`
+  didn't match the child's fresh `run_id`. The middleware now drops any
+  element whose `.hitl` is a checkpointed `HitlBinding` before
+  constructing the child — the subagent runs autonomously without the
+  parent's HITL channel, matching its "ephemeral and autonomous" design
+  intent. Elements without `.hitl`, or with non-checkpointed bindings,
+  are inherited as-is.
+
 ## [0.8.0] - 2026-06-06
 
 ### Added

--- a/cubepi/middleware/subagents.py
+++ b/cubepi/middleware/subagents.py
@@ -22,6 +22,24 @@ EventMapper = Callable[[AgentEvent], Sequence[StructuredValue] | StructuredValue
 EventHandler = Callable[[str, StructuredValue], Awaitable[None] | None]
 
 
+def _drop_checkpointed_hitl(items: Sequence) -> list:
+    """Remove elements whose ``.hitl`` is a checkpointed binding.
+
+    Used by ``SubagentMiddleware`` to keep parent-bound HITL state out of an
+    ephemeral child agent — the child has its own run_id, but a checkpointed
+    ``HitlBinding`` carries the parent's run_id, which ``Agent._validate_hitl
+    _bindings`` rejects at ``prompt()`` entry. Elements without ``.hitl`` (or
+    with a non-checkpointed binding) pass through untouched.
+    """
+    out: list = []
+    for x in items:
+        binding = getattr(x, "hitl", None)
+        if binding is not None and getattr(binding, "checkpointed", False):
+            continue
+        out.append(x)
+    return out
+
+
 class SubagentTracer(Protocol):
     def attach(
         self, agent: Agent[BaseModel]
@@ -151,8 +169,19 @@ class SubagentMiddleware(Middleware):
             self._subagents["general-purpose"],
         )
         model = spec.model or self._default_model
-        tools = [*self._shared_tools, *spec.tools]
-        middleware = [*self._inherited_middleware, *spec.middleware]
+        # Subagents are ephemeral and autonomous: they run under their own
+        # run_id, so a tool/middleware whose HITL channel was checkpointed
+        # against the parent's run_id can't legally pause from the child —
+        # ``Agent._validate_hitl_bindings`` would reject the child's
+        # ``prompt()`` call with "Agent has checkpointed HITL elements bound
+        # to run_ids ...". Drop those bindings before constructing the child;
+        # non-HITL behaviour on the same element (e.g. tool execution path,
+        # non-HITL middleware logic) is unaffected because we only strip the
+        # whole element when its ``.hitl`` is checkpointed.
+        tools = _drop_checkpointed_hitl([*self._shared_tools, *spec.tools])
+        middleware = _drop_checkpointed_hitl(
+            [*self._inherited_middleware, *spec.middleware]
+        )
         child: Agent[BaseModel] = Agent(
             model=model,
             system_prompt=spec.system_prompt,

--- a/cubepi/middleware/subagents.py
+++ b/cubepi/middleware/subagents.py
@@ -22,19 +22,47 @@ EventMapper = Callable[[AgentEvent], Sequence[StructuredValue] | StructuredValue
 EventHandler = Callable[[str, StructuredValue], Awaitable[None] | None]
 
 
+def _is_checkpointed_hitl(x: object) -> bool:
+    """True if ``x.hitl`` is a checkpointed ``HitlBinding``."""
+    binding = getattr(x, "hitl", None)
+    return binding is not None and bool(getattr(binding, "checkpointed", False))
+
+
 def _drop_checkpointed_hitl(items: Sequence) -> list:
-    """Remove elements whose ``.hitl`` is a checkpointed binding.
+    """Remove elements that carry — or expose — a checkpointed HITL binding.
 
     Used by ``SubagentMiddleware`` to keep parent-bound HITL state out of an
-    ephemeral child agent — the child has its own run_id, but a checkpointed
-    ``HitlBinding`` carries the parent's run_id, which ``Agent._validate_hitl
-    _bindings`` rejects at ``prompt()`` entry. Elements without ``.hitl`` (or
-    with a non-checkpointed binding) pass through untouched.
+    ephemeral child agent. The child has its own run_id, but a checkpointed
+    ``HitlBinding`` carries the parent's run_id, which
+    ``Agent._validate_hitl_bindings`` rejects at ``prompt()`` entry.
+
+    Two ways an element can introduce parent-bound HITL into the child:
+
+    * The element itself has ``.hitl`` set (an ``AgentTool`` like
+      ``ask_user_tool(...)`` or a middleware like
+      ``ApprovalPolicyMiddleware``). Dropped directly.
+    * A middleware that doesn't carry ``.hitl`` itself but exposes
+      ``.tools`` containing an HITL-checkpointed tool — ``Agent.__init__``
+      appends ``getattr(mw, "tools", [])`` to ``state.tools`` and the
+      validator would still see the parent-bound tool there. The whole
+      middleware is dropped in this case; constructing a tools-filtered
+      proxy would break ``compose_middleware._has_method`` (it does
+      ``type(mw)`` lookups), so dropping the unit is the simpler and
+      type-safe option. Trade-off: any non-HITL hooks on that middleware
+      are also lost in the subagent — by packaging HITL tools inside a
+      middleware the host has effectively declared the middleware to be
+      an HITL unit.
+
+    Elements without ``.hitl`` (or with a non-checkpointed binding) and
+    with no checkpointed-HITL tools inside their ``.tools`` attribute
+    pass through untouched.
     """
     out: list = []
     for x in items:
-        binding = getattr(x, "hitl", None)
-        if binding is not None and getattr(binding, "checkpointed", False):
+        if _is_checkpointed_hitl(x):
+            continue
+        nested_tools = getattr(x, "tools", None)
+        if nested_tools and any(_is_checkpointed_hitl(t) for t in nested_tools):
             continue
         out.append(x)
     return out

--- a/tests/middleware/test_subagents.py
+++ b/tests/middleware/test_subagents.py
@@ -566,3 +566,73 @@ async def test_subagent_strips_checkpointed_hitl_bound_tools() -> None:
     await parent.prompt("dispatch the subagent")
 
     assert parent.state.error_message is None
+
+
+async def test_subagent_strips_middleware_exposing_checkpointed_hitl_tools() -> None:
+    """A custom middleware that itself has no ``.hitl`` but exposes a
+    checkpointed-HITL tool via its ``.tools`` attribute must NOT reach the
+    child agent — ``Agent.__init__`` would otherwise append that tool to
+    ``state.tools`` and the child's ``prompt()`` would fail with the same
+    ``checkpointed HITL elements bound to run_ids`` error this fix is meant
+    to avoid (codex P2 on PR #159).
+    """
+    from cubepi.hitl.binding import HitlBinding
+    from cubepi.middleware.base import Middleware
+
+    class _NoOpParams(BaseModel):
+        pass
+
+    async def _noop_exec(
+        call_id: str, args: _NoOpParams, *, signal=None, on_update=None
+    ) -> AgentToolResult:
+        del call_id, args, signal, on_update
+        return AgentToolResult(content=[TextContent(text="noop")])
+
+    parent_bound_tool = AgentTool(
+        name="parent_hitl_tool",
+        description="HITL tool inside a custom middleware",
+        parameters=_NoOpParams,
+        execute=_noop_exec,
+        hitl=HitlBinding(checkpointed=True, run_id="parent-run-zzz"),
+    )
+
+    class _HitlPackagingMiddleware(Middleware):
+        def __init__(self) -> None:
+            self.tools = [parent_bound_tool]
+
+    provider = FauxProvider(provider_id="faux")
+    provider.set_responses([faux_assistant_message("done")])
+
+    middleware = _make_middleware(
+        provider=provider,
+        inherited_middleware=[_HitlPackagingMiddleware()],
+    )
+
+    parent_provider = FauxProvider(provider_id="faux")
+    parent_provider.set_responses(
+        [
+            faux_assistant_message(
+                [
+                    faux_tool_call(
+                        "subagent",
+                        {"name": "n", "role": "r", "task": "t", "prompt": "p"},
+                    )
+                ],
+                stop_reason="tool_use",
+            ),
+            faux_assistant_message("done"),
+        ]
+    )
+    parent = Agent(
+        model=parent_provider.model("faux-1"),
+        system_prompt="parent",
+        tools=middleware.tools,
+        middleware=[middleware],
+    )
+
+    # Without the .tools drill-in, the wrapping middleware passes the strip
+    # and ``Agent.__init__`` lifts ``parent_hitl_tool`` into the child's
+    # ``state.tools`` — child ``prompt()`` then raises.
+    await parent.prompt("dispatch the subagent")
+
+    assert parent.state.error_message is None

--- a/tests/middleware/test_subagents.py
+++ b/tests/middleware/test_subagents.py
@@ -495,3 +495,74 @@ class _FakeTracer:
             return flush()
 
         return detach
+
+
+async def test_subagent_strips_checkpointed_hitl_bound_tools() -> None:
+    """A shared_tool whose ``.hitl`` is a checkpointed binding (parent's
+    ``ask_user_tool`` is the typical case) must NOT reach the child agent.
+
+    Otherwise ``Agent._validate_hitl_bindings`` at the child's ``prompt()``
+    entry would reject the run with ``"Agent has checkpointed HITL elements
+    bound to run_ids ..."`` because the child runs under its own run_id.
+    """
+    from cubepi.hitl.binding import HitlBinding
+
+    class _NoOpParams(BaseModel):
+        pass
+
+    async def _noop_exec(
+        call_id: str, args: _NoOpParams, *, signal=None, on_update=None
+    ) -> AgentToolResult:
+        del call_id, args, signal, on_update
+        return AgentToolResult(content=[TextContent(text="noop")])
+
+    parent_bound_tool = AgentTool(
+        name="parent_hitl_tool",
+        description="A tool whose HITL channel is checkpointed against a parent run_id",
+        parameters=_NoOpParams,
+        execute=_noop_exec,
+        hitl=HitlBinding(checkpointed=True, run_id="parent-run-abc"),
+    )
+
+    plain_tool = AgentTool(
+        name="plain_tool",
+        description="Plain tool with no HITL binding",
+        parameters=_NoOpParams,
+        execute=_noop_exec,
+    )
+
+    provider = FauxProvider(provider_id="faux")
+    provider.set_responses([faux_assistant_message("subagent done")])
+
+    middleware = _make_middleware(
+        provider=provider,
+        shared_tools=[parent_bound_tool, plain_tool],
+    )
+
+    parent_provider = FauxProvider(provider_id="faux")
+    parent_provider.set_responses(
+        [
+            faux_assistant_message(
+                [
+                    faux_tool_call(
+                        "subagent",
+                        {"name": "n", "role": "r", "task": "t", "prompt": "p"},
+                    )
+                ],
+                stop_reason="tool_use",
+            ),
+            faux_assistant_message("done"),
+        ]
+    )
+    parent = Agent(
+        model=parent_provider.model("faux-1"),
+        system_prompt="parent",
+        tools=middleware.tools,
+        middleware=[middleware],
+    )
+
+    # Without the strip this raises:
+    #   ValueError: Agent has checkpointed HITL elements bound to run_ids ['parent-run-abc']; ...
+    await parent.prompt("dispatch the subagent")
+
+    assert parent.state.error_message is None

--- a/website/docs/guides/middleware/subagents.md
+++ b/website/docs/guides/middleware/subagents.md
@@ -60,6 +60,20 @@ Subagents only receive the tools you pass in:
 Use `inherited_middleware` for middleware every child should run. Use
 `SubagentSpec.middleware` for behavior specific to one subagent type.
 
+### Checkpointed HITL bindings are stripped
+
+A tool or middleware whose `.hitl` is a checkpointed `HitlBinding` carries
+the parent run's `run_id`. The child runs under its own fresh `run_id`, so
+inheriting such an element would crash with `Agent has checkpointed HITL
+elements bound to run_ids ...` at the child's `prompt()` entry. The
+middleware drops these elements automatically before constructing the
+child agent. The most common case is the parent's `ask_user_tool(...)`
+appearing in `shared_tools` — it simply won't be in the child's tool list.
+
+Elements with no `.hitl`, or with a non-checkpointed binding, are
+inherited as-is. Use a non-HITL approval / policy mechanism if a subagent
+needs gating.
+
 ## Stream child events to your host
 
 Applications often need child events in their own UI or audit log. Provide an


### PR DESCRIPTION
## Summary

`SubagentMiddleware._run_subagent` inherits `shared_tools` and `inherited_middleware` into the child agent. If any inherited element carries a **checkpointed** `HitlBinding` — the typical case is the parent agent's `ask_user_tool(channel)` in `shared_tools` — the child's first `prompt()` hits `Agent._validate_hitl_bindings` and raises:

```
ValueError: Agent has checkpointed HITL elements bound to run_ids
['<parent-run-id>']; prompt(run_id=...) must be explicitly supplied
```

The child runs under its own fresh `run_id`; it can't legally pause on the parent's HITL channel — different runs.

**Fix:** strip elements whose `.hitl` is a checkpointed binding before constructing the child. Matches the existing "ephemeral autonomous child" design intent. Elements with no `.hitl`, or with a non-checkpointed binding, pass through untouched.

## Surfaced from

cubebox `test_subagent_dispatch_real_llm` was hitting this — cubebox builds an `ask_user_tool(CheckpointedChannel)` and includes it in the tools shared into subagents.

## Test plan

- [x] `uv run pytest tests/` — 1597 passed, 45 skipped (was 1596 + 1 new regression test)
- [x] `uv run ruff check cubepi/ tests/` — clean
- [x] `uv run ruff format --check cubepi/ tests/` — clean
- [x] `uv run mypy cubepi` — clean
- [x] New regression test: `test_subagent_strips_checkpointed_hitl_bound_tools` exercises a tool with `HitlBinding(checkpointed=True, run_id='parent-run-abc')` in `shared_tools`; dispatching the subagent must not raise.

## Workflow

- Spec/plan: focused fix, scoped one-file refactor — skipped per established convention for narrow bug fixes (per CLAUDE.md: "Decide spec/plan/code split based on coupling and review cost").
- Skipped local codex review; going straight to PR codex.

## Docs

`website/docs/guides/middleware/subagents.md` gets a new "Checkpointed HITL bindings are stripped" subsection. `CHANGELOG.md` `[Unreleased]` → Fixed entry.