### PR TITLE
fix(site): 301-redirect cubepi.pages.dev to cubepi.ai (complete the migration)

### DIFF
--- a/website/static/functions/_middleware.js
+++ b/website/static/functions/_middleware.js
@@ -1,0 +1,25 @@
+// Cloudflare Pages middleware.
+//
+// The site moved from the default *.pages.dev hostname to the custom domain
+// cubepi.ai. This 301-redirects the production pages.dev hostname to the
+// canonical domain so the migration sends search engines one clean signal
+// (every old URL maps 1:1 to its new path) instead of leaving the old domain
+// serving duplicate content.
+//
+// Notes:
+//   - Matches the production hostname exactly, so preview deployments
+//     (e.g. <hash>.cubepi.pages.dev) keep working for review.
+//   - Runs on every request; cubepi.ai and previews fall through to
+//     context.next(), so there is no redirect loop.
+//   - Lives in static/ so Docusaurus copies it to build/functions/, which is
+//     the directory uploaded to Cloudflare Pages (see .github/workflows/docs.yml).
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  if (url.hostname === "cubepi.pages.dev") {
+    url.hostname = "cubepi.ai";
+    url.protocol = "https:";
+    url.port = "";
+    return Response.redirect(url.toString(), 301);
+  }
+  return context.next();
+}


### PR DESCRIPTION
## Summary

Completes the `cubepi.pages.dev` → `cubepi.ai` domain migration.

**Problem:** the migration was only half-done. Only the root path redirected to cubepi.ai; every deep page still returned **200 on cubepi.pages.dev** (e.g. `/docs/`, `/changelog/`), so the same content was live on two domains. This was mitigated only by the `canonical` tag pointing to cubepi.ai — weaker and slower than a real 301, and a likely contributor to the post-migration ranking dip (the site is indexed, 26 pages, but ranks for nothing except the exact domain string).

**Fix:** a Cloudflare Pages middleware (`functions/_middleware.js`) that 301-redirects the production `cubepi.pages.dev` hostname to the matching `cubepi.ai` path, giving search engines one clean 1:1 migration signal.

Why a middleware and not a dashboard Redirect Rule or `_redirects`:
- `*.pages.dev` is **not our Cloudflare zone**, so dashboard Redirect Rules / Bulk Redirects don't apply to it — only the Pages project's own code runs on that hostname.
- `_redirects` matches on path only (no hostname condition), so a blanket rule would also redirect cubepi.ai → itself (loop). The middleware branches on `hostname`, so it's loop-safe.

Behaviour:
- Matches the **production** hostname exactly (`cubepi.pages.dev`), so preview deployments (`<hash>.cubepi.pages.dev`) keep working for review.
- cubepi.ai and previews fall through to `context.next()` — no loop.
- Path + query string are preserved (1:1 mapping).

## Deployment mechanics

The deploy workflow uploads `website/build` via `cloudflare/pages-action`. The file lives in `website/static/functions/_middleware.js`, which Docusaurus copies to `website/build/functions/_middleware.js` — the `functions/` directory wrangler compiles into a Pages Function.

## Verification

- `pnpm build` passes (both locales); confirmed `website/build/functions/_middleware.js` is emitted in the deploy directory.

**After merge + deploy, confirm:**
```
curl -sI https://cubepi.pages.dev/docs/       # → 301, location: https://cubepi.ai/docs/
curl -sI https://cubepi.pages.dev/changelog/  # → 301, location: https://cubepi.ai/changelog/
```
Then request indexing for key cubepi.ai pages in Google Search Console.

https://claude.ai/code/session_01UV4NAWz6qcBE35Nv1s1WRM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UV4NAWz6qcBE35Nv1s1WRM)_