### PR TITLE
feat: DeferredToolGroup — progressive tool disclosure primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`DeferredToolGroup` / `DeferredToolsMiddleware`** — progressive tool
   disclosure primitive. Hides MCP tool schemas from the model by default,
   injecting a compact catalog into the system prompt instead. The model
-  expands groups on demand via the built-in `expand_tools` tool (full or
+  expands groups on demand via the built-in `load_tools` tool (full or
   selective). Key properties:
   - Catalog sorted by `group_id` for byte-stable system prompt prefix.
   - Expanded schemas append-only (expansion order, never reordered) for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`DeferredToolGroup` / `DeferredToolsMiddleware`** — progressive tool
+  disclosure primitive. Hides MCP tool schemas from the model by default,
+  injecting a compact catalog into the system prompt instead. The model
+  expands groups on demand via the built-in `expand_tools` tool (full or
+  selective). Key properties:
+  - Catalog sorted by `group_id` for byte-stable system prompt prefix.
+  - Expanded schemas append-only (expansion order, never reordered) for
+    prompt-cache prefix stability across turns.
+  - Loader called once per group per run; selective expansions filter from
+    the cached result.
+  - `Agent(deferred_tool_groups=[...])` — primary API. Middleware is
+    auto-created internally with `extra_ref` bound to `self._extra`.
+  - Cross-run replay via `DeferredToolsMiddleware.prepare_resumed_state()`,
+    which returns pre-loaded tools, remaining groups, and expanded schemas
+    for prompt-cache continuity.
+  - Exported from `cubepi.deferred` as `DeferredToolGroup`,
+    `DeferredToolsMiddleware`, and `ResumedState`.
+
 ### Fixed
 
 - **`Recorder.attach()` and `Meter.attach()` now subscribe to every provider in

--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ The model sees a compact catalog in the system prompt instead of full schemas:
   create_issue, search_repos, create_pr, list_comments
 ```
 
-When the model needs a group, it calls the built-in `expand_tools` tool:
+When the model needs a group, it calls the built-in `load_tools` tool:
 
 ```
-expand_tools(group_id="mcp:github")                        # expand all
-expand_tools(group_id="mcp:github", tool_names=["create_issue"])  # or just one
+load_tools(group_id="mcp:github")                        # load all
+load_tools(group_id="mcp:github", tool_names=["create_issue"])  # or just one
 ```
 
 The loader is called once per group per run; subsequent selective expansions

--- a/README.md
+++ b/README.md
@@ -189,6 +189,69 @@ hooks = compose_middleware([LoggingMiddleware(), SafetyMiddleware()])
 | `should_stop_after_turn` | Any true stops |
 | `on_run_end` | Messages concatenate; non-empty result triggers one extra model turn |
 
+### Deferred Tool Groups
+
+When an agent has access to many MCP servers, their combined tool schemas can
+consume significant context. Deferred tool groups hide schemas by default and
+let the model expand them on demand:
+
+```python
+from cubepi import Agent
+from cubepi.deferred import DeferredToolGroup
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr", "list_comments"],
+    loader=github_mcp.load_tools,  # async () -> list[AgentTool]
+)
+
+agent = Agent(
+    model=provider.model("claude-sonnet-4-6"),
+    tools=[get_weather],                     # always-available tools
+    deferred_tool_groups=[github_group],      # hidden until requested
+)
+```
+
+The model sees a compact catalog in the system prompt instead of full schemas:
+
+```
+# Deferred tool groups
+
+- `mcp:github` — GitHub: Issues, PRs, repos, code search (4 tools)
+  create_issue, search_repos, create_pr, list_comments
+```
+
+When the model needs a group, it calls the built-in `expand_tools` tool:
+
+```
+expand_tools(group_id="mcp:github")                        # expand all
+expand_tools(group_id="mcp:github", tool_names=["create_issue"])  # or just one
+```
+
+The loader is called once per group per run; subsequent selective expansions
+filter from the cached result. Expanded tool schemas are appended to the system
+prompt in expansion order (append-only) for prompt-cache prefix stability.
+
+For advanced use (custom catalog header, cross-run replay), construct
+`DeferredToolsMiddleware` directly:
+
+```python
+from cubepi.deferred import DeferredToolsMiddleware
+
+# Replay expansion state from a previous run
+resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+    groups=all_groups,
+    expanded=saved_extra["expanded_groups"],
+)
+agent = Agent(
+    model=model,
+    tools=[*builtins, *resumed.pre_loaded_tools],
+    deferred_tool_groups=resumed.remaining_groups,
+)
+```
+
 ### Checkpointer
 
 Persist conversation state with append-only semantics:

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -216,7 +216,9 @@ class Agent(Generic[TMessage]):
             deferred_mw = DeferredToolsMiddleware(
                 groups=deferred_tool_groups,
                 extra_ref=lambda: self._extra,
-                on_tools_expanded=lambda tools: self._state._tools.extend(tools),
+                on_tools_expanded=lambda new: self._state._tools.extend(
+                    t for t in new if t.name not in {e.name for e in self._state._tools}
+                ),
             )
             middleware = [*(middleware or []), deferred_mw]
         middleware = middleware or []

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -50,6 +50,7 @@ from cubepi.types import JsonObject, StructuredValue
 TMessage = TypeVar("TMessage")
 
 if TYPE_CHECKING:
+    from cubepi.deferred.types import DeferredToolGroup
     from cubepi.providers.fallback import FallbackBoundModel
 
 
@@ -161,6 +162,7 @@ class Agent(Generic[TMessage]):
         checkpointer: Checkpointer | None = None,
         thread_id: str | None = None,
         middleware: list[Middleware] | None = None,
+        deferred_tool_groups: list[DeferredToolGroup] | None = None,
         channel: HitlChannel | None = None,
         messages: Sequence[Message] | None = None,
     ) -> None:
@@ -182,6 +184,14 @@ class Agent(Generic[TMessage]):
             self._state.messages = list(seeded)
         if tools:
             self._state.tools = tools
+        if deferred_tool_groups:
+            from cubepi.deferred.middleware import DeferredToolsMiddleware
+
+            deferred_mw = DeferredToolsMiddleware(
+                groups=deferred_tool_groups,
+                extra_ref=lambda: self._extra,
+            )
+            middleware = [*(middleware or []), deferred_mw]
         middleware = middleware or []
         # Retain the list so observers (e.g. cubepi.tracing.Recorder) can
         # walk it after construction — they need to reach attributes like

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -25,6 +25,7 @@ from cubepi.agent.types import (
     AgentEndEvent,
     AgentEvent,
     AgentTool,
+    AgentToolResult,
     ForkOnceResult,
     MessageEndEvent,
     MessageStartEvent,
@@ -52,6 +53,31 @@ TMessage = TypeVar("TMessage")
 if TYPE_CHECKING:
     from cubepi.deferred.types import DeferredToolGroup
     from cubepi.providers.fallback import FallbackBoundModel
+
+
+def _deny_in_fork(tool: AgentTool) -> AgentTool:
+    """Return a copy of *tool* whose execute always returns an error.
+
+    Used by fork_once to keep middleware tools in the schema (prompt-cache
+    parity) while preventing execution that would mutate parent state.
+    """
+    from dataclasses import replace
+
+    async def _denied(
+        tool_call_id: str,
+        args: object,
+        *,
+        signal: asyncio.Event | None = None,
+        on_update: Callable | None = None,
+    ) -> AgentToolResult:
+        return AgentToolResult(
+            content=[
+                TextContent(text=f"{tool.name} is not available in a forked agent.")
+            ],
+            is_error=True,
+        )
+
+    return replace(tool, execute=_denied)
 
 
 def _default_convert_to_llm(
@@ -537,12 +563,15 @@ class Agent(Generic[TMessage]):
         # middleware twice — the parent's composed result already lives on
         # self.transform_context etc.
         #
-        # Strip middleware-owned tools (e.g. expand_tools) — their execute
-        # callbacks close over the parent's state and would corrupt it.
+        # Keep middleware-owned tools in the schema (prompt-cache parity)
+        # but deny their execution at runtime — their execute callbacks
+        # close over the parent's state and would corrupt it.
         _mw_tool_ids = {
             id(t) for mw in self._middleware for t in getattr(mw, "tools", []) or []
         }
-        fork_tools = [t for t in self._state.tools if id(t) not in _mw_tool_ids]
+        fork_tools = [
+            _deny_in_fork(t) if id(t) in _mw_tool_ids else t for t in self._state.tools
+        ]
         child: Agent = Agent(
             model=self._model,
             system_prompt=self._state.system_prompt,

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -190,6 +190,7 @@ class Agent(Generic[TMessage]):
             deferred_mw = DeferredToolsMiddleware(
                 groups=deferred_tool_groups,
                 extra_ref=lambda: self._extra,
+                on_tools_expanded=lambda tools: self._state._tools.extend(tools),
             )
             middleware = [*(middleware or []), deferred_mw]
         middleware = middleware or []
@@ -535,10 +536,17 @@ class Agent(Generic[TMessage]):
         # as explicit args means we pass middleware=[] to avoid composing
         # middleware twice — the parent's composed result already lives on
         # self.transform_context etc.
+        #
+        # Strip middleware-owned tools (e.g. expand_tools) — their execute
+        # callbacks close over the parent's state and would corrupt it.
+        _mw_tool_ids = {
+            id(t) for mw in self._middleware for t in getattr(mw, "tools", []) or []
+        }
+        fork_tools = [t for t in self._state.tools if id(t) not in _mw_tool_ids]
         child: Agent = Agent(
             model=self._model,
             system_prompt=self._state.system_prompt,
-            tools=list(self._state.tools),
+            tools=fork_tools,
             thinking=self._state.thinking,
             convert_to_llm=self.convert_to_llm,
             transform_context=self.transform_context,

--- a/cubepi/deferred/__init__.py
+++ b/cubepi/deferred/__init__.py
@@ -1,0 +1,5 @@
+"""Deferred tool groups — progressive tool disclosure primitive."""
+
+from cubepi.deferred.types import DeferredToolGroup
+
+__all__ = ["DeferredToolGroup"]

--- a/cubepi/deferred/__init__.py
+++ b/cubepi/deferred/__init__.py
@@ -1,5 +1,6 @@
 """Deferred tool groups — progressive tool disclosure primitive."""
 
+from cubepi.deferred.middleware import DeferredToolsMiddleware, ResumedState
 from cubepi.deferred.types import DeferredToolGroup
 
-__all__ = ["DeferredToolGroup"]
+__all__ = ["DeferredToolGroup", "DeferredToolsMiddleware", "ResumedState"]

--- a/cubepi/deferred/_catalog.py
+++ b/cubepi/deferred/_catalog.py
@@ -32,7 +32,8 @@ def render_catalog(
             continue
 
         if expanded_names is not None:
-            remaining = [n for n in group.tool_names if n not in set(expanded_names)]
+            expanded_set = set(expanded_names)
+            remaining = [n for n in group.tool_names if n not in expanded_set]
         else:
             remaining = list(group.tool_names)
 

--- a/cubepi/deferred/_catalog.py
+++ b/cubepi/deferred/_catalog.py
@@ -7,9 +7,9 @@ from cubepi.deferred.types import DeferredToolGroup
 DEFAULT_CATALOG_HEADER = (
     "# Deferred tool groups\n"
     "\n"
-    "These tool groups are available but not yet loaded. Call `expand_tools(group_id)`\n"
+    "These tool groups are available but not yet loaded. Call `load_tools(group_id)`\n"
     "to load a group's tools for the rest of this conversation.\n"
-    "You can also call `expand_tools(group_id, tool_names=[...])` to load specific tools only."
+    "You can also call `load_tools(group_id, tool_names=[...])` to load specific tools only."
 )
 
 

--- a/cubepi/deferred/_catalog.py
+++ b/cubepi/deferred/_catalog.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+
+from cubepi.deferred.types import DeferredToolGroup
+
+DEFAULT_CATALOG_HEADER = (
+    "# Deferred tool groups\n"
+    "\n"
+    "These tool groups are available but not yet loaded. Call `expand_tools(group_id)`\n"
+    "to load a group's tools for the rest of this conversation.\n"
+    "You can also call `expand_tools(group_id, tool_names=[...])` to load specific tools only."
+)
+
+
+ToolSchema = dict[str, object]
+
+
+def render_catalog(
+    *,
+    groups: list[DeferredToolGroup],
+    expanded: dict[str, list[str] | None],
+    header: str = DEFAULT_CATALOG_HEADER,
+) -> str:
+    lines: list[str] = []
+
+    for group in sorted(groups, key=lambda g: g.group_id):
+        expanded_names = expanded.get(group.group_id)
+
+        if expanded_names is None and group.group_id in expanded:
+            # Fully expanded (None sentinel) — omit from catalog
+            continue
+
+        if expanded_names is not None:
+            remaining = [n for n in group.tool_names if n not in set(expanded_names)]
+        else:
+            remaining = list(group.tool_names)
+
+        if not remaining:
+            continue
+
+        count = len(remaining)
+        count_label = f"{count} remaining tools" if group.group_id in expanded else f"{count} tools"
+        lines.append(
+            f"- `{group.group_id}` — {group.display_name}: {group.description} ({count_label})"
+        )
+        lines.append(f"  {', '.join(remaining)}")
+
+    if not lines:
+        return ""
+
+    return header + "\n\n" + "\n".join(lines)
+
+
+def render_expanded_schemas(
+    *,
+    expanded_schemas: list[tuple[str, list[ToolSchema]]],
+) -> str:
+    if not expanded_schemas:
+        return ""
+
+    sections: list[str] = []
+    for group_id, tool_defs in expanded_schemas:
+        tool_lines: list[str] = []
+        for td in tool_defs:
+            name = td.get("name", "")
+            desc = td.get("description", "")
+            params = td.get("parameters", {})
+            params_json = json.dumps(params, sort_keys=True, ensure_ascii=False)
+            tool_lines.append(f"- **{name}**: {desc}")
+            tool_lines.append(f"  Parameters: {params_json}")
+        sections.append(f"## {group_id}\n\n" + "\n".join(tool_lines))
+
+    return "# Expanded tool groups\n\n" + "\n\n".join(sections)

--- a/cubepi/deferred/_catalog.py
+++ b/cubepi/deferred/_catalog.py
@@ -40,7 +40,11 @@ def render_catalog(
             continue
 
         count = len(remaining)
-        count_label = f"{count} remaining tools" if group.group_id in expanded else f"{count} tools"
+        count_label = (
+            f"{count} remaining tools"
+            if group.group_id in expanded
+            else f"{count} tools"
+        )
         lines.append(
             f"- `{group.group_id}` — {group.display_name}: {group.description} ({count_label})"
         )

--- a/cubepi/deferred/_expand_tool.py
+++ b/cubepi/deferred/_expand_tool.py
@@ -10,18 +10,20 @@ from cubepi.agent.types import AgentTool, AgentToolResult
 from cubepi.providers.base import TextContent
 from cubepi.types import StructuredValue
 
+TOOL_NAME = "load_tools"
 
-class ExpandToolsInput(BaseModel):
+
+class LoadToolsInput(BaseModel):
     group_id: str = Field(
         description="The group_id from your 'Deferred tool groups' catalog.",
     )
     tool_names: list[str] | None = Field(
         default=None,
-        description="Specific tools to expand. Omit to expand all tools in the group.",
+        description="Specific tools to load. Omit to load all tools in the group.",
     )
 
 
-class ExpandToolsOutput(BaseModel):
+class LoadToolsOutput(BaseModel):
     group_id: str
     expanded: bool
     tool_names: list[str]
@@ -29,25 +31,25 @@ class ExpandToolsOutput(BaseModel):
     error: str | None = None
 
 
-ExpandCallback = Callable[
+LoadCallback = Callable[
     [str, list[str] | None],
-    Awaitable[ExpandToolsOutput],
+    Awaitable[LoadToolsOutput],
 ]
 
 
-def _make_expand_tools(
+def _make_load_tools(
     *,
-    expand_callback: ExpandCallback,
-) -> AgentTool[ExpandToolsInput]:
+    load_callback: LoadCallback,
+) -> AgentTool[LoadToolsInput]:
     async def _execute(
         tool_call_id: str,
-        args: ExpandToolsInput,
+        args: LoadToolsInput,
         *,
         signal: asyncio.Event | None = None,
         on_update: Callable[[StructuredValue], None] | None = None,
     ) -> AgentToolResult:
         del signal, on_update
-        output = await expand_callback(args.group_id, args.tool_names)
+        output = await load_callback(args.group_id, args.tool_names)
         text = json.dumps(output.model_dump(), ensure_ascii=False)
         return AgentToolResult(
             content=[TextContent(text=text)],
@@ -55,12 +57,12 @@ def _make_expand_tools(
         )
 
     return AgentTool(
-        name="expand_tools",
+        name=TOOL_NAME,
         description=(
-            "Expand a deferred tool group to make its tools available. "
+            "Load a deferred tool group to make its tools available. "
             "Call with a group_id from the 'Deferred tool groups' catalog. "
-            "Optionally pass tool_names to expand specific tools only."
+            "Optionally pass tool_names to load specific tools only."
         ),
-        parameters=ExpandToolsInput,
+        parameters=LoadToolsInput,
         execute=_execute,
     )

--- a/cubepi/deferred/_expand_tool.py
+++ b/cubepi/deferred/_expand_tool.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+
+from pydantic import BaseModel, Field
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from cubepi.types import StructuredValue
+
+
+class ExpandToolsInput(BaseModel):
+    group_id: str = Field(
+        description="The group_id from your 'Deferred tool groups' catalog.",
+    )
+    tool_names: list[str] | None = Field(
+        default=None,
+        description="Specific tools to expand. Omit to expand all tools in the group.",
+    )
+
+
+class ExpandToolsOutput(BaseModel):
+    group_id: str
+    expanded: bool
+    tool_names: list[str]
+    remaining: int
+    error: str | None = None
+
+
+ExpandCallback = Callable[
+    [str, list[str] | None],
+    Awaitable[ExpandToolsOutput],
+]
+
+
+def _make_expand_tools(
+    *,
+    expand_callback: ExpandCallback,
+) -> AgentTool[ExpandToolsInput]:
+    async def _execute(
+        tool_call_id: str,
+        args: ExpandToolsInput,
+        *,
+        signal: asyncio.Event | None = None,
+        on_update: Callable[[StructuredValue], None] | None = None,
+    ) -> AgentToolResult:
+        del signal, on_update
+        output = await expand_callback(args.group_id, args.tool_names)
+        text = json.dumps(output.model_dump(), ensure_ascii=False)
+        return AgentToolResult(
+            content=[TextContent(text=text)],
+            is_error=bool(output.error),
+        )
+
+    return AgentTool(
+        name="expand_tools",
+        description=(
+            "Expand a deferred tool group to make its tools available. "
+            "Call with a group_id from the 'Deferred tool groups' catalog. "
+            "Optionally pass tool_names to expand specific tools only."
+        ),
+        parameters=ExpandToolsInput,
+        execute=_execute,
+    )

--- a/cubepi/deferred/_expand_tool.py
+++ b/cubepi/deferred/_expand_tool.py
@@ -51,7 +51,7 @@ def _make_expand_tools(
         text = json.dumps(output.model_dump(), ensure_ascii=False)
         return AgentToolResult(
             content=[TextContent(text=text)],
-            is_error=bool(output.error),
+            is_error=not output.expanded,
         )
 
     return AgentTool(

--- a/cubepi/deferred/middleware.py
+++ b/cubepi/deferred/middleware.py
@@ -1,7 +1,7 @@
 """DeferredToolsMiddleware — progressive tool disclosure for large tool sets.
 
 Two-phase expansion:
-1. ``_expand_callback`` runs inside ``expand_tools`` execute (no AgentContext).
+1. ``_expand_callback`` runs inside ``load_tools`` execute (no AgentContext).
    Validates, invokes the loader (cached), updates state, queues pending tools.
 2. ``after_tool_call`` fires after execute and injects pending tools into
    ``ctx.context.tools`` so the next model loop iteration sees them.
@@ -29,8 +29,9 @@ from cubepi.deferred._catalog import (
     render_expanded_schemas,
 )
 from cubepi.deferred._expand_tool import (
-    ExpandToolsOutput,
-    _make_expand_tools,
+    TOOL_NAME,
+    LoadToolsOutput,
+    _make_load_tools,
 )
 from cubepi.deferred.types import DeferredToolGroup
 from cubepi.middleware.base import Middleware
@@ -50,7 +51,7 @@ class DeferredToolsMiddleware(Middleware):
     """Middleware that manages deferred tool groups via progressive disclosure.
 
     Attributes:
-        tools: ``[expand_tools]`` — merged into agent state at construction.
+        tools: ``[load_tools]`` — merged into agent state at construction.
     """
 
     def __init__(
@@ -82,7 +83,7 @@ class DeferredToolsMiddleware(Middleware):
         self._loader_locks: dict[str, asyncio.Lock] = {}
 
         self.tools: list[AgentTool] = [
-            _make_expand_tools(expand_callback=self._expand_callback)
+            _make_load_tools(load_callback=self._expand_callback)
         ]
 
     # ------------------------------------------------------------------
@@ -93,11 +94,11 @@ class DeferredToolsMiddleware(Middleware):
         self,
         group_id: str,
         tool_names: list[str] | None,
-    ) -> ExpandToolsOutput:
+    ) -> LoadToolsOutput:
         extra = self._extra_ref()
         group = self._groups.get(group_id)
         if group is None:
-            return ExpandToolsOutput(
+            return LoadToolsOutput(
                 group_id=group_id,
                 expanded=False,
                 tool_names=[],
@@ -115,7 +116,7 @@ class DeferredToolsMiddleware(Middleware):
                 if group_id not in self._loader_cache:
                     self._loader_cache[group_id] = await group.loader()
             except Exception as exc:
-                return ExpandToolsOutput(
+                return LoadToolsOutput(
                     group_id=group_id,
                     expanded=False,
                     tool_names=[],
@@ -199,7 +200,7 @@ class DeferredToolsMiddleware(Middleware):
         else:
             remaining = len(group.tool_names)
 
-        return ExpandToolsOutput(
+        return LoadToolsOutput(
             group_id=group_id,
             expanded=True,
             tool_names=expanded_names,
@@ -232,7 +233,7 @@ class DeferredToolsMiddleware(Middleware):
         group_id: str,
         tool_names: list[str] | None,
         context: AgentContext,
-    ) -> ExpandToolsOutput:
+    ) -> LoadToolsOutput:
         output = await self._expand_callback(group_id, tool_names)
         if output.expanded and context.tools is not None:
             self._drain_pending(context.tools)
@@ -249,7 +250,7 @@ class DeferredToolsMiddleware(Middleware):
         signal: asyncio.Event | None = None,
     ) -> AfterToolCallResult | None:
         del signal
-        if ctx.tool_call.name != "expand_tools":
+        if ctx.tool_call.name != TOOL_NAME:
             return None
         if ctx.is_error:
             return None
@@ -309,22 +310,26 @@ class DeferredToolsMiddleware(Middleware):
         selected tools pre-loaded but stay in remaining (still deferrable).
         Unexpanded groups pass through untouched.
         """
-        pre_loaded: list[AgentTool] = []
+        # Partition groups and load expanded ones concurrently.
         remaining: list[DeferredToolGroup] = []
-        schemas: list[tuple[str, list[ToolSchema]]] = []
-        cache: dict[str, list[AgentTool]] = {}
-
+        to_load: list[tuple[DeferredToolGroup, list[str] | None]] = []
         for group in groups:
             exp = expanded.get(group.group_id)
             if exp is None and group.group_id not in expanded:
-                # Never expanded — stays deferred.
                 remaining.append(group)
-                continue
+            else:
+                to_load.append((group, exp))
 
-            loaded = await group.loader()
+        loaded_results: list[list[AgentTool]] = await asyncio.gather(
+            *(g.loader() for g, _ in to_load)
+        )
+
+        pre_loaded: list[AgentTool] = []
+        schemas: list[tuple[str, list[ToolSchema]]] = []
+        cache: dict[str, list[AgentTool]] = {}
+        for (group, exp), loaded in zip(to_load, loaded_results):
             cache[group.group_id] = loaded
             if exp is None:
-                # Fully expanded (None sentinel) — load all, drop from remaining.
                 pre_loaded.extend(loaded)
                 schemas.append(
                     (
@@ -333,7 +338,6 @@ class DeferredToolsMiddleware(Middleware):
                     )
                 )
             else:
-                # Partially expanded — load selected, keep in remaining.
                 name_set = set(exp)
                 selected = [t for t in loaded if t.name in name_set]
                 pre_loaded.extend(selected)

--- a/cubepi/deferred/middleware.py
+++ b/cubepi/deferred/middleware.py
@@ -176,7 +176,7 @@ class DeferredToolsMiddleware(Middleware):
                 self._expanded_schemas.append((group_id, new_schemas))
 
         # Stage newly expanded tools for injection by after_tool_call.
-        self._pending_injection = newly_expanded
+        self._pending_injection.extend(newly_expanded)
 
         # Calculate remaining count.
         current_expanded = expanded_groups.get(group_id)
@@ -207,8 +207,8 @@ class DeferredToolsMiddleware(Middleware):
     ) -> ExpandToolsOutput:
         output = await self._expand_callback(group_id, tool_names)
         if output.expanded and self._pending_injection:
-            newly_expanded = self._pending_injection
-            self._pending_injection = []
+            newly_expanded = list(self._pending_injection)
+            self._pending_injection.clear()
             if context.tools is not None:
                 existing_names = {t.name for t in context.tools}
                 for tool in newly_expanded:
@@ -233,8 +233,8 @@ class DeferredToolsMiddleware(Middleware):
             return None
 
         if self._pending_injection:
-            newly_expanded = self._pending_injection
-            self._pending_injection = []
+            newly_expanded = list(self._pending_injection)
+            self._pending_injection.clear()
             if ctx.context.tools is not None:
                 existing_names = {t.name for t in ctx.context.tools}
                 for tool in newly_expanded:

--- a/cubepi/deferred/middleware.py
+++ b/cubepi/deferred/middleware.py
@@ -60,9 +60,7 @@ class DeferredToolsMiddleware(Middleware):
         catalog_header: str = DEFAULT_CATALOG_HEADER,
         resumed_schemas: list[tuple[str, list[ToolSchema]]] | None = None,
     ) -> None:
-        self._groups: dict[str, DeferredToolGroup] = {
-            g.group_id: g for g in groups
-        }
+        self._groups: dict[str, DeferredToolGroup] = {g.group_id: g for g in groups}
         self._extra_ref = extra_ref
         self._catalog_header = catalog_header
 
@@ -119,7 +117,8 @@ class DeferredToolsMiddleware(Middleware):
 
         # Determine what is already expanded.
         expanded_groups: dict[str, list[str] | None] = extra.get(
-            "expanded_groups", {},
+            "expanded_groups",
+            {},
         )
         already_val = expanded_groups.get(group_id)
         if group_id in expanded_groups and already_val is None:
@@ -159,9 +158,7 @@ class DeferredToolsMiddleware(Middleware):
 
         # Record schemas for expanded tools (append-only).
         if newly_expanded:
-            new_schemas = [
-                t.to_definition().model_dump() for t in newly_expanded
-            ]
+            new_schemas = [t.to_definition().model_dump() for t in newly_expanded]
             existing_idx = next(
                 (
                     i
@@ -261,7 +258,8 @@ class DeferredToolsMiddleware(Middleware):
         del signal
         extra = self._extra_ref()
         expanded: dict[str, list[str] | None] = extra.get(
-            "expanded_groups", {},
+            "expanded_groups",
+            {},
         )
 
         catalog = render_catalog(
@@ -313,19 +311,23 @@ class DeferredToolsMiddleware(Middleware):
             if exp is None:
                 # Fully expanded (None sentinel) — load all, drop from remaining.
                 pre_loaded.extend(loaded)
-                schemas.append((
-                    group.group_id,
-                    [t.to_definition().model_dump() for t in loaded],
-                ))
+                schemas.append(
+                    (
+                        group.group_id,
+                        [t.to_definition().model_dump() for t in loaded],
+                    )
+                )
             else:
                 # Partially expanded — load selected, keep in remaining.
                 name_set = set(exp)
                 selected = [t for t in loaded if t.name in name_set]
                 pre_loaded.extend(selected)
-                schemas.append((
-                    group.group_id,
-                    [t.to_definition().model_dump() for t in selected],
-                ))
+                schemas.append(
+                    (
+                        group.group_id,
+                        [t.to_definition().model_dump() for t in selected],
+                    )
+                )
                 remaining.append(group)
 
         return ResumedState(

--- a/cubepi/deferred/middleware.py
+++ b/cubepi/deferred/middleware.py
@@ -195,10 +195,9 @@ class DeferredToolsMiddleware(Middleware):
         current_expanded = expanded_groups.get(group_id)
         if current_expanded is None and group_id in expanded_groups:
             remaining = 0
-        elif isinstance(current_expanded, list):
-            remaining = len(group.tool_names) - len(current_expanded)
         else:
-            remaining = len(group.tool_names)
+            assert isinstance(current_expanded, list)
+            remaining = len(group.tool_names) - len(current_expanded)
 
         return LoadToolsOutput(
             group_id=group_id,

--- a/cubepi/deferred/middleware.py
+++ b/cubepi/deferred/middleware.py
@@ -42,6 +42,7 @@ class ResumedState:
 
     pre_loaded_tools: list[AgentTool]
     remaining_groups: list[DeferredToolGroup]
+    expanded_schemas: list[tuple[str, list[ToolSchema]]]
 
 
 class DeferredToolsMiddleware(Middleware):
@@ -57,6 +58,7 @@ class DeferredToolsMiddleware(Middleware):
         groups: list[DeferredToolGroup],
         extra_ref: Callable[[], dict[str, Any]],
         catalog_header: str = DEFAULT_CATALOG_HEADER,
+        resumed_schemas: list[tuple[str, list[ToolSchema]]] | None = None,
     ) -> None:
         self._groups: dict[str, DeferredToolGroup] = {
             g.group_id: g for g in groups
@@ -67,7 +69,9 @@ class DeferredToolsMiddleware(Middleware):
         # Loader called exactly once per group per run.
         self._loader_cache: dict[str, list[AgentTool]] = {}
         # Append-only, expansion order for cache stability.
-        self._expanded_schemas: list[tuple[str, list[ToolSchema]]] = []
+        self._expanded_schemas: list[tuple[str, list[ToolSchema]]] = (
+            list(resumed_schemas) if resumed_schemas else []
+        )
         # Staging area: expand_callback queues, after_tool_call drains.
         self._pending_injection: list[AgentTool] = []
 
@@ -296,6 +300,7 @@ class DeferredToolsMiddleware(Middleware):
         """
         pre_loaded: list[AgentTool] = []
         remaining: list[DeferredToolGroup] = []
+        schemas: list[tuple[str, list[ToolSchema]]] = []
 
         for group in groups:
             exp = expanded.get(group.group_id)
@@ -308,14 +313,23 @@ class DeferredToolsMiddleware(Middleware):
             if exp is None:
                 # Fully expanded (None sentinel) — load all, drop from remaining.
                 pre_loaded.extend(loaded)
+                schemas.append((
+                    group.group_id,
+                    [t.to_definition().model_dump() for t in loaded],
+                ))
             else:
                 # Partially expanded — load selected, keep in remaining.
                 name_set = set(exp)
                 selected = [t for t in loaded if t.name in name_set]
                 pre_loaded.extend(selected)
+                schemas.append((
+                    group.group_id,
+                    [t.to_definition().model_dump() for t in selected],
+                ))
                 remaining.append(group)
 
         return ResumedState(
             pre_loaded_tools=pre_loaded,
             remaining_groups=remaining,
+            expanded_schemas=schemas,
         )

--- a/cubepi/deferred/middleware.py
+++ b/cubepi/deferred/middleware.py
@@ -1,0 +1,321 @@
+"""DeferredToolsMiddleware — progressive tool disclosure for large tool sets.
+
+Two-phase expansion:
+1. ``_expand_callback`` runs inside ``expand_tools`` execute (no AgentContext).
+   Validates, invokes the loader (cached), updates state, queues pending tools.
+2. ``after_tool_call`` fires after execute and injects pending tools into
+   ``ctx.context.tools`` so the next model loop iteration sees them.
+
+``_expand`` combines both phases for testing without the full agent loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from cubepi.agent.types import (
+    AfterToolCallContext,
+    AfterToolCallResult,
+    AgentContext,
+    AgentTool,
+)
+from cubepi.deferred._catalog import (
+    DEFAULT_CATALOG_HEADER,
+    ToolSchema,
+    render_catalog,
+    render_expanded_schemas,
+)
+from cubepi.deferred._expand_tool import (
+    ExpandToolsOutput,
+    _make_expand_tools,
+)
+from cubepi.deferred.types import DeferredToolGroup
+from cubepi.middleware.base import Middleware
+
+
+@dataclass
+class ResumedState:
+    """Pre-loaded tools and remaining groups for cross-run replay."""
+
+    pre_loaded_tools: list[AgentTool]
+    remaining_groups: list[DeferredToolGroup]
+
+
+class DeferredToolsMiddleware(Middleware):
+    """Middleware that manages deferred tool groups via progressive disclosure.
+
+    Attributes:
+        tools: ``[expand_tools]`` — merged into agent state at construction.
+    """
+
+    def __init__(
+        self,
+        *,
+        groups: list[DeferredToolGroup],
+        extra_ref: Callable[[], dict[str, Any]],
+        catalog_header: str = DEFAULT_CATALOG_HEADER,
+    ) -> None:
+        self._groups: dict[str, DeferredToolGroup] = {
+            g.group_id: g for g in groups
+        }
+        self._extra_ref = extra_ref
+        self._catalog_header = catalog_header
+
+        # Loader called exactly once per group per run.
+        self._loader_cache: dict[str, list[AgentTool]] = {}
+        # Append-only, expansion order for cache stability.
+        self._expanded_schemas: list[tuple[str, list[ToolSchema]]] = []
+        # Staging area: expand_callback queues, after_tool_call drains.
+        self._pending_injection: list[AgentTool] = []
+
+        self.tools: list[AgentTool] = [
+            _make_expand_tools(expand_callback=self._expand_callback)
+        ]
+
+    # ------------------------------------------------------------------
+    # Phase 1: expand callback (called from expand_tools execute)
+    # ------------------------------------------------------------------
+
+    async def _expand_callback(
+        self,
+        group_id: str,
+        tool_names: list[str] | None,
+    ) -> ExpandToolsOutput:
+        extra = self._extra_ref()
+        group = self._groups.get(group_id)
+        if group is None:
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=False,
+                tool_names=[],
+                remaining=0,
+                error=(
+                    f"Unknown group_id: {group_id}. "
+                    f"Available: {', '.join(sorted(self._groups))}"
+                ),
+            )
+
+        # Load once per group per run.
+        try:
+            if group_id not in self._loader_cache:
+                self._loader_cache[group_id] = await group.loader()
+        except Exception as exc:
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=False,
+                tool_names=[],
+                remaining=len(group.tool_names),
+                error=f"Loader failed: {exc}",
+            )
+
+        all_loaded = self._loader_cache[group_id]
+
+        # Determine what is already expanded.
+        expanded_groups: dict[str, list[str] | None] = extra.get(
+            "expanded_groups", {},
+        )
+        already_val = expanded_groups.get(group_id)
+        if group_id in expanded_groups and already_val is None:
+            # Fully expanded (None sentinel) — everything already injected.
+            already_set: set[str] = {t.name for t in all_loaded}
+        elif isinstance(already_val, list):
+            already_set = set(already_val)
+        else:
+            already_set = set()
+
+        # Filter to requested tools.
+        if tool_names is not None:
+            requested_set = set(tool_names)
+            requested = [t for t in all_loaded if t.name in requested_set]
+        else:
+            requested = list(all_loaded)
+
+        newly_expanded = [t for t in requested if t.name not in already_set]
+        expanded_names = [t.name for t in requested]
+
+        # Update expansion state.
+        if tool_names is None:
+            expanded_groups[group_id] = None
+        else:
+            prev = expanded_groups.get(group_id)
+            if prev is None and group_id in expanded_groups:
+                pass  # already fully expanded, no-op
+            else:
+                merged = list(prev) if isinstance(prev, list) else []
+                merged_set = set(merged)
+                for name in expanded_names:
+                    if name not in merged_set:
+                        merged.append(name)
+                        merged_set.add(name)
+                expanded_groups[group_id] = merged
+        extra["expanded_groups"] = expanded_groups
+
+        # Record schemas for expanded tools (append-only).
+        if newly_expanded:
+            new_schemas = [
+                t.to_definition().model_dump() for t in newly_expanded
+            ]
+            existing_idx = next(
+                (
+                    i
+                    for i, (gid, _) in enumerate(self._expanded_schemas)
+                    if gid == group_id
+                ),
+                None,
+            )
+            if existing_idx is not None:
+                prev_schemas = self._expanded_schemas[existing_idx][1]
+                self._expanded_schemas[existing_idx] = (
+                    group_id,
+                    prev_schemas + new_schemas,
+                )
+            else:
+                self._expanded_schemas.append((group_id, new_schemas))
+
+        # Stage newly expanded tools for injection by after_tool_call.
+        self._pending_injection = newly_expanded
+
+        # Calculate remaining count.
+        current_expanded = expanded_groups.get(group_id)
+        if current_expanded is None and group_id in expanded_groups:
+            remaining = 0
+        elif isinstance(current_expanded, list):
+            remaining = len(group.tool_names) - len(current_expanded)
+        else:
+            remaining = len(group.tool_names)
+
+        return ExpandToolsOutput(
+            group_id=group_id,
+            expanded=True,
+            tool_names=expanded_names,
+            remaining=max(remaining, 0),
+        )
+
+    # ------------------------------------------------------------------
+    # Combined expand + inject (for testing without the full agent loop)
+    # ------------------------------------------------------------------
+
+    async def _expand(
+        self,
+        *,
+        group_id: str,
+        tool_names: list[str] | None,
+        context: AgentContext,
+    ) -> ExpandToolsOutput:
+        output = await self._expand_callback(group_id, tool_names)
+        if output.expanded and self._pending_injection:
+            newly_expanded = self._pending_injection
+            self._pending_injection = []
+            if context.tools is not None:
+                existing_names = {t.name for t in context.tools}
+                for tool in newly_expanded:
+                    if tool.name not in existing_names:
+                        context.tools.append(tool)
+        return output
+
+    # ------------------------------------------------------------------
+    # Phase 2: after_tool_call hook (injects tools into live context)
+    # ------------------------------------------------------------------
+
+    async def after_tool_call(
+        self,
+        ctx: AfterToolCallContext,
+        *,
+        signal: asyncio.Event | None = None,
+    ) -> AfterToolCallResult | None:
+        del signal
+        if ctx.tool_call.name != "expand_tools":
+            return None
+        if ctx.is_error:
+            return None
+
+        if self._pending_injection:
+            newly_expanded = self._pending_injection
+            self._pending_injection = []
+            if ctx.context.tools is not None:
+                existing_names = {t.name for t in ctx.context.tools}
+                for tool in newly_expanded:
+                    if tool.name not in existing_names:
+                        ctx.context.tools.append(tool)
+
+        return None
+
+    # ------------------------------------------------------------------
+    # System prompt: catalog + expanded schemas
+    # ------------------------------------------------------------------
+
+    async def transform_system_prompt(
+        self,
+        system_prompt: str,
+        *,
+        ctx: AgentContext,
+        signal: asyncio.Event | None = None,
+    ) -> str:
+        del signal
+        extra = self._extra_ref()
+        expanded: dict[str, list[str] | None] = extra.get(
+            "expanded_groups", {},
+        )
+
+        catalog = render_catalog(
+            groups=list(self._groups.values()),
+            expanded=expanded,
+            header=self._catalog_header,
+        )
+
+        schemas = render_expanded_schemas(
+            expanded_schemas=self._expanded_schemas,
+        )
+
+        parts = [system_prompt]
+        if catalog:
+            parts.append(catalog)
+        if schemas:
+            parts.append(schemas)
+
+        return "\n\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # Cross-run replay
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    async def prepare_resumed_state(
+        groups: list[DeferredToolGroup],
+        expanded: dict[str, list[str] | None],
+    ) -> ResumedState:
+        """Replay expansion state from a previous run.
+
+        Fully expanded groups (``None``) get all tools pre-loaded and are
+        removed from the remaining set.  Partially expanded groups get the
+        selected tools pre-loaded but stay in remaining (still deferrable).
+        Unexpanded groups pass through untouched.
+        """
+        pre_loaded: list[AgentTool] = []
+        remaining: list[DeferredToolGroup] = []
+
+        for group in groups:
+            exp = expanded.get(group.group_id)
+            if exp is None and group.group_id not in expanded:
+                # Never expanded — stays deferred.
+                remaining.append(group)
+                continue
+
+            loaded = await group.loader()
+            if exp is None:
+                # Fully expanded (None sentinel) — load all, drop from remaining.
+                pre_loaded.extend(loaded)
+            else:
+                # Partially expanded — load selected, keep in remaining.
+                name_set = set(exp)
+                selected = [t for t in loaded if t.name in name_set]
+                pre_loaded.extend(selected)
+                remaining.append(group)
+
+        return ResumedState(
+            pre_loaded_tools=pre_loaded,
+            remaining_groups=remaining,
+        )

--- a/cubepi/deferred/middleware.py
+++ b/cubepi/deferred/middleware.py
@@ -43,6 +43,7 @@ class ResumedState:
     pre_loaded_tools: list[AgentTool]
     remaining_groups: list[DeferredToolGroup]
     expanded_schemas: list[tuple[str, list[ToolSchema]]]
+    loader_cache: dict[str, list[AgentTool]]
 
 
 class DeferredToolsMiddleware(Middleware):
@@ -59,13 +60,18 @@ class DeferredToolsMiddleware(Middleware):
         extra_ref: Callable[[], dict[str, Any]],
         catalog_header: str = DEFAULT_CATALOG_HEADER,
         resumed_schemas: list[tuple[str, list[ToolSchema]]] | None = None,
+        resumed_loader_cache: dict[str, list[AgentTool]] | None = None,
+        on_tools_expanded: Callable[[list[AgentTool]], None] | None = None,
     ) -> None:
         self._groups: dict[str, DeferredToolGroup] = {g.group_id: g for g in groups}
         self._extra_ref = extra_ref
         self._catalog_header = catalog_header
+        self._on_tools_expanded = on_tools_expanded
 
         # Loader called exactly once per group per run.
-        self._loader_cache: dict[str, list[AgentTool]] = {}
+        self._loader_cache: dict[str, list[AgentTool]] = (
+            dict(resumed_loader_cache) if resumed_loader_cache else {}
+        )
         # Append-only, expansion order for cache stability.
         self._expanded_schemas: list[tuple[str, list[ToolSchema]]] = (
             list(resumed_schemas) if resumed_schemas else []
@@ -115,11 +121,10 @@ class DeferredToolsMiddleware(Middleware):
 
         all_loaded = self._loader_cache[group_id]
 
-        # Determine what is already expanded.
-        expanded_groups: dict[str, list[str] | None] = extra.get(
-            "expanded_groups",
-            {},
-        )
+        # Use the shared dict in extra — never replace it, only mutate in place.
+        if "expanded_groups" not in extra:
+            extra["expanded_groups"] = {}
+        expanded_groups: dict[str, list[str] | None] = extra["expanded_groups"]
         already_val = expanded_groups.get(group_id)
         if group_id in expanded_groups and already_val is None:
             # Fully expanded (None sentinel) — everything already injected.
@@ -154,7 +159,6 @@ class DeferredToolsMiddleware(Middleware):
                         merged.append(name)
                         merged_set.add(name)
                 expanded_groups[group_id] = merged
-        extra["expanded_groups"] = expanded_groups
 
         # Record schemas for expanded tools (append-only).
         if newly_expanded:
@@ -178,6 +182,9 @@ class DeferredToolsMiddleware(Middleware):
 
         # Stage newly expanded tools for injection by after_tool_call.
         self._pending_injection.extend(newly_expanded)
+        # Persist to the agent's canonical tool list for cross-prompt() use.
+        if newly_expanded and self._on_tools_expanded:
+            self._on_tools_expanded(newly_expanded)
 
         # Calculate remaining count.
         current_expanded = expanded_groups.get(group_id)
@@ -196,6 +203,22 @@ class DeferredToolsMiddleware(Middleware):
         )
 
     # ------------------------------------------------------------------
+    # Drain pending injection into a tools list (shared by _expand and
+    # after_tool_call so the dedup logic lives in one place).
+    # ------------------------------------------------------------------
+
+    def _drain_pending(self, tools: list[AgentTool]) -> None:
+        if not self._pending_injection:
+            return
+        pending = list(self._pending_injection)
+        self._pending_injection.clear()
+        existing_names = {t.name for t in tools}
+        for tool in pending:
+            if tool.name not in existing_names:
+                tools.append(tool)
+                existing_names.add(tool.name)
+
+    # ------------------------------------------------------------------
     # Combined expand + inject (for testing without the full agent loop)
     # ------------------------------------------------------------------
 
@@ -207,14 +230,8 @@ class DeferredToolsMiddleware(Middleware):
         context: AgentContext,
     ) -> ExpandToolsOutput:
         output = await self._expand_callback(group_id, tool_names)
-        if output.expanded and self._pending_injection:
-            newly_expanded = list(self._pending_injection)
-            self._pending_injection.clear()
-            if context.tools is not None:
-                existing_names = {t.name for t in context.tools}
-                for tool in newly_expanded:
-                    if tool.name not in existing_names:
-                        context.tools.append(tool)
+        if output.expanded and context.tools is not None:
+            self._drain_pending(context.tools)
         return output
 
     # ------------------------------------------------------------------
@@ -232,16 +249,8 @@ class DeferredToolsMiddleware(Middleware):
             return None
         if ctx.is_error:
             return None
-
-        if self._pending_injection:
-            newly_expanded = list(self._pending_injection)
-            self._pending_injection.clear()
-            if ctx.context.tools is not None:
-                existing_names = {t.name for t in ctx.context.tools}
-                for tool in newly_expanded:
-                    if tool.name not in existing_names:
-                        ctx.context.tools.append(tool)
-
+        if ctx.context.tools is not None:
+            self._drain_pending(ctx.context.tools)
         return None
 
     # ------------------------------------------------------------------
@@ -299,6 +308,7 @@ class DeferredToolsMiddleware(Middleware):
         pre_loaded: list[AgentTool] = []
         remaining: list[DeferredToolGroup] = []
         schemas: list[tuple[str, list[ToolSchema]]] = []
+        cache: dict[str, list[AgentTool]] = {}
 
         for group in groups:
             exp = expanded.get(group.group_id)
@@ -308,6 +318,7 @@ class DeferredToolsMiddleware(Middleware):
                 continue
 
             loaded = await group.loader()
+            cache[group.group_id] = loaded
             if exp is None:
                 # Fully expanded (None sentinel) — load all, drop from remaining.
                 pre_loaded.extend(loaded)
@@ -334,4 +345,5 @@ class DeferredToolsMiddleware(Middleware):
             pre_loaded_tools=pre_loaded,
             remaining_groups=remaining,
             expanded_schemas=schemas,
+            loader_cache=cache,
         )

--- a/cubepi/deferred/middleware.py
+++ b/cubepi/deferred/middleware.py
@@ -78,6 +78,8 @@ class DeferredToolsMiddleware(Middleware):
         )
         # Staging area: expand_callback queues, after_tool_call drains.
         self._pending_injection: list[AgentTool] = []
+        # Per-group lock to prevent concurrent loader invocations.
+        self._loader_locks: dict[str, asyncio.Lock] = {}
 
         self.tools: list[AgentTool] = [
             _make_expand_tools(expand_callback=self._expand_callback)
@@ -106,18 +108,20 @@ class DeferredToolsMiddleware(Middleware):
                 ),
             )
 
-        # Load once per group per run.
-        try:
-            if group_id not in self._loader_cache:
-                self._loader_cache[group_id] = await group.loader()
-        except Exception as exc:
-            return ExpandToolsOutput(
-                group_id=group_id,
-                expanded=False,
-                tool_names=[],
-                remaining=len(group.tool_names),
-                error=f"Loader failed: {exc}",
-            )
+        # Load once per group per run (lock prevents duplicate under parallel).
+        lock = self._loader_locks.setdefault(group_id, asyncio.Lock())
+        async with lock:
+            try:
+                if group_id not in self._loader_cache:
+                    self._loader_cache[group_id] = await group.loader()
+            except Exception as exc:
+                return ExpandToolsOutput(
+                    group_id=group_id,
+                    expanded=False,
+                    tool_names=[],
+                    remaining=len(group.tool_names),
+                    error=f"Loader failed: {exc}",
+                )
 
         all_loaded = self._loader_cache[group_id]
 

--- a/cubepi/deferred/types.py
+++ b/cubepi/deferred/types.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from cubepi.agent.types import AgentTool
+
+
+@dataclass
+class DeferredToolGroup:
+    """A group of tools that starts collapsed and expands on demand.
+
+    ``loader`` is called exactly once per group per agent run — the middleware
+    caches the result and filters by ``tool_names`` on selective expansions.
+    """
+
+    group_id: str
+    display_name: str
+    description: str
+    tool_names: list[str]
+    loader: Callable[[], Awaitable[list[AgentTool]]]

--- a/dev/plans/2026-06-09-deferred-tool-group.md
+++ b/dev/plans/2026-06-09-deferred-tool-group.md
@@ -1,0 +1,1365 @@
+# DeferredToolGroup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `DeferredToolGroup` primitive to cubepi that lets host applications register groups of tools that start collapsed (catalog only) and expand on demand mid-run, reducing context bloat and improving tool selection accuracy.
+
+**Architecture:** A new `cubepi/deferred/` package provides `DeferredToolGroup` (dataclass) and `DeferredToolsMiddleware` (middleware). The middleware injects an `expand_tools` builtin, renders a catalog in the system prompt, and handles mid-run tool injection via the `after_tool_call` hook. `Agent.__init__` gains a `deferred_tool_groups` parameter that auto-creates the middleware. Zero changes to `loop.py`.
+
+**Tech Stack:** Python 3.11+, Pydantic v2 (tool input/output schemas), pytest with `asyncio_mode=auto`, mypy strict.
+
+---
+
+## File Structure
+
+- **Create** `cubepi/deferred/__init__.py` — public exports: `DeferredToolGroup`, `DeferredToolsMiddleware`, `ResumedState`.
+- **Create** `cubepi/deferred/types.py` — `DeferredToolGroup` dataclass.
+- **Create** `cubepi/deferred/_catalog.py` — pure functions: `render_catalog()`, `render_expanded_schemas()`.
+- **Create** `cubepi/deferred/_expand_tool.py` — `expand_tools` builtin factory (`_make_expand_tools`), `ExpandToolsInput`, `ExpandToolsOutput`.
+- **Create** `cubepi/deferred/middleware.py` — `DeferredToolsMiddleware`, `ResumedState`, `prepare_resumed_state`.
+- **Modify** `cubepi/agent/agent.py:141-166` — add `deferred_tool_groups` parameter, auto-create middleware.
+- **Create** `tests/deferred/__init__.py` — empty.
+- **Create** `tests/deferred/test_catalog.py` — catalog rendering tests.
+- **Create** `tests/deferred/test_expand_tool.py` — expand_tools builtin tests.
+- **Create** `tests/deferred/test_middleware.py` — middleware integration tests.
+- **Create** `tests/deferred/test_agent_wiring.py` — Agent-level `deferred_tool_groups` wiring tests.
+
+---
+
+## Task 1: `DeferredToolGroup` dataclass
+
+**Files:**
+- Create: `cubepi/deferred/__init__.py`
+- Create: `cubepi/deferred/types.py`
+- Create: `tests/deferred/__init__.py`
+- Test: `tests/deferred/test_catalog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/deferred/test_catalog.py
+from __future__ import annotations
+
+import pytest
+
+from cubepi.deferred.types import DeferredToolGroup
+
+
+class TestDeferredToolGroup:
+    def test_basic_construction(self) -> None:
+        async def _loader():
+            return []
+
+        group = DeferredToolGroup(
+            group_id="mcp:github",
+            display_name="GitHub",
+            description="Code hosting: issues, PRs, repos",
+            tool_names=["create_issue", "search_repos"],
+            loader=_loader,
+        )
+        assert group.group_id == "mcp:github"
+        assert group.display_name == "GitHub"
+        assert group.description == "Code hosting: issues, PRs, repos"
+        assert group.tool_names == ["create_issue", "search_repos"]
+        assert group.loader is _loader
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_catalog.py::TestDeferredToolGroup::test_basic_construction -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cubepi.deferred'`
+
+- [ ] **Step 3: Create the package and dataclass**
+
+```python
+# cubepi/deferred/__init__.py
+"""Deferred tool groups — progressive tool disclosure primitive."""
+
+from cubepi.deferred.types import DeferredToolGroup
+
+__all__ = ["DeferredToolGroup"]
+```
+
+```python
+# cubepi/deferred/types.py
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from cubepi.agent.types import AgentTool
+
+
+@dataclass
+class DeferredToolGroup:
+    """A group of tools that starts collapsed and expands on demand.
+
+    ``loader`` is called exactly once per group per agent run — the middleware
+    caches the result and filters by ``tool_names`` on selective expansions.
+    """
+
+    group_id: str
+    display_name: str
+    description: str
+    tool_names: list[str]
+    loader: Callable[[], Awaitable[list[AgentTool]]]
+```
+
+```python
+# tests/deferred/__init__.py
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_catalog.py::TestDeferredToolGroup::test_basic_construction -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && git add cubepi/deferred/__init__.py cubepi/deferred/types.py tests/deferred/__init__.py tests/deferred/test_catalog.py && git commit -m "feat(deferred): add DeferredToolGroup dataclass (#166)"
+```
+
+---
+
+## Task 2: Catalog rendering — pure functions
+
+**Files:**
+- Create: `cubepi/deferred/_catalog.py`
+- Test: `tests/deferred/test_catalog.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/deferred/test_catalog.py`:
+
+```python
+from cubepi.deferred._catalog import render_catalog, render_expanded_schemas
+
+
+def _make_group(
+    group_id: str,
+    display_name: str,
+    description: str,
+    tool_names: list[str],
+) -> DeferredToolGroup:
+    async def _noop_loader():
+        return []
+
+    return DeferredToolGroup(
+        group_id=group_id,
+        display_name=display_name,
+        description=description,
+        tool_names=tool_names,
+        loader=_noop_loader,
+    )
+
+
+class TestRenderCatalog:
+    def test_no_groups_returns_empty(self) -> None:
+        result = render_catalog(groups=[], expanded={})
+        assert result == ""
+
+    def test_single_group_no_expansion(self) -> None:
+        groups = [_make_group("mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos"])]
+        result = render_catalog(groups=groups, expanded={})
+        assert "mcp:github" in result
+        assert "GitHub" in result
+        assert "Code hosting" in result
+        assert "2 tools" in result
+        assert "create_issue" in result
+        assert "search_repos" in result
+
+    def test_sorted_by_group_id(self) -> None:
+        groups = [
+            _make_group("z:last", "Last", "desc", ["t1"]),
+            _make_group("a:first", "First", "desc", ["t2"]),
+        ]
+        result = render_catalog(groups=groups, expanded={})
+        a_pos = result.index("a:first")
+        z_pos = result.index("z:last")
+        assert a_pos < z_pos
+
+    def test_byte_stable_across_input_orderings(self) -> None:
+        g1 = _make_group("mcp:a", "A", "desc", ["t1"])
+        g2 = _make_group("mcp:b", "B", "desc", ["t2"])
+        result_ab = render_catalog(groups=[g1, g2], expanded={})
+        result_ba = render_catalog(groups=[g2, g1], expanded={})
+        assert result_ab == result_ba
+
+    def test_fully_expanded_group_omitted(self) -> None:
+        groups = [
+            _make_group("mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos"]),
+            _make_group("mcp:linear", "Linear", "Issues", ["create_issue"]),
+        ]
+        expanded: dict[str, list[str] | None] = {"mcp:github": None}
+        result = render_catalog(groups=groups, expanded=expanded)
+        assert "mcp:github" not in result
+        assert "mcp:linear" in result
+
+    def test_partially_expanded_shows_remaining(self) -> None:
+        groups = [_make_group("mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos", "create_pr"])]
+        expanded: dict[str, list[str] | None] = {"mcp:github": ["create_issue"]}
+        result = render_catalog(groups=groups, expanded=expanded)
+        assert "2 remaining tools" in result
+        assert "create_issue" not in result
+        assert "search_repos" in result
+        assert "create_pr" in result
+
+    def test_all_groups_fully_expanded_returns_empty(self) -> None:
+        groups = [_make_group("mcp:github", "GitHub", "desc", ["t1"])]
+        expanded: dict[str, list[str] | None] = {"mcp:github": None}
+        result = render_catalog(groups=groups, expanded=expanded)
+        assert result == ""
+
+    def test_custom_header(self) -> None:
+        groups = [_make_group("mcp:a", "A", "desc", ["t1"])]
+        result = render_catalog(groups=groups, expanded={}, header="Custom header text")
+        assert "Custom header text" in result
+
+
+class TestRenderExpandedSchemas:
+    def test_no_expansions_returns_empty(self) -> None:
+        result = render_expanded_schemas(expanded_schemas=[])
+        assert result == ""
+
+    def test_single_expansion(self) -> None:
+        schemas = [("mcp:github", [{"name": "create_issue", "description": "Create an issue", "parameters": {"type": "object", "properties": {}}}])]
+        result = render_expanded_schemas(expanded_schemas=schemas)
+        assert "mcp:github" in result
+        assert "create_issue" in result
+        assert "Create an issue" in result
+
+    def test_expansion_order_preserved(self) -> None:
+        schemas = [
+            ("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}]),
+            ("mcp:github", [{"name": "t2", "description": "d2", "parameters": {}}]),
+        ]
+        result = render_expanded_schemas(expanded_schemas=schemas)
+        linear_pos = result.index("mcp:linear")
+        github_pos = result.index("mcp:github")
+        assert linear_pos < github_pos
+
+    def test_append_only_prefix_stable(self) -> None:
+        schemas_v1 = [("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}])]
+        schemas_v2 = [
+            ("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}]),
+            ("mcp:github", [{"name": "t2", "description": "d2", "parameters": {}}]),
+        ]
+        result_v1 = render_expanded_schemas(expanded_schemas=schemas_v1)
+        result_v2 = render_expanded_schemas(expanded_schemas=schemas_v2)
+        assert result_v2.startswith(result_v1)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_catalog.py -v -k "not test_basic_construction"`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cubepi.deferred._catalog'`
+
+- [ ] **Step 3: Implement catalog rendering**
+
+```python
+# cubepi/deferred/_catalog.py
+from __future__ import annotations
+
+import json
+
+from cubepi.deferred.types import DeferredToolGroup
+
+DEFAULT_CATALOG_HEADER = (
+    "# Deferred tool groups\n"
+    "\n"
+    "These tool groups are available but not yet loaded. Call `expand_tools(group_id)`\n"
+    "to load a group's tools for the rest of this conversation.\n"
+    "You can also call `expand_tools(group_id, tool_names=[...])` to load specific tools only."
+)
+
+
+ToolSchema = dict[str, object]
+
+
+def render_catalog(
+    *,
+    groups: list[DeferredToolGroup],
+    expanded: dict[str, list[str] | None],
+    header: str = DEFAULT_CATALOG_HEADER,
+) -> str:
+    lines: list[str] = []
+
+    for group in sorted(groups, key=lambda g: g.group_id):
+        expanded_names = expanded.get(group.group_id)
+
+        if expanded_names is None and group.group_id in expanded:
+            continue
+
+        if expanded_names is not None:
+            remaining = [n for n in group.tool_names if n not in set(expanded_names)]
+        else:
+            remaining = list(group.tool_names)
+
+        if not remaining:
+            continue
+
+        count = len(remaining)
+        count_label = f"{count} remaining tools" if group.group_id in expanded else f"{count} tools"
+        lines.append(f"- `{group.group_id}` — {group.display_name}: {group.description} ({count_label})")
+        lines.append(f"  {', '.join(remaining)}")
+
+    if not lines:
+        return ""
+
+    return header + "\n\n" + "\n".join(lines)
+
+
+def render_expanded_schemas(
+    *,
+    expanded_schemas: list[tuple[str, list[ToolSchema]]],
+) -> str:
+    if not expanded_schemas:
+        return ""
+
+    sections: list[str] = []
+    for group_id, tool_defs in expanded_schemas:
+        tool_lines: list[str] = []
+        for td in tool_defs:
+            name = td.get("name", "")
+            desc = td.get("description", "")
+            params = td.get("parameters", {})
+            params_json = json.dumps(params, sort_keys=True, ensure_ascii=False)
+            tool_lines.append(f"- **{name}**: {desc}")
+            tool_lines.append(f"  Parameters: {params_json}")
+        sections.append(f"## {group_id}\n\n" + "\n".join(tool_lines))
+
+    return "# Expanded tool groups\n\n" + "\n\n".join(sections)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_catalog.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && git add cubepi/deferred/_catalog.py tests/deferred/test_catalog.py && git commit -m "feat(deferred): catalog + expanded schema rendering (#166)"
+```
+
+---
+
+## Task 3: `expand_tools` builtin
+
+**Files:**
+- Create: `cubepi/deferred/_expand_tool.py`
+- Test: `tests/deferred/test_expand_tool.py`
+
+The `expand_tools` builtin is an `AgentTool` whose `execute` delegates expansion logic to the middleware (via a callback). The tool itself handles input validation and returns structured output. The actual loader invocation and tool injection happen in `after_tool_call` (Task 4).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/deferred/test_expand_tool.py
+from __future__ import annotations
+
+import pytest
+
+from cubepi.deferred._expand_tool import (
+    ExpandToolsInput,
+    ExpandToolsOutput,
+    _make_expand_tools,
+)
+from cubepi.agent.types import AgentTool
+
+
+class TestExpandToolsInput:
+    def test_group_id_only(self) -> None:
+        inp = ExpandToolsInput(group_id="mcp:github")
+        assert inp.group_id == "mcp:github"
+        assert inp.tool_names is None
+
+    def test_group_id_with_tool_names(self) -> None:
+        inp = ExpandToolsInput(group_id="mcp:github", tool_names=["create_issue"])
+        assert inp.tool_names == ["create_issue"]
+
+
+class TestExpandToolsOutput:
+    def test_success_output(self) -> None:
+        out = ExpandToolsOutput(
+            group_id="mcp:github",
+            expanded=True,
+            tool_names=["create_issue"],
+            remaining=5,
+        )
+        assert out.expanded is True
+        assert out.error is None
+
+    def test_error_output(self) -> None:
+        out = ExpandToolsOutput(
+            group_id="bad:id",
+            expanded=False,
+            tool_names=[],
+            remaining=0,
+            error="Unknown group_id: bad:id",
+        )
+        assert out.expanded is False
+        assert out.error is not None
+
+
+class TestMakeExpandTools:
+    def test_returns_agent_tool(self) -> None:
+        tool = _make_expand_tools(expand_callback=_noop_callback)
+        assert isinstance(tool, AgentTool)
+        assert tool.name == "expand_tools"
+
+    def test_schema_has_group_id_and_tool_names(self) -> None:
+        tool = _make_expand_tools(expand_callback=_noop_callback)
+        defn = tool.to_definition()
+        props = defn.parameters.get("properties", {})
+        assert "group_id" in props
+        assert "tool_names" in props
+
+    async def test_execute_calls_callback(self) -> None:
+        calls: list[tuple[str, list[str] | None]] = []
+
+        async def _callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+            calls.append((group_id, tool_names))
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=True,
+                tool_names=["t1"],
+                remaining=0,
+            )
+
+        tool = _make_expand_tools(expand_callback=_callback)
+        result = await tool.execute("call-1", ExpandToolsInput(group_id="mcp:github"))
+        assert len(calls) == 1
+        assert calls[0] == ("mcp:github", None)
+        assert result.is_error is None or result.is_error is False
+
+    async def test_execute_with_tool_names(self) -> None:
+        calls: list[tuple[str, list[str] | None]] = []
+
+        async def _callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+            calls.append((group_id, tool_names))
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=True,
+                tool_names=tool_names or [],
+                remaining=0,
+            )
+
+        tool = _make_expand_tools(expand_callback=_callback)
+        result = await tool.execute(
+            "call-2",
+            ExpandToolsInput(group_id="mcp:github", tool_names=["create_issue"]),
+        )
+        assert calls[0] == ("mcp:github", ["create_issue"])
+
+    async def test_execute_error_sets_is_error(self) -> None:
+        async def _err_callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=False,
+                tool_names=[],
+                remaining=0,
+                error="Unknown group_id: bad",
+            )
+
+        tool = _make_expand_tools(expand_callback=_err_callback)
+        result = await tool.execute("call-3", ExpandToolsInput(group_id="bad"))
+        assert result.is_error is True
+
+
+async def _noop_callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+    return ExpandToolsOutput(group_id=group_id, expanded=True, tool_names=[], remaining=0)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_expand_tool.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cubepi.deferred._expand_tool'`
+
+- [ ] **Step 3: Implement the expand_tools builtin**
+
+```python
+# cubepi/deferred/_expand_tool.py
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.providers.base import TextContent
+from cubepi.types import StructuredValue
+
+
+class ExpandToolsInput(BaseModel):
+    group_id: str = Field(
+        description="The group_id from your 'Deferred tool groups' catalog.",
+    )
+    tool_names: list[str] | None = Field(
+        default=None,
+        description="Specific tools to expand. Omit to expand all tools in the group.",
+    )
+
+
+class ExpandToolsOutput(BaseModel):
+    group_id: str
+    expanded: bool
+    tool_names: list[str]
+    remaining: int
+    error: str | None = None
+
+
+ExpandCallback = Callable[
+    [str, list[str] | None],
+    Awaitable[ExpandToolsOutput],
+]
+
+
+def _make_expand_tools(
+    *,
+    expand_callback: ExpandCallback,
+) -> AgentTool[ExpandToolsInput]:
+    async def _execute(
+        tool_call_id: str,
+        args: ExpandToolsInput,
+        *,
+        signal: asyncio.Event | None = None,
+        on_update: Callable[[StructuredValue], None] | None = None,
+    ) -> AgentToolResult:
+        del signal, on_update
+        output = await expand_callback(args.group_id, args.tool_names)
+        text = json.dumps(output.model_dump(), ensure_ascii=False)
+        return AgentToolResult(
+            content=[TextContent(text=text)],
+            is_error=bool(output.error),
+        )
+
+    return AgentTool(
+        name="expand_tools",
+        description=(
+            "Expand a deferred tool group to make its tools available. "
+            "Call with a group_id from the 'Deferred tool groups' catalog. "
+            "Optionally pass tool_names to expand specific tools only."
+        ),
+        parameters=ExpandToolsInput,
+        execute=_execute,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_expand_tool.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && git add cubepi/deferred/_expand_tool.py tests/deferred/test_expand_tool.py && git commit -m "feat(deferred): expand_tools builtin tool (#166)"
+```
+
+---
+
+## Task 4: `DeferredToolsMiddleware` — core middleware
+
+**Files:**
+- Create: `cubepi/deferred/middleware.py`
+- Modify: `cubepi/deferred/__init__.py`
+- Test: `tests/deferred/test_middleware.py`
+
+This is the largest task. The middleware ties together catalog rendering, the expand_tools builtin, loader caching, mid-run tool injection, and expansion state persistence.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/deferred/test_middleware.py
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cubepi.agent.types import AgentContext, AgentTool, AgentToolResult, AfterToolCallContext
+from cubepi.deferred.middleware import DeferredToolsMiddleware, ResumedState
+from cubepi.deferred.types import DeferredToolGroup
+from cubepi.providers.base import AssistantMessage, TextContent, ToolCall
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _dummy_tool(name: str, description: str = "dummy") -> AgentTool:
+    from pydantic import BaseModel
+
+    class _Empty(BaseModel):
+        pass
+
+    async def _exec(tool_call_id, args, *, signal=None, on_update=None):
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    return AgentTool(name=name, description=description, parameters=_Empty, execute=_exec)
+
+
+def _make_group(
+    group_id: str,
+    tool_names: list[str],
+    *,
+    display_name: str = "Test",
+    description: str = "desc",
+    loader_tools: list[AgentTool] | None = None,
+    loader_call_count: list[int] | None = None,
+) -> DeferredToolGroup:
+    tools = loader_tools or [_dummy_tool(n) for n in tool_names]
+    call_count = loader_call_count if loader_call_count is not None else [0]
+
+    async def _loader() -> list[AgentTool]:
+        call_count[0] += 1
+        return list(tools)
+
+    return DeferredToolGroup(
+        group_id=group_id,
+        display_name=display_name,
+        description=description,
+        tool_names=tool_names,
+        loader=_loader,
+    )
+
+
+def _make_expand_result(group_id: str, tool_names: list[str] | None = None) -> AgentToolResult:
+    """Simulate what expand_tools returns on success."""
+    payload = {
+        "group_id": group_id,
+        "expanded": True,
+        "tool_names": tool_names or [],
+        "remaining": 0,
+        "error": None,
+    }
+    return AgentToolResult(content=[TextContent(text=json.dumps(payload))])
+
+
+def _make_after_tool_call_ctx(
+    tool_name: str,
+    args: dict,
+    result: AgentToolResult,
+    context: AgentContext,
+    is_error: bool = False,
+) -> AfterToolCallContext:
+    tc = ToolCall(id="tc-1", name=tool_name, arguments=args)
+    msg = AssistantMessage(content=[tc])
+    from pydantic import BaseModel
+
+    class _Empty(BaseModel):
+        pass
+
+    return AfterToolCallContext(
+        assistant_message=msg,
+        tool_call=tc,
+        args=_Empty(),
+        result=result,
+        is_error=is_error,
+        context=context,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareConstruction:
+    def test_tools_attribute_contains_expand_tools(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:a", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        assert len(mw.tools) == 1
+        assert mw.tools[0].name == "expand_tools"
+
+
+class TestTransformSystemPrompt:
+    async def test_appends_catalog(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:github", ["create_issue", "search_repos"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        ctx = AgentContext(system_prompt="base", messages=[])
+        result = await mw.transform_system_prompt("base prompt", ctx=ctx)
+        assert "mcp:github" in result
+        assert "create_issue" in result
+        assert "base prompt" in result
+
+    async def test_fully_expanded_group_omitted_from_catalog(self) -> None:
+        extra: dict = {"expanded_groups": {"mcp:github": None}}
+        group = _make_group("mcp:github", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        ctx = AgentContext(system_prompt="", messages=[])
+        result = await mw.transform_system_prompt("base", ctx=ctx)
+        assert "mcp:github" not in result or "Expanded tool groups" in result
+
+    async def test_expanded_schemas_appended_after_catalog(self) -> None:
+        extra: dict = {"expanded_groups": {"mcp:a": None}}
+        group = _make_group("mcp:a", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        # Simulate having expanded schemas stored
+        mw._expanded_schemas.append(
+            ("mcp:a", [{"name": "t1", "description": "Tool 1", "parameters": {}}])
+        )
+        ctx = AgentContext(system_prompt="", messages=[])
+        result = await mw.transform_system_prompt("base", ctx=ctx)
+        assert "Expanded tool groups" in result
+        assert "t1" in result
+
+
+class TestAfterToolCallExpansion:
+    async def test_expand_all_injects_tools(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:github", ["create_issue", "search_repos"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(system_prompt="", messages=[], tools=context_tools, extra=extra)
+
+        # Simulate calling expand_tools
+        output = await mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        assert output.expanded is True
+        assert len(output.tool_names) == 2
+        assert output.remaining == 0
+        # Tools injected into context
+        assert len(context_tools) == 3  # expand_tools + 2 new
+        assert extra["expanded_groups"] == {"mcp:github": None}
+
+    async def test_expand_selective_injects_only_requested(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:github", ["create_issue", "search_repos", "create_pr"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(system_prompt="", messages=[], tools=context_tools, extra=extra)
+
+        output = await mw._expand(group_id="mcp:github", tool_names=["create_issue"], context=ctx)
+        assert output.expanded is True
+        assert output.tool_names == ["create_issue"]
+        assert output.remaining == 2
+        assert len(context_tools) == 2  # expand_tools + 1 new
+        assert extra["expanded_groups"] == {"mcp:github": ["create_issue"]}
+
+    async def test_incremental_expand_same_group(self) -> None:
+        extra: dict = {}
+        call_count = [0]
+        group = _make_group("mcp:github", ["t1", "t2", "t3"], loader_call_count=call_count)
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(system_prompt="", messages=[], tools=context_tools, extra=extra)
+
+        # First expand
+        await mw._expand(group_id="mcp:github", tool_names=["t1"], context=ctx)
+        assert len(context_tools) == 2
+        assert extra["expanded_groups"] == {"mcp:github": ["t1"]}
+
+        # Second expand
+        await mw._expand(group_id="mcp:github", tool_names=["t2"], context=ctx)
+        assert len(context_tools) == 3
+        assert extra["expanded_groups"] == {"mcp:github": ["t1", "t2"]}
+
+        # Loader called only once
+        assert call_count[0] == 1
+
+    async def test_expand_unknown_group_returns_error(self) -> None:
+        extra: dict = {}
+        mw = DeferredToolsMiddleware(groups=[], extra_ref=lambda: extra)
+        ctx = AgentContext(system_prompt="", messages=[], tools=[], extra=extra)
+
+        output = await mw._expand(group_id="bad:id", tool_names=None, context=ctx)
+        assert output.expanded is False
+        assert output.error is not None
+        assert "expanded_groups" not in extra
+
+    async def test_expand_idempotent_no_duplicate(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:github", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(system_prompt="", messages=[], tools=context_tools, extra=extra)
+
+        await mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        assert len(context_tools) == 2
+
+        # Expand again — same tool, no duplicate
+        await mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        assert len(context_tools) == 2
+
+    async def test_loader_failure_returns_error(self) -> None:
+        async def _failing_loader() -> list[AgentTool]:
+            raise RuntimeError("connection refused")
+
+        group = DeferredToolGroup(
+            group_id="mcp:broken",
+            display_name="Broken",
+            description="desc",
+            tool_names=["t1"],
+            loader=_failing_loader,
+        )
+        extra: dict = {}
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        ctx = AgentContext(system_prompt="", messages=[], tools=[], extra=extra)
+
+        output = await mw._expand(group_id="mcp:broken", tool_names=None, context=ctx)
+        assert output.expanded is False
+        assert "connection refused" in (output.error or "")
+        assert "expanded_groups" not in extra
+
+
+class TestExpansionOrderPreserved:
+    async def test_expansion_order_in_schemas(self) -> None:
+        extra: dict = {}
+        g1 = _make_group("mcp:z", ["tz"])
+        g2 = _make_group("mcp:a", ["ta"])
+        mw = DeferredToolsMiddleware(groups=[g1, g2], extra_ref=lambda: extra)
+
+        ctx = AgentContext(system_prompt="", messages=[], tools=list(mw.tools), extra=extra)
+
+        # Expand z first, then a
+        await mw._expand(group_id="mcp:z", tool_names=None, context=ctx)
+        await mw._expand(group_id="mcp:a", tool_names=None, context=ctx)
+
+        # Schema order should be z then a (expansion order), not a then z (sorted)
+        assert list(extra["expanded_groups"].keys()) == ["mcp:z", "mcp:a"]
+        assert len(mw._expanded_schemas) == 2
+        assert mw._expanded_schemas[0][0] == "mcp:z"
+        assert mw._expanded_schemas[1][0] == "mcp:a"
+
+
+class TestPrepareResumedState:
+    async def test_fully_expanded_group(self) -> None:
+        group = _make_group("mcp:github", ["t1", "t2"])
+        expanded: dict[str, list[str] | None] = {"mcp:github": None}
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group], expanded=expanded,
+        )
+        assert len(resumed.pre_loaded_tools) == 2
+        assert len(resumed.remaining_groups) == 0
+
+    async def test_partially_expanded_group(self) -> None:
+        group = _make_group("mcp:github", ["t1", "t2", "t3"])
+        expanded: dict[str, list[str] | None] = {"mcp:github": ["t1"]}
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group], expanded=expanded,
+        )
+        assert len(resumed.pre_loaded_tools) == 1
+        assert resumed.pre_loaded_tools[0].name == "t1"
+        assert len(resumed.remaining_groups) == 1
+
+    async def test_unexpanded_group_stays_deferred(self) -> None:
+        group = _make_group("mcp:github", ["t1"])
+        expanded: dict[str, list[str] | None] = {}
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group], expanded=expanded,
+        )
+        assert len(resumed.pre_loaded_tools) == 0
+        assert len(resumed.remaining_groups) == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_middleware.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cubepi.deferred.middleware'`
+
+- [ ] **Step 3: Implement the middleware**
+
+```python
+# cubepi/deferred/middleware.py
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from cubepi.agent.types import (
+    AfterToolCallContext,
+    AfterToolCallResult,
+    AgentContext,
+    AgentTool,
+)
+from cubepi.deferred._catalog import (
+    DEFAULT_CATALOG_HEADER,
+    ToolSchema,
+    render_catalog,
+    render_expanded_schemas,
+)
+from cubepi.deferred._expand_tool import (
+    ExpandToolsOutput,
+    _make_expand_tools,
+)
+from cubepi.deferred.types import DeferredToolGroup
+from cubepi.middleware.base import Middleware
+
+
+@dataclass
+class ResumedState:
+    pre_loaded_tools: list[AgentTool]
+    remaining_groups: list[DeferredToolGroup]
+
+
+class DeferredToolsMiddleware(Middleware):
+    def __init__(
+        self,
+        *,
+        groups: list[DeferredToolGroup],
+        extra_ref: Callable[[], dict[str, Any]],
+        catalog_header: str = DEFAULT_CATALOG_HEADER,
+    ) -> None:
+        self._groups: dict[str, DeferredToolGroup] = {g.group_id: g for g in groups}
+        self._extra_ref = extra_ref
+        self._catalog_header = catalog_header
+        self._loader_cache: dict[str, list[AgentTool]] = {}
+        self._expanded_schemas: list[tuple[str, list[ToolSchema]]] = []
+
+        self.tools: list[AgentTool] = [
+            _make_expand_tools(expand_callback=self._expand_callback)
+        ]
+
+    async def _expand_callback(
+        self, group_id: str, tool_names: list[str] | None
+    ) -> ExpandToolsOutput:
+        # Called from expand_tools execute(). Does validation, loader
+        # invocation, state bookkeeping, and schema recording. Stores
+        # newly loaded tools in _pending_injection for after_tool_call
+        # to inject into context.tools (execute() has no AgentContext).
+        extra = self._extra_ref()
+        group = self._groups.get(group_id)
+        if group is None:
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=False,
+                tool_names=[],
+                remaining=0,
+                error=f"Unknown group_id: {group_id}. Available: {', '.join(sorted(self._groups))}",
+            )
+
+        # Load tools (cached per group)
+        try:
+            if group_id not in self._loader_cache:
+                self._loader_cache[group_id] = await group.loader()
+        except Exception as exc:
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=False,
+                tool_names=[],
+                remaining=len(group.tool_names),
+                error=f"Loader failed: {exc}",
+            )
+
+        all_loaded = self._loader_cache[group_id]
+        expanded_groups: dict[str, list[str] | None] = extra.get("expanded_groups", {})
+        already_expanded = expanded_groups.get(group_id)
+        already_set: set[str] = set(already_expanded) if isinstance(already_expanded, list) else (
+            set() if already_expanded is None and group_id not in expanded_groups else
+            {t.name for t in all_loaded}
+        )
+
+        # Determine which tools to expand this call
+        if tool_names is not None:
+            requested = [t for t in all_loaded if t.name in set(tool_names)]
+        else:
+            requested = list(all_loaded)
+
+        newly_expanded = [t for t in requested if t.name not in already_set]
+        expanded_names = [t.name for t in requested]
+
+        # Update expansion state
+        if tool_names is None:
+            expanded_groups[group_id] = None
+        else:
+            prev = expanded_groups.get(group_id)
+            if prev is None and group_id in expanded_groups:
+                pass  # already fully expanded
+            else:
+                merged = list(prev) if isinstance(prev, list) else []
+                for name in expanded_names:
+                    if name not in set(merged):
+                        merged.append(name)
+                expanded_groups[group_id] = merged
+
+        extra["expanded_groups"] = expanded_groups
+
+        # Store schema info for expanded tools (append-only for cache stability)
+        if newly_expanded:
+            new_schemas = [t.to_definition().model_dump() for t in newly_expanded]
+            # Check if this group already has a schemas entry
+            existing_idx = next(
+                (i for i, (gid, _) in enumerate(self._expanded_schemas) if gid == group_id),
+                None,
+            )
+            if existing_idx is not None:
+                prev_schemas = self._expanded_schemas[existing_idx][1]
+                self._expanded_schemas[existing_idx] = (group_id, prev_schemas + new_schemas)
+            else:
+                self._expanded_schemas.append((group_id, new_schemas))
+
+        # Store pending injection for after_tool_call
+        self._pending_injection = newly_expanded
+
+        # Calculate remaining
+        current_expanded = expanded_groups.get(group_id)
+        if current_expanded is None and group_id in expanded_groups:
+            remaining = 0
+        elif isinstance(current_expanded, list):
+            remaining = len(group.tool_names) - len(current_expanded)
+        else:
+            remaining = len(group.tool_names)
+
+        return ExpandToolsOutput(
+            group_id=group_id,
+            expanded=True,
+            tool_names=expanded_names,
+            remaining=max(remaining, 0),
+        )
+
+    async def _expand(
+        self,
+        *,
+        group_id: str,
+        tool_names: list[str] | None,
+        context: AgentContext,
+    ) -> ExpandToolsOutput:
+        """Expand a group — called directly in tests, via callback + after_tool_call in production."""
+        output = await self._expand_callback(group_id, tool_names)
+        if output.expanded and hasattr(self, "_pending_injection"):
+            newly_expanded = self._pending_injection
+            self._pending_injection = []
+            if context.tools is not None:
+                existing_names = {t.name for t in context.tools}
+                for tool in newly_expanded:
+                    if tool.name not in existing_names:
+                        context.tools.append(tool)
+        return output
+
+    async def after_tool_call(
+        self,
+        ctx: AfterToolCallContext,
+        *,
+        signal: asyncio.Event | None = None,
+    ) -> AfterToolCallResult | None:
+        del signal
+        if ctx.tool_call.name != "expand_tools":
+            return None
+        if ctx.is_error:
+            return None
+
+        # Inject pending tools into context
+        if hasattr(self, "_pending_injection") and self._pending_injection:
+            newly_expanded = self._pending_injection
+            self._pending_injection = []
+            if ctx.context.tools is not None:
+                existing_names = {t.name for t in ctx.context.tools}
+                for tool in newly_expanded:
+                    if tool.name not in existing_names:
+                        ctx.context.tools.append(tool)
+
+        return None
+
+    async def transform_system_prompt(
+        self,
+        system_prompt: str,
+        *,
+        ctx: AgentContext,
+        signal: asyncio.Event | None = None,
+    ) -> str:
+        del signal
+        extra = self._extra_ref()
+        expanded: dict[str, list[str] | None] = extra.get("expanded_groups", {})
+
+        catalog = render_catalog(
+            groups=list(self._groups.values()),
+            expanded=expanded,
+            header=self._catalog_header,
+        )
+
+        schemas = render_expanded_schemas(expanded_schemas=self._expanded_schemas)
+
+        parts = [system_prompt]
+        if catalog:
+            parts.append(catalog)
+        if schemas:
+            parts.append(schemas)
+
+        return "\n\n".join(parts)
+
+    @staticmethod
+    async def prepare_resumed_state(
+        groups: list[DeferredToolGroup],
+        expanded: dict[str, list[str] | None],
+    ) -> ResumedState:
+        pre_loaded: list[AgentTool] = []
+        remaining: list[DeferredToolGroup] = []
+
+        for group in groups:
+            exp = expanded.get(group.group_id)
+            if exp is None and group.group_id not in expanded:
+                remaining.append(group)
+                continue
+
+            loaded = await group.loader()
+            if exp is None:
+                pre_loaded.extend(loaded)
+            else:
+                name_set = set(exp)
+                selected = [t for t in loaded if t.name in name_set]
+                pre_loaded.extend(selected)
+                remaining.append(group)
+
+        return ResumedState(
+            pre_loaded_tools=pre_loaded,
+            remaining_groups=remaining,
+        )
+```
+
+- [ ] **Step 4: Update `__init__.py` exports**
+
+```python
+# cubepi/deferred/__init__.py
+"""Deferred tool groups — progressive tool disclosure primitive."""
+
+from cubepi.deferred.middleware import DeferredToolsMiddleware, ResumedState
+from cubepi.deferred.types import DeferredToolGroup
+
+__all__ = ["DeferredToolGroup", "DeferredToolsMiddleware", "ResumedState"]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_middleware.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Run all deferred tests together**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && git add cubepi/deferred/middleware.py cubepi/deferred/__init__.py tests/deferred/test_middleware.py && git commit -m "feat(deferred): DeferredToolsMiddleware with expansion, catalog, injection (#166)"
+```
+
+---
+
+## Task 5: Agent-level `deferred_tool_groups` parameter
+
+**Files:**
+- Modify: `cubepi/agent/agent.py:141-166`
+- Test: `tests/deferred/test_agent_wiring.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/deferred/test_agent_wiring.py
+from __future__ import annotations
+
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.deferred import DeferredToolGroup, DeferredToolsMiddleware
+from cubepi.providers.base import TextContent
+from pydantic import BaseModel
+
+
+class _Empty(BaseModel):
+    pass
+
+
+def _dummy_tool(name: str) -> AgentTool:
+    async def _exec(tool_call_id, args, *, signal=None, on_update=None):
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    return AgentTool(name=name, description="dummy", parameters=_Empty, execute=_exec)
+
+
+def _make_group(group_id: str, tool_names: list[str]) -> DeferredToolGroup:
+    async def _loader():
+        return [_dummy_tool(n) for n in tool_names]
+
+    return DeferredToolGroup(
+        group_id=group_id,
+        display_name="Test",
+        description="desc",
+        tool_names=tool_names,
+        loader=_loader,
+    )
+
+
+def _make_faux_model():
+    """Create a minimal BoundModel for Agent construction."""
+    from cubepi.providers.faux import FauxProvider
+    provider = FauxProvider()
+    return provider.model("faux")
+
+
+class TestAgentDeferredToolGroups:
+    def test_agent_accepts_deferred_tool_groups(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1", "t2"])
+        agent = Agent(
+            model=model,
+            tools=[_dummy_tool("builtin")],
+            deferred_tool_groups=[group],
+        )
+        # expand_tools should be in the tool set
+        tool_names = [t.name for t in agent._state.tools]
+        assert "builtin" in tool_names
+        assert "expand_tools" in tool_names
+
+    def test_middleware_auto_created(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+        agent = Agent(
+            model=model,
+            deferred_tool_groups=[group],
+        )
+        assert any(isinstance(mw, DeferredToolsMiddleware) for mw in agent._middleware)
+
+    def test_extra_ref_bound_to_agent_extra(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+        agent = Agent(
+            model=model,
+            deferred_tool_groups=[group],
+        )
+        deferred_mw = next(mw for mw in agent._middleware if isinstance(mw, DeferredToolsMiddleware))
+        # The extra_ref should point to agent._extra
+        assert deferred_mw._extra_ref() is agent._extra
+
+    def test_no_deferred_groups_no_middleware(self) -> None:
+        model = _make_faux_model()
+        agent = Agent(model=model, tools=[_dummy_tool("t1")])
+        assert not any(isinstance(mw, DeferredToolsMiddleware) for mw in agent._middleware)
+
+    def test_explicit_middleware_still_works(self) -> None:
+        """User can still pass DeferredToolsMiddleware directly."""
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+        extra: dict = {}
+        mw = DeferredToolsMiddleware(
+            groups=[group],
+            extra_ref=lambda: extra,
+            catalog_header="Custom",
+        )
+        agent = Agent(
+            model=model,
+            middleware=[mw],
+        )
+        assert any(isinstance(m, DeferredToolsMiddleware) for m in agent._middleware)
+        tool_names = [t.name for t in agent._state.tools]
+        assert "expand_tools" in tool_names
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_agent_wiring.py -v`
+Expected: FAIL with `TypeError: Agent.__init__() got an unexpected keyword argument 'deferred_tool_groups'`
+
+- [ ] **Step 3: Add `deferred_tool_groups` parameter to Agent**
+
+In `cubepi/agent/agent.py`, modify `Agent.__init__`:
+
+1. Add the parameter to the signature (after `middleware`):
+
+```python
+        deferred_tool_groups: list[DeferredToolGroup] | None = None,
+```
+
+2. Add the import at the top of the file (with the other type imports):
+
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING
+# ... existing imports ...
+if TYPE_CHECKING:
+    from cubepi.deferred.types import DeferredToolGroup
+```
+
+3. Add the auto-wiring logic right before the existing `middleware = middleware or []` line (around line 185):
+
+```python
+        if deferred_tool_groups:
+            from cubepi.deferred.middleware import DeferredToolsMiddleware
+
+            deferred_mw = DeferredToolsMiddleware(
+                groups=deferred_tool_groups,
+                extra_ref=lambda: self._extra,
+            )
+            middleware = [*(middleware or []), deferred_mw]
+```
+
+The exact edit: the current line 185 reads `middleware = middleware or []`. Replace it with the deferred_tool_groups logic followed by the existing line. The conditional must run before `middleware = middleware or []` because it needs to append to the list.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/test_agent_wiring.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Run all existing agent tests to verify no regression**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/agent/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && git add cubepi/agent/agent.py tests/deferred/test_agent_wiring.py && git commit -m "feat(deferred): Agent(deferred_tool_groups=...) parameter (#166)"
+```
+
+---
+
+## Task 6: Type checking and full test sweep
+
+**Files:**
+- All files from Tasks 1-5
+
+- [ ] **Step 1: Run mypy on the new package**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run mypy cubepi/deferred/`
+Expected: PASS (no errors)
+
+- [ ] **Step 2: Run mypy on agent.py**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run mypy cubepi/agent/agent.py`
+Expected: PASS (no errors). Fix any type issues found.
+
+- [ ] **Step 3: Run all deferred tests**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/deferred/ -v`
+Expected: ALL PASS
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && uv run pytest tests/ -v --ignore=tests/e2e`
+Expected: ALL PASS. Fix any regressions.
+
+- [ ] **Step 5: Commit any fixes**
+
+Only if Step 1-4 required changes:
+
+```bash
+cd /home/chris/cubepi/.worktrees/feat-deferred-tool-group && git add -u && git commit -m "fix(deferred): type and test fixes (#166)"
+```
+
+---
+
+## Summary
+
+| Task | What it builds | Key files |
+|------|---------------|-----------|
+| 1 | `DeferredToolGroup` dataclass | `types.py` |
+| 2 | Catalog + expanded schema rendering | `_catalog.py` |
+| 3 | `expand_tools` builtin tool | `_expand_tool.py` |
+| 4 | `DeferredToolsMiddleware` (core) | `middleware.py` |
+| 5 | `Agent(deferred_tool_groups=...)` | `agent.py` |
+| 6 | Type checking + full sweep | all |

--- a/dev/specs/2026-06-09-deferred-tool-group.md
+++ b/dev/specs/2026-06-09-deferred-tool-group.md
@@ -136,22 +136,26 @@ class DeferredToolsMiddleware(Middleware):
 `agent.state.tools` automatically (agent.py:191-195).
 
 **`transform_system_prompt`:**
-1. Append **catalog section** — sorted by `group_id` for byte-stability. Lists each non-expanded
-   group with display_name, description, tool_names, and count. Groups already expanded are omitted
-   from the catalog (they are callable directly).
+1. Append **catalog section** — sorted by `group_id` for byte-stability. For each group, shows only
+   the **not-yet-expanded** tool names. A fully expanded group is omitted entirely; a partially
+   expanded group shows only remaining tools with an updated count.
 2. Append **expanded schema section** — for each expanded group, **in expansion order** (not
-   sorted), append its tools' full definitions (name + description + parameters JSON). Expansion
-   order is append-only: a newly expanded group always lands after every already-rendered block,
-   preserving earlier cache segments byte-identical.
+   sorted), append the **expanded tools'** full definitions (name + description + parameters JSON).
+   When a group is partially expanded, only the selected tools' schemas appear. Expansion order is
+   append-only: a newly expanded group (or newly expanded tools within a group) always lands after
+   every already-rendered block, preserving earlier cache segments byte-identical.
 
 Why expansion order, not sorted? Groups expand incrementally mid-conversation. Sorting could insert
 a later expansion before an already-cached block and invalidate the prompt-cache prefix.
 
 **`after_tool_call`:**
 - Fires on every tool call. Checks: is the tool name `expand_tools`? Did it succeed?
-- If yes: parse the result to get the `group_id`. Look up the group. Call `loader()`. Append the
-  returned `AgentTool`s to `ctx.context.tools` (the live list reference — next iteration sees them).
-  Record the group_id in `extra["expanded_groups"]` (ordered list, dedup, first-expanded-first).
+- If yes: parse the result to get the `group_id` and optional `tool_names`. Look up the group.
+  On first access to a group, call `loader()` and **cache the full result** (the loader is invoked
+  exactly once per group per run regardless of how many selective expansions follow). Filter the
+  cached tools by `tool_names` (or take all if `tool_names` is None). Append the filtered
+  `AgentTool`s to `ctx.context.tools` (the live list reference — next iteration sees them).
+  Record the expansion in `extra["expanded_groups"]`.
 - Store the loaded tools' definitions for `transform_system_prompt` to render in the expanded
   schema section.
 
@@ -162,18 +166,34 @@ class ExpandToolsInput(BaseModel):
     group_id: str = Field(
         description="The group_id from your 'Deferred tool groups' catalog."
     )
+    tool_names: list[str] | None = Field(
+        default=None,
+        description="Specific tools to expand. Omit to expand all tools in the group.",
+    )
 
 class ExpandToolsOutput(BaseModel):
     group_id: str
     expanded: bool
-    tool_names: list[str]
+    tool_names: list[str]       # the tools that were actually expanded this call
+    remaining: int              # tools still deferred in this group
     error: str | None = None
 ```
 
 Behavior:
-- Valid group_id → call `loader()`, return `expanded=True` + tool names list.
+- Valid group_id, no tool_names → expand all tools, return full list.
+- Valid group_id + tool_names → expand only those tools, return them. Unknown names within the
+  list are silently ignored (the rest still expand).
 - Unknown group_id → return `is_error=True` + error message.
-- Already-expanded group_id → return `expanded=True` + tool names (idempotent, no re-load).
+- Already-expanded tools → idempotent (no re-inject, no duplicate in context.tools). The response
+  still lists them as expanded.
+
+**Incremental expansion.** The model can call `expand_tools` multiple times for the same group with
+different `tool_names`. Each call adds only the newly requested tools. Example flow:
+```
+expand_tools("mcp:github", tool_names=["create_issue"])       → 1 tool loaded, 11 remaining
+expand_tools("mcp:github", tool_names=["search_repos"])       → 1 more loaded, 10 remaining
+expand_tools("mcp:github")                                     → remaining 10 loaded, 0 remaining
+```
 
 The tool result contains tool names + descriptions only, **not** full schemas. The middleware
 injects schema text into the system-prompt suffix (matching the skills pattern where content goes
@@ -197,12 +217,19 @@ to load a group's tools for the rest of this conversation.
 ```
 
 Properties:
-- Sorted by `group_id` → byte-identical every turn (for groups that haven't been expanded yet).
-- Only non-expanded groups appear (expanded groups are callable directly and show in the expanded
-  schema section).
+- Sorted by `group_id` → byte-identical every turn (for the non-expanded portion).
+- Fully expanded groups are omitted. Partially expanded groups show only the remaining
+  (not-yet-expanded) tool names with an updated count.
 - Tool names listed without descriptions or schemas — tool names in MCP/plugin conventions
   (`verb_noun`) are self-descriptive. ~40 tokens per group of 12 tools.
 - `catalog_header` is customizable via constructor for host apps with different wording needs.
+
+Example after partial expansion of `mcp:github` (`create_issue` already expanded):
+```
+- `mcp:github` — Code hosting (11 remaining tools)
+  search_repos, create_pr, list_pull_requests, merge_pull_request,
+  search_code, list_commits, create_comment, ...
+```
 
 ### Expanded schema rendering
 
@@ -234,8 +261,19 @@ Properties:
 When `after_tool_call` fires for a successful `expand_tools`:
 
 ```python
-loaded_tools = await group.loader()
-ctx.context.tools.extend(loaded_tools)   # visible next iteration
+# First access to this group: call loader, cache the full result
+if group_id not in self._loader_cache:
+    self._loader_cache[group_id] = await group.loader()
+
+all_tools = self._loader_cache[group_id]
+
+# Filter by requested tool_names (or take all)
+selected = [t for t in all_tools if t.name in requested_names] if requested_names else all_tools
+
+# Only inject tools not already in context (idempotent)
+existing_names = {t.name for t in ctx.context.tools}
+new_tools = [t for t in selected if t.name not in existing_names]
+ctx.context.tools.extend(new_tools)   # visible next iteration
 ```
 
 This works because `current_context.tools` in `_run_loop` is a reference to the same list — the
@@ -248,36 +286,54 @@ docs), not the mechanism that makes tools callable.
 ### Expansion state persistence
 
 ```python
-extra["expanded_groups"]  # list[str], ordered, e.g. ["mcp:linear", "mcp:gdrive"]
+extra["expanded_groups"]
+# Ordered dict: group_id → list[str] | None
+# None = all tools expanded; list = specific tool names
+# Ordering = expansion order (first group expanded first)
+#
+# Example:
+# {
+#     "mcp:github": ["create_issue", "search_repos"],  # partial
+#     "mcp:linear": null,                                # all expanded
+# }
 ```
 
-- Written by `after_tool_call` on each new expansion.
-- Read by `transform_system_prompt` to decide what to render.
+- Written by `after_tool_call` on each new expansion (append new group, or extend existing
+  group's tool list).
+- Read by `transform_system_prompt` to decide what to render in catalog vs expanded sections.
 - Persisted by the host application's checkpointer (same mechanism as TodoListMiddleware's todos).
-- **Must be serialized as an ordered list.** If a checkpointer deserializes it as an unordered set,
+- **Must be serialized as an ordered dict.** If a checkpointer deserializes it as an unordered map,
   the expansion-order invariant breaks and the prompt-cache prefix becomes unstable across turns.
+  Python `dict` preserves insertion order since 3.7, so standard JSON round-tripping is safe.
 
 ### Replay on subsequent runs
 
 When the host application creates a new run (next user turn), it should:
 
-1. Read persisted `extra["expanded_groups"]` from the checkpointer.
-2. Pre-load those groups' tools (call each loader).
+1. Read persisted `extra["expanded_groups"]` from the checkpointer (an ordered dict of
+   `group_id → list[str] | None`).
+2. Pre-load the expanded tools: for each group with expanded tools, call loader and filter to the
+   expanded tool names (or take all if `None`).
 3. Pass the pre-loaded tools as regular `tools` to `Agent(tools=[...builtins, ...pre_loaded])`.
-4. Construct `DeferredToolsMiddleware` with only the **remaining** (non-expanded) groups.
-5. Set `extra["expanded_groups"]` on the agent so `transform_system_prompt` renders the expanded
-   schema section correctly.
+4. Construct `DeferredToolsMiddleware` with the original groups list — the middleware reads
+   `extra["expanded_groups"]` to know which tools are already expanded and adjusts the catalog
+   accordingly.
 
 This is the host application's responsibility, not the middleware's — the middleware only handles
-within-a-single-run expansion. cubepi provides a helper for step 2-5:
+within-a-single-run expansion. cubepi provides a helper for step 2-3:
 
 ```python
+@dataclass
+class ResumedState:
+    pre_loaded_tools: list[AgentTool]       # tools to pass as Agent(tools=...)
+    remaining_groups: list[DeferredToolGroup]  # groups still fully/partially deferred
+
 @staticmethod
-def prepare_resumed_state(
+async def prepare_resumed_state(
     groups: list[DeferredToolGroup],
-    expanded_ids: list[str],
+    expanded: dict[str, list[str] | None],
 ) -> ResumedState:
-    """Split groups into already-expanded (need pre-loading) and still-deferred."""
+    """Call loaders for expanded groups, filter to expanded tools, return split."""
     ...
 ```
 
@@ -340,21 +396,25 @@ No registration method on Agent — follows the existing pattern where middlewar
 Unit tests (no real LLM, no MCP server):
 
 1. **Catalog rendering** — sorted by group_id, byte-stable across input orderings, no schemas,
-   expanded groups omitted.
+   fully expanded groups omitted, partially expanded groups show only remaining tools.
 2. **Expanded schema rendering** — expansion order preserved, append-only (second expansion's text
-   starts with first expansion's text), JSON keys sorted for byte stability.
+   starts with first expansion's text), JSON keys sorted for byte stability. Partial expansion
+   renders only the selected tools' schemas.
 3. **expand_tools builtin** — valid group → expanded=True + tool names; unknown group → error;
-   already-expanded → idempotent.
-4. **Mid-run injection** — after expand_tools fires, `ctx.context.tools` contains the new tools;
+   already-expanded → idempotent; with tool_names → selective expansion.
+4. **Incremental expansion** — expand one tool, then another from same group; loader called only
+   once; both tools in context; catalog shows remaining.
+5. **Mid-run injection** — after expand_tools fires, `ctx.context.tools` contains the new tools;
    simulate a second `_stream_assistant_response` call and verify `tools_defs` includes them.
-5. **Expansion state** — after_tool_call writes to extra["expanded_groups"] in order; duplicate
-   expansion doesn't add twice; transform_system_prompt uses the stored order.
-6. **Loader failure** — if loader raises, expand_tools returns is_error=True, no tools injected,
+6. **Expansion state** — after_tool_call writes to extra["expanded_groups"] correctly; duplicate
+   tool names not added twice; transform_system_prompt uses the stored order.
+7. **Loader failure** — if loader raises, expand_tools returns is_error=True, no tools injected,
    no state change.
+8. **Loader caching** — two selective expands on the same group call loader exactly once.
 
 Integration test (with Agent, mock provider):
 
-7. **Full round-trip** — Agent with DeferredToolsMiddleware, mock provider that calls expand_tools
+9. **Full round-trip** — Agent with DeferredToolsMiddleware, mock provider that calls expand_tools
    then uses an expanded tool. Assert: first model call sees expand_tools but not deferred tools;
    after expansion, next iteration sees deferred tools in tools_defs.
 

--- a/dev/specs/2026-06-09-deferred-tool-group.md
+++ b/dev/specs/2026-06-09-deferred-tool-group.md
@@ -23,12 +23,14 @@ themselves.
 
 ## Goals
 
-- Provide a `DeferredToolGroup` dataclass that host apps use to register groups of tools that start
+- Provide a `DeferredToolGroup` dataclass that host apps use to declare groups of tools that start
   collapsed.
-- Provide a `DeferredToolsMiddleware` that handles everything: catalog rendering in the system
-  prompt, an `expand_tools` builtin, mid-run tool injection on expand, expansion-order tracking.
-- **Zero changes to Agent or loop.py.** The mechanism works entirely through the existing middleware
-  system.
+- `Agent(deferred_tool_groups=[...])` as the primary API — declare deferred groups alongside
+  regular tools; Agent handles all internal wiring. No middleware assembly required from the user.
+- `DeferredToolsMiddleware` available as a lower-level API for advanced customization (custom
+  catalog header, custom middleware ordering).
+- **Minimal changes to Agent, zero changes to loop.py.** Agent gains one optional parameter;
+  internally it creates the middleware and binds `extra_ref` automatically.
 - Expansion-order-preserving, append-only system-prompt growth for prompt-cache stability.
 - Tool-source-agnostic: cubepi knows about "groups with loaders", not about MCP or any specific
   tool source.
@@ -37,7 +39,6 @@ themselves.
 
 - No MCP-specific integration in v1 (convenience bridge from `MCPDiscoveryResult` →
   `DeferredToolGroup` is a later recipe, not core API).
-- No per-tool (sub-group) disclosure — the unit is a whole group.
 - No semantic / embedding retrieval — the catalog is designed to be small enough for the model to
   read directly.
 - No "code mode" (tools as a callable API the model writes code against).
@@ -72,7 +73,7 @@ themselves.
 
 **Key insight:** because `current_context.tools` is a reference to the same list object, appending
 to it from an `after_tool_call` hook makes new tools visible to the model on the **next iteration
-of the same run**. No changes to Agent or loop.py are needed for mid-run tool injection.
+of the same run**. No changes to loop.py are needed for mid-run tool injection.
 
 ### Middleware hooks (used by this feature)
 
@@ -88,6 +89,41 @@ of the same run**. No changes to Agent or loop.py are needed for mid-run tool in
 `Agent._extra` is a `JsonObject` dict shared with `AgentContext.extra`. Middlewares write state
 into it (e.g. TodoListMiddleware writes todos). Host applications persist it via checkpointers.
 DeferredToolGroup uses this for expansion state (`extra["expanded_groups"]`).
+
+### Agent-level `deferred_tool_groups` parameter
+
+`Agent.__init__` gains an optional `deferred_tool_groups: list[DeferredToolGroup] | None`
+parameter. When provided, Agent automatically creates a `DeferredToolsMiddleware` and appends it
+to the middleware chain — no manual middleware assembly from the caller.
+
+```python
+class Agent:
+    def __init__(
+        self,
+        *,
+        model: BoundModel,
+        tools: list[AgentTool] | None = None,
+        middleware: list[Middleware] | None = None,
+        deferred_tool_groups: list[DeferredToolGroup] | None = None,  # NEW
+        ...
+    ) -> None:
+        ...
+        if deferred_tool_groups:
+            from cubepi.deferred import DeferredToolsMiddleware
+            deferred_mw = DeferredToolsMiddleware(
+                groups=deferred_tool_groups,
+                extra_ref=lambda: self._extra,
+            )
+            middleware = [*(middleware or []), deferred_mw]
+        ...
+```
+
+This follows the same principle as other Agent conveniences: the user declares intent
+(`deferred_tool_groups=[...]`) and Agent handles the wiring. The `extra_ref` binding to
+`self._extra` is automatic — the caller never needs to think about it.
+
+Users who need custom `catalog_header` or non-default middleware ordering can still construct
+`DeferredToolsMiddleware` directly and pass it via `middleware=[...]`.
 
 ## Design
 
@@ -314,18 +350,18 @@ When the host application creates a new run (next user turn), it should:
    `group_id → list[str] | None`).
 2. Pre-load the expanded tools: for each group with expanded tools, call loader and filter to the
    expanded tool names (or take all if `None`).
-3. Pass the pre-loaded tools as regular `tools` to `Agent(tools=[...builtins, ...pre_loaded])`.
-4. Construct `DeferredToolsMiddleware` with the original groups list — the middleware reads
-   `extra["expanded_groups"]` to know which tools are already expanded and adjusts the catalog
-   accordingly.
+3. Pass the pre-loaded tools as regular `tools` to
+   `Agent(tools=[...builtins, ...pre_loaded], deferred_tool_groups=groups)`.
+4. Agent creates the middleware internally; the middleware reads `extra["expanded_groups"]` to know
+   which tools are already expanded and adjusts the catalog accordingly.
 
 This is the host application's responsibility, not the middleware's — the middleware only handles
-within-a-single-run expansion. cubepi provides a helper for step 2-3:
+within-a-single-run expansion. cubepi provides a helper for step 2:
 
 ```python
 @dataclass
 class ResumedState:
-    pre_loaded_tools: list[AgentTool]       # tools to pass as Agent(tools=...)
+    pre_loaded_tools: list[AgentTool]         # merge into Agent(tools=...)
     remaining_groups: list[DeferredToolGroup]  # groups still fully/partially deferred
 
 @staticmethod
@@ -337,12 +373,26 @@ async def prepare_resumed_state(
     ...
 ```
 
+Usage with Agent-level API:
+
+```python
+resumed = await DeferredToolsMiddleware.prepare_resumed_state(groups, saved_extra["expanded_groups"])
+agent = Agent(
+    model=model,
+    tools=[*builtins, *resumed.pre_loaded_tools],
+    deferred_tool_groups=resumed.remaining_groups,
+    extra=saved_extra,
+)
+```
+
 ## File layout
 
 ```
 cubepi/
+  agent/
+    agent.py             # +deferred_tool_groups parameter, auto-creates middleware (~10 lines)
   deferred/
-    __init__.py          # public exports
+    __init__.py          # public exports: DeferredToolGroup, DeferredToolsMiddleware
     types.py             # DeferredToolGroup dataclass
     middleware.py         # DeferredToolsMiddleware
     _catalog.py          # catalog + expanded schema rendering (pure functions)
@@ -356,40 +406,55 @@ tests/
 ```
 
 New `cubepi/deferred/` package — does not import from `cubepi/mcp/` (tool-source-agnostic).
+`agent.py` change is small: accept the parameter, lazy-import `DeferredToolsMiddleware`, create
+and append to middleware list.
 
 ## Public API surface
 
+**Primary API — Agent-level parameter:**
+
 ```python
-# cubepi.deferred
-from cubepi.deferred import DeferredToolGroup, DeferredToolsMiddleware
-
-# Construction
-groups = [
-    DeferredToolGroup(
-        group_id="mcp:github",
-        display_name="GitHub",
-        description="Code hosting: issues, PRs, repos",
-        tool_names=["create_issue", "search_repos", "create_pr", ...],
-        loader=lambda: load_my_github_tools(),
-    ),
-]
-
-middleware = DeferredToolsMiddleware(
-    groups=groups,
-    extra_ref=lambda: agent._extra,
-)
+from cubepi.deferred import DeferredToolGroup
 
 agent = Agent(
     model=model,
     system_prompt="...",
-    tools=[...builtins],
-    middleware=[middleware, ...other_middleware],
+    tools=[t1, t2],                             # always-visible tools
+    deferred_tool_groups=[                       # groups that start collapsed
+        DeferredToolGroup(
+            group_id="mcp:github",
+            display_name="GitHub",
+            description="Code hosting: issues, PRs, repos",
+            tool_names=["create_issue", "search_repos", "create_pr", ...],
+            loader=lambda: load_my_github_tools(),
+        ),
+    ],
 )
 ```
 
-Two exports. `DeferredToolGroup` is a plain dataclass, `DeferredToolsMiddleware` is the middleware.
-No registration method on Agent — follows the existing pattern where middlewares are passed to
-`Agent(middleware=[...])`.
+Agent creates the middleware internally, binds `extra_ref` to `self._extra`, and appends
+`expand_tools` to the tool set. The caller never touches `DeferredToolsMiddleware`.
+
+**Advanced API — direct middleware construction:**
+
+```python
+from cubepi.deferred import DeferredToolGroup, DeferredToolsMiddleware
+
+middleware = DeferredToolsMiddleware(
+    groups=groups,
+    extra_ref=lambda: agent._extra,
+    catalog_header="Custom header...",           # override default catalog text
+)
+
+agent = Agent(
+    model=model,
+    tools=[...builtins],
+    middleware=[middleware, ...other_middleware],  # explicit ordering control
+)
+```
+
+Use when you need custom `catalog_header` text, specific middleware ordering, or other
+customization that the Agent-level shorthand does not expose.
 
 ## Testing strategy
 
@@ -414,9 +479,11 @@ Unit tests (no real LLM, no MCP server):
 
 Integration test (with Agent, mock provider):
 
-9. **Full round-trip** — Agent with DeferredToolsMiddleware, mock provider that calls expand_tools
-   then uses an expanded tool. Assert: first model call sees expand_tools but not deferred tools;
-   after expansion, next iteration sees deferred tools in tools_defs.
+9. **Full round-trip** — Agent with `deferred_tool_groups=[...]`, mock provider that calls
+   expand_tools then uses an expanded tool. Assert: first model call sees expand_tools but not
+   deferred tools; after expansion, next iteration sees deferred tools in tools_defs.
+10. **Agent-level wiring** — `Agent(deferred_tool_groups=[...])` automatically creates the
+    middleware, binds extra_ref, and merges expand_tools into the tool set.
 
 ## Open questions
 
@@ -437,8 +504,9 @@ Integration test (with Agent, mock provider):
 
 **v1:**
 - `DeferredToolGroup` dataclass.
-- `DeferredToolsMiddleware` with catalog rendering, `expand_tools` builtin, mid-run injection,
-  expansion-order tracking, expanded schema rendering.
+- `Agent(deferred_tool_groups=[...])` parameter (primary API).
+- `DeferredToolsMiddleware` with catalog rendering, `expand_tools` builtin (with selective
+  `tool_names`), mid-run injection, expansion-order tracking, expanded schema rendering.
 - `prepare_resumed_state` helper for cross-run replay.
 - Unit + integration tests.
 
@@ -446,5 +514,4 @@ Integration test (with Agent, mock provider):
 - MCP convenience bridge (`deferred_group_from_mcp_server`).
 - Auto-mode threshold (context-window-percentage gate).
 - Unify with skills disclosure under a shared primitive.
-- Per-tool (sub-group) disclosure.
 - Semantic / embedding retrieval for very large catalogs.

--- a/dev/specs/2026-06-09-deferred-tool-group.md
+++ b/dev/specs/2026-06-09-deferred-tool-group.md
@@ -1,0 +1,390 @@
+# DeferredToolGroup — Progressive Tool Disclosure Primitive
+
+Date: 2026-06-09
+Branch: `feat/deferred-tool-group`
+Issue: cubepi#166
+
+## Problem
+
+When a cubepi agent has many tools registered (MCP servers, plugins, host-provided builtins), their
+full JSON schemas are sent to the model on every turn via `tools=`. This creates three scaling
+problems:
+
+- **Context bloat.** Tool definitions are part of the cached prefix. A handful of rich servers can
+  push the tool block into tens of thousands of tokens before the user types anything.
+- **Cache cost.** That block is billed at cache-write rate on changes and cache-read rate every
+  turn. More tools = a bigger fixed tax per turn.
+- **Worse tool selection.** Published benchmarks show accuracy drops as the toolset grows; the model
+  has to scan dozens of similar schemas to pick one.
+
+Host applications (cubebox, standalone cubepi users) need a way to register tool groups that are
+hidden by default and expanded on demand, without building the entire disclosure mechanism
+themselves.
+
+## Goals
+
+- Provide a `DeferredToolGroup` dataclass that host apps use to register groups of tools that start
+  collapsed.
+- Provide a `DeferredToolsMiddleware` that handles everything: catalog rendering in the system
+  prompt, an `expand_tools` builtin, mid-run tool injection on expand, expansion-order tracking.
+- **Zero changes to Agent or loop.py.** The mechanism works entirely through the existing middleware
+  system.
+- Expansion-order-preserving, append-only system-prompt growth for prompt-cache stability.
+- Tool-source-agnostic: cubepi knows about "groups with loaders", not about MCP or any specific
+  tool source.
+
+## Non-goals
+
+- No MCP-specific integration in v1 (convenience bridge from `MCPDiscoveryResult` →
+  `DeferredToolGroup` is a later recipe, not core API).
+- No per-tool (sub-group) disclosure — the unit is a whole group.
+- No semantic / embedding retrieval — the catalog is designed to be small enough for the model to
+  read directly.
+- No "code mode" (tools as a callable API the model writes code against).
+- No changes to the existing MCP loader module (`cubepi/mcp/`).
+
+## Prior art
+
+- **hermes-agent Tool Search** (`tools/tool_search.py`, 735 lines): per-tool granularity, three
+  bridge tools (search/describe/call), BM25 retrieval, stateless catalog rebuilt every turn,
+  context-window-percentage threshold. Key lessons: (1) core tools must never defer, (2) catalog
+  drift silently drops tools (OpenClaw #84141), (3) transparent unwrap so hooks see real tool names.
+- **Anthropic Tool Search Tool** (GA Feb 2026): provider-side `defer_loading: true`, regex/BM25
+  search, ~85% token reduction. Provider-specific; cubepi must work provider-agnostically.
+- **cubebox skills system** (`SkillsMiddleware` + `load_skill`): the direct analog in cubebox.
+  Catalog in system prompt, model calls builtin to expand, middleware injects content into prompt
+  suffix. DeferredToolGroup generalizes this pattern for arbitrary tool sources.
+- **cubepi TodoListMiddleware**: the in-repo pattern to follow — `tools` attribute for builtin
+  injection, `extra_ref` for state persistence, `transform_system_prompt` for prompt augmentation.
+
+## Current cubepi architecture (relevant to this design)
+
+### Agent tool lifecycle
+
+1. **Construction.** `Agent.__init__` receives `tools: list[AgentTool]` and `middleware: list`.
+   Middleware `tools` attributes are extracted and appended to `agent.state.tools` (agent.py:191-195).
+2. **Context snapshot.** `_create_context_snapshot()` (agent.py:713-719) builds `AgentContext` with
+   `tools=list(self._state._tools)`. This is the snapshot the loop runs against.
+3. **Loop reads.** `run_agent_loop` creates `current_context` with `tools=context.tools`
+   (loop.py:61) — **a reference, not a deep copy**. Each iteration calls
+   `_stream_assistant_response(context=current_context)` which re-reads `context.tools` at
+   loop.py:705-706 to build `tools_defs`.
+
+**Key insight:** because `current_context.tools` is a reference to the same list object, appending
+to it from an `after_tool_call` hook makes new tools visible to the model on the **next iteration
+of the same run**. No changes to Agent or loop.py are needed for mid-run tool injection.
+
+### Middleware hooks (used by this feature)
+
+- `tools: list[AgentTool]` — class attribute; extracted at Agent construction and merged into
+  `agent.state.tools`. Used to inject the `expand_tools` builtin.
+- `transform_system_prompt(system_prompt, *, ctx, signal) → str` — chained sequentially across
+  middlewares. Used to append catalog text and expanded schema text.
+- `after_tool_call(ctx, *, signal) → AfterToolCallResult | None` — fires after every tool
+  execution. Used to detect `expand_tools` calls and inject the expanded group's tools.
+
+### State persistence
+
+`Agent._extra` is a `JsonObject` dict shared with `AgentContext.extra`. Middlewares write state
+into it (e.g. TodoListMiddleware writes todos). Host applications persist it via checkpointers.
+DeferredToolGroup uses this for expansion state (`extra["expanded_groups"]`).
+
+## Design
+
+### Data types
+
+```python
+@dataclass
+class DeferredToolGroup:
+    group_id: str                                       # "mcp:github", "plugin:kanban"
+    display_name: str                                   # "GitHub"
+    description: str                                    # "Code hosting: issues, PRs"
+    tool_names: list[str]                               # for catalog display only
+    loader: Callable[[], Awaitable[list[AgentTool]]]    # invoked on expand
+```
+
+`loader` is an async callback that returns callable `AgentTool`s. It is invoked exactly once per
+expansion (not per turn). The host application owns what happens inside: cubebox calls
+`load_workspace_mcp_tools_for_cubepi` filtered to one server; a standalone user might call
+`load_mcp_tools_http` directly.
+
+`tool_names` is for catalog display only — these names appear in the system prompt so the model
+can judge which group to expand. They are never used to construct tools or validate schemas.
+
+### `DeferredToolsMiddleware`
+
+A single middleware that encapsulates the entire feature. Follows TodoListMiddleware patterns.
+
+```python
+class DeferredToolsMiddleware(Middleware):
+    def __init__(
+        self,
+        *,
+        groups: list[DeferredToolGroup],
+        extra_ref: Callable[[], dict[str, Any]],
+        catalog_header: str = DEFAULT_CATALOG_HEADER,
+    ) -> None: ...
+```
+
+**Construction-time:**
+- Stores the deferred groups indexed by `group_id`.
+- Creates the `expand_tools` builtin as `self.tools = [_make_expand_tools(...)]`.
+- `extra_ref` works exactly like TodoListMiddleware: a closure returning `agent._extra` so the
+  tool's `execute` can write expansion state into the persisted dict.
+
+**`tools` attribute** — exposes `[expand_tools_agent_tool]`. Agent construction merges this into
+`agent.state.tools` automatically (agent.py:191-195).
+
+**`transform_system_prompt`:**
+1. Append **catalog section** — sorted by `group_id` for byte-stability. Lists each non-expanded
+   group with display_name, description, tool_names, and count. Groups already expanded are omitted
+   from the catalog (they are callable directly).
+2. Append **expanded schema section** — for each expanded group, **in expansion order** (not
+   sorted), append its tools' full definitions (name + description + parameters JSON). Expansion
+   order is append-only: a newly expanded group always lands after every already-rendered block,
+   preserving earlier cache segments byte-identical.
+
+Why expansion order, not sorted? Groups expand incrementally mid-conversation. Sorting could insert
+a later expansion before an already-cached block and invalidate the prompt-cache prefix.
+
+**`after_tool_call`:**
+- Fires on every tool call. Checks: is the tool name `expand_tools`? Did it succeed?
+- If yes: parse the result to get the `group_id`. Look up the group. Call `loader()`. Append the
+  returned `AgentTool`s to `ctx.context.tools` (the live list reference — next iteration sees them).
+  Record the group_id in `extra["expanded_groups"]` (ordered list, dedup, first-expanded-first).
+- Store the loaded tools' definitions for `transform_system_prompt` to render in the expanded
+  schema section.
+
+### `expand_tools` builtin
+
+```python
+class ExpandToolsInput(BaseModel):
+    group_id: str = Field(
+        description="The group_id from your 'Deferred tool groups' catalog."
+    )
+
+class ExpandToolsOutput(BaseModel):
+    group_id: str
+    expanded: bool
+    tool_names: list[str]
+    error: str | None = None
+```
+
+Behavior:
+- Valid group_id → call `loader()`, return `expanded=True` + tool names list.
+- Unknown group_id → return `is_error=True` + error message.
+- Already-expanded group_id → return `expanded=True` + tool names (idempotent, no re-load).
+
+The tool result contains tool names + descriptions only, **not** full schemas. The middleware
+injects schema text into the system-prompt suffix (matching the skills pattern where content goes
+into the prompt, not the tool result).
+
+### Catalog rendering
+
+Example output appended to system prompt:
+
+```
+# Deferred tool groups
+
+These tool groups are available but not yet loaded. Call `expand_tools(group_id)`
+to load a group's tools for the rest of this conversation.
+
+- `mcp:linear` — Issue tracking (8 tools)
+  create_issue, update_issue, search_issues, get_issue, create_project,
+  list_projects, create_cycle, list_cycles
+- `mcp:gdrive` — Google Drive (5 tools)
+  search_files, read_file, list_folders, get_file_metadata, create_file
+```
+
+Properties:
+- Sorted by `group_id` → byte-identical every turn (for groups that haven't been expanded yet).
+- Only non-expanded groups appear (expanded groups are callable directly and show in the expanded
+  schema section).
+- Tool names listed without descriptions or schemas — tool names in MCP/plugin conventions
+  (`verb_noun`) are self-descriptive. ~40 tokens per group of 12 tools.
+- `catalog_header` is customizable via constructor for host apps with different wording needs.
+
+### Expanded schema rendering
+
+Appended after the catalog, in expansion order:
+
+```
+# Expanded tool groups
+
+## mcp:linear
+
+- **create_issue**: Open a new issue
+  Parameters: {"type": "object", "properties": {"title": {"type": "string"}, ...}}
+- **update_issue**: Update an existing issue
+  Parameters: {...}
+...
+
+## mcp:gdrive
+
+...
+```
+
+Properties:
+- Expansion order preserved (append-only, never re-sorted).
+- Schema text derived from the loaded `AgentTool.to_definition()` at expansion time.
+- Stored on the middleware instance (not re-computed from tools list) so it's stable across turns.
+
+### Mid-run tool injection
+
+When `after_tool_call` fires for a successful `expand_tools`:
+
+```python
+loaded_tools = await group.loader()
+ctx.context.tools.extend(loaded_tools)   # visible next iteration
+```
+
+This works because `current_context.tools` in `_run_loop` is a reference to the same list — the
+loop re-reads `context.tools` at each iteration (loop.py:705). No Agent or loop changes needed.
+
+The expanded tools are real `AgentTool`s in `tools=` — the model can call them directly. The
+expanded schema section in the system prompt is supplementary context (descriptions, parameter
+docs), not the mechanism that makes tools callable.
+
+### Expansion state persistence
+
+```python
+extra["expanded_groups"]  # list[str], ordered, e.g. ["mcp:linear", "mcp:gdrive"]
+```
+
+- Written by `after_tool_call` on each new expansion.
+- Read by `transform_system_prompt` to decide what to render.
+- Persisted by the host application's checkpointer (same mechanism as TodoListMiddleware's todos).
+- **Must be serialized as an ordered list.** If a checkpointer deserializes it as an unordered set,
+  the expansion-order invariant breaks and the prompt-cache prefix becomes unstable across turns.
+
+### Replay on subsequent runs
+
+When the host application creates a new run (next user turn), it should:
+
+1. Read persisted `extra["expanded_groups"]` from the checkpointer.
+2. Pre-load those groups' tools (call each loader).
+3. Pass the pre-loaded tools as regular `tools` to `Agent(tools=[...builtins, ...pre_loaded])`.
+4. Construct `DeferredToolsMiddleware` with only the **remaining** (non-expanded) groups.
+5. Set `extra["expanded_groups"]` on the agent so `transform_system_prompt` renders the expanded
+   schema section correctly.
+
+This is the host application's responsibility, not the middleware's — the middleware only handles
+within-a-single-run expansion. cubepi provides a helper for step 2-5:
+
+```python
+@staticmethod
+def prepare_resumed_state(
+    groups: list[DeferredToolGroup],
+    expanded_ids: list[str],
+) -> ResumedState:
+    """Split groups into already-expanded (need pre-loading) and still-deferred."""
+    ...
+```
+
+## File layout
+
+```
+cubepi/
+  deferred/
+    __init__.py          # public exports
+    types.py             # DeferredToolGroup dataclass
+    middleware.py         # DeferredToolsMiddleware
+    _catalog.py          # catalog + expanded schema rendering (pure functions)
+    _expand_tool.py      # expand_tools builtin (AgentTool factory)
+tests/
+  test_deferred/
+    test_catalog.py      # catalog rendering determinism
+    test_middleware.py    # middleware integration (after_tool_call, transform_system_prompt)
+    test_expand_tool.py  # expand_tools builtin (valid/invalid/idempotent)
+    test_injection.py    # mid-run tool injection via context.tools mutation
+```
+
+New `cubepi/deferred/` package — does not import from `cubepi/mcp/` (tool-source-agnostic).
+
+## Public API surface
+
+```python
+# cubepi.deferred
+from cubepi.deferred import DeferredToolGroup, DeferredToolsMiddleware
+
+# Construction
+groups = [
+    DeferredToolGroup(
+        group_id="mcp:github",
+        display_name="GitHub",
+        description="Code hosting: issues, PRs, repos",
+        tool_names=["create_issue", "search_repos", "create_pr", ...],
+        loader=lambda: load_my_github_tools(),
+    ),
+]
+
+middleware = DeferredToolsMiddleware(
+    groups=groups,
+    extra_ref=lambda: agent._extra,
+)
+
+agent = Agent(
+    model=model,
+    system_prompt="...",
+    tools=[...builtins],
+    middleware=[middleware, ...other_middleware],
+)
+```
+
+Two exports. `DeferredToolGroup` is a plain dataclass, `DeferredToolsMiddleware` is the middleware.
+No registration method on Agent — follows the existing pattern where middlewares are passed to
+`Agent(middleware=[...])`.
+
+## Testing strategy
+
+Unit tests (no real LLM, no MCP server):
+
+1. **Catalog rendering** — sorted by group_id, byte-stable across input orderings, no schemas,
+   expanded groups omitted.
+2. **Expanded schema rendering** — expansion order preserved, append-only (second expansion's text
+   starts with first expansion's text), JSON keys sorted for byte stability.
+3. **expand_tools builtin** — valid group → expanded=True + tool names; unknown group → error;
+   already-expanded → idempotent.
+4. **Mid-run injection** — after expand_tools fires, `ctx.context.tools` contains the new tools;
+   simulate a second `_stream_assistant_response` call and verify `tools_defs` includes them.
+5. **Expansion state** — after_tool_call writes to extra["expanded_groups"] in order; duplicate
+   expansion doesn't add twice; transform_system_prompt uses the stored order.
+6. **Loader failure** — if loader raises, expand_tools returns is_error=True, no tools injected,
+   no state change.
+
+Integration test (with Agent, mock provider):
+
+7. **Full round-trip** — Agent with DeferredToolsMiddleware, mock provider that calls expand_tools
+   then uses an expanded tool. Assert: first model call sees expand_tools but not deferred tools;
+   after expansion, next iteration sees deferred tools in tools_defs.
+
+## Open questions
+
+- **Catalog in system prompt vs. in tool description.** Current design puts the catalog in the
+  system prompt (via `transform_system_prompt`). Alternative: put it in the `expand_tools` tool's
+  description field. Pro: shorter system prompt. Con: tool descriptions are less visible to models
+  than system prompt text, and the catalog changes as groups expand (dynamic tool descriptions are
+  unusual). Recommend: system prompt (current design).
+- **Loader caching.** Should the middleware cache loader results so a re-expand (or replay) doesn't
+  re-invoke the loader? v1: no — the host application manages caching if needed. The middleware
+  calls loader exactly once per group per run.
+- **Max groups / token budget.** Should the middleware have a hard limit on how many groups can be
+  registered, or a token-budget gate like hermes-agent's threshold_pct? v1: no — the host
+  application decides what to defer. A future version could add an `auto` mode that estimates
+  token cost and only defers when it's worth the indirection overhead.
+
+## v1 scope vs later
+
+**v1:**
+- `DeferredToolGroup` dataclass.
+- `DeferredToolsMiddleware` with catalog rendering, `expand_tools` builtin, mid-run injection,
+  expansion-order tracking, expanded schema rendering.
+- `prepare_resumed_state` helper for cross-run replay.
+- Unit + integration tests.
+
+**Later:**
+- MCP convenience bridge (`deferred_group_from_mcp_server`).
+- Auto-mode threshold (context-window-percentage gate).
+- Unify with skills disclosure under a shared primitive.
+- Per-tool (sub-group) disclosure.
+- Semantic / embedding retrieval for very large catalogs.

--- a/tests/deferred/test_agent_wiring.py
+++ b/tests/deferred/test_agent_wiring.py
@@ -135,8 +135,11 @@ class TestAgentDeferredToolGroups:
         assert deferred_mw._on_tools_expanded is not None
 
 
-class TestForkOnceStripsMiddlewareTools:
-    def test_fork_tools_exclude_expand_tools(self) -> None:
+class TestForkOnceDeniesMiddlewareTools:
+    def test_fork_keeps_expand_tools_in_schema(self) -> None:
+        """expand_tools stays in the tool list for prompt-cache parity."""
+        from cubepi.agent.agent import _deny_in_fork
+
         model = _make_faux_model()
         group = _make_group("mcp:github", ["t1", "t2"])
         agent = Agent(
@@ -144,11 +147,29 @@ class TestForkOnceStripsMiddlewareTools:
             tools=[_dummy_tool("builtin")],
             deferred_tool_groups=[group],
         )
-        # Collect middleware tool ids.
         mw_tool_ids = {
             id(t) for mw in agent._middleware for t in getattr(mw, "tools", []) or []
         }
-        fork_tools = [t for t in agent._state.tools if id(t) not in mw_tool_ids]
+        fork_tools = [
+            _deny_in_fork(t) if id(t) in mw_tool_ids else t for t in agent._state.tools
+        ]
         fork_tool_names = [t.name for t in fork_tools]
         assert "builtin" in fork_tool_names
-        assert "expand_tools" not in fork_tool_names
+        assert "expand_tools" in fork_tool_names
+
+    async def test_fork_expand_tools_returns_error(self) -> None:
+        """expand_tools in fork returns is_error=True instead of executing."""
+        from cubepi.agent.agent import _deny_in_fork
+
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+        agent = Agent(
+            model=model,
+            deferred_tool_groups=[group],
+        )
+        expand_tool = next(t for t in agent._state.tools if t.name == "expand_tools")
+        denied = _deny_in_fork(expand_tool)
+        assert denied.name == "expand_tools"
+        result = await denied.execute("call-1", _Empty())
+        assert result.is_error is True
+        assert "not available in a forked agent" in result.content[0].text

--- a/tests/deferred/test_agent_wiring.py
+++ b/tests/deferred/test_agent_wiring.py
@@ -51,7 +51,7 @@ class TestAgentDeferredToolGroups:
         )
         tool_names = [t.name for t in agent._state.tools]
         assert "builtin" in tool_names
-        assert "expand_tools" in tool_names
+        assert "load_tools" in tool_names
 
     def test_middleware_auto_created(self) -> None:
         model = _make_faux_model()
@@ -96,7 +96,7 @@ class TestAgentDeferredToolGroups:
         )
         assert any(isinstance(m, DeferredToolsMiddleware) for m in agent._middleware)
         tool_names = [t.name for t in agent._state.tools]
-        assert "expand_tools" in tool_names
+        assert "load_tools" in tool_names
 
     def test_combined_explicit_middleware_and_deferred_groups(self) -> None:
         model = _make_faux_model()
@@ -134,10 +134,36 @@ class TestAgentDeferredToolGroups:
         )
         assert deferred_mw._on_tools_expanded is not None
 
+    async def test_on_tools_expanded_deduplicates(self) -> None:
+        """Pre-loaded tools from resume are not duplicated by on_tools_expanded."""
+        from cubepi.agent.types import AgentContext
+
+        model = _make_faux_model()
+        t1 = _dummy_tool("t1")
+        group = _make_group("mcp:github", ["t1", "t2"])
+        agent = Agent(
+            model=model,
+            tools=[t1],
+            deferred_tool_groups=[group],
+        )
+        deferred_mw = next(
+            mw for mw in agent._middleware if isinstance(mw, DeferredToolsMiddleware)
+        )
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=list(agent._state.tools),
+            extra=agent._extra,
+        )
+        await deferred_mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        names = [t.name for t in agent._state._tools]
+        assert names.count("t1") == 1
+        assert "t2" in names
+
 
 class TestForkOnceDeniesMiddlewareTools:
-    def test_fork_keeps_expand_tools_in_schema(self) -> None:
-        """expand_tools stays in the tool list for prompt-cache parity."""
+    def test_fork_keeps_load_tools_in_schema(self) -> None:
+        """load_tools stays in the tool list for prompt-cache parity."""
         from cubepi.agent.agent import _deny_in_fork
 
         model = _make_faux_model()
@@ -155,10 +181,10 @@ class TestForkOnceDeniesMiddlewareTools:
         ]
         fork_tool_names = [t.name for t in fork_tools]
         assert "builtin" in fork_tool_names
-        assert "expand_tools" in fork_tool_names
+        assert "load_tools" in fork_tool_names
 
-    async def test_fork_expand_tools_returns_error(self) -> None:
-        """expand_tools in fork returns is_error=True instead of executing."""
+    async def test_fork_load_tools_returns_error(self) -> None:
+        """load_tools in fork returns is_error=True instead of executing."""
         from cubepi.agent.agent import _deny_in_fork
 
         model = _make_faux_model()
@@ -167,9 +193,9 @@ class TestForkOnceDeniesMiddlewareTools:
             model=model,
             deferred_tool_groups=[group],
         )
-        expand_tool = next(t for t in agent._state.tools if t.name == "expand_tools")
+        expand_tool = next(t for t in agent._state.tools if t.name == "load_tools")
         denied = _deny_in_fork(expand_tool)
-        assert denied.name == "expand_tools"
+        assert denied.name == "load_tools"
         result = await denied.execute("call-1", _Empty())
         assert result.is_error is True
         assert "not available in a forked agent" in result.content[0].text

--- a/tests/deferred/test_agent_wiring.py
+++ b/tests/deferred/test_agent_wiring.py
@@ -112,15 +112,11 @@ class TestAgentDeferredToolGroups:
             deferred_tool_groups=[group],
         )
         assert agent._middleware[0] is marker
-        assert any(
-            isinstance(mw, DeferredToolsMiddleware)
-            for mw in agent._middleware
-        )
+        assert any(isinstance(mw, DeferredToolsMiddleware) for mw in agent._middleware)
 
     def test_empty_deferred_groups_no_middleware(self) -> None:
         model = _make_faux_model()
         agent = Agent(model=model, deferred_tool_groups=[])
         assert not any(
-            isinstance(mw, DeferredToolsMiddleware)
-            for mw in agent._middleware
+            isinstance(mw, DeferredToolsMiddleware) for mw in agent._middleware
         )

--- a/tests/deferred/test_agent_wiring.py
+++ b/tests/deferred/test_agent_wiring.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from cubepi.agent.agent import Agent
 from cubepi.agent.types import AgentTool, AgentToolResult
 from cubepi.deferred import DeferredToolGroup, DeferredToolsMiddleware

--- a/tests/deferred/test_agent_wiring.py
+++ b/tests/deferred/test_agent_wiring.py
@@ -120,3 +120,35 @@ class TestAgentDeferredToolGroups:
         assert not any(
             isinstance(mw, DeferredToolsMiddleware) for mw in agent._middleware
         )
+
+    def test_on_tools_expanded_wired(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+        agent = Agent(
+            model=model,
+            tools=[_dummy_tool("builtin")],
+            deferred_tool_groups=[group],
+        )
+        deferred_mw = next(
+            mw for mw in agent._middleware if isinstance(mw, DeferredToolsMiddleware)
+        )
+        assert deferred_mw._on_tools_expanded is not None
+
+
+class TestForkOnceStripsMiddlewareTools:
+    def test_fork_tools_exclude_expand_tools(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1", "t2"])
+        agent = Agent(
+            model=model,
+            tools=[_dummy_tool("builtin")],
+            deferred_tool_groups=[group],
+        )
+        # Collect middleware tool ids.
+        mw_tool_ids = {
+            id(t) for mw in agent._middleware for t in getattr(mw, "tools", []) or []
+        }
+        fork_tools = [t for t in agent._state.tools if id(t) not in mw_tool_ids]
+        fork_tool_names = [t.name for t in fork_tools]
+        assert "builtin" in fork_tool_names
+        assert "expand_tools" not in fork_tool_names

--- a/tests/deferred/test_agent_wiring.py
+++ b/tests/deferred/test_agent_wiring.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+from cubepi.agent.agent import Agent
+from cubepi.agent.types import AgentTool, AgentToolResult
+from cubepi.deferred import DeferredToolGroup, DeferredToolsMiddleware
+from cubepi.providers.base import TextContent
+from cubepi.middleware.base import Middleware
+from pydantic import BaseModel
+
+
+class _Empty(BaseModel):
+    pass
+
+
+def _dummy_tool(name: str) -> AgentTool:
+    async def _exec(tool_call_id, args, *, signal=None, on_update=None):
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    return AgentTool(name=name, description="dummy", parameters=_Empty, execute=_exec)
+
+
+def _make_group(group_id: str, tool_names: list[str]) -> DeferredToolGroup:
+    async def _loader():
+        return [_dummy_tool(n) for n in tool_names]
+
+    return DeferredToolGroup(
+        group_id=group_id,
+        display_name="Test",
+        description="desc",
+        tool_names=tool_names,
+        loader=_loader,
+    )
+
+
+def _make_faux_model():
+    """Create a minimal BoundModel for Agent construction."""
+    from cubepi.providers.faux import FauxProvider
+
+    provider = FauxProvider()
+    return provider.model("faux")
+
+
+class TestAgentDeferredToolGroups:
+    def test_agent_accepts_deferred_tool_groups(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1", "t2"])
+        agent = Agent(
+            model=model,
+            tools=[_dummy_tool("builtin")],
+            deferred_tool_groups=[group],
+        )
+        tool_names = [t.name for t in agent._state.tools]
+        assert "builtin" in tool_names
+        assert "expand_tools" in tool_names
+
+    def test_middleware_auto_created(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+        agent = Agent(
+            model=model,
+            deferred_tool_groups=[group],
+        )
+        assert any(isinstance(mw, DeferredToolsMiddleware) for mw in agent._middleware)
+
+    def test_extra_ref_bound_to_agent_extra(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+        agent = Agent(
+            model=model,
+            deferred_tool_groups=[group],
+        )
+        deferred_mw = next(
+            mw for mw in agent._middleware if isinstance(mw, DeferredToolsMiddleware)
+        )
+        assert deferred_mw._extra_ref() is agent._extra
+
+    def test_no_deferred_groups_no_middleware(self) -> None:
+        model = _make_faux_model()
+        agent = Agent(model=model, tools=[_dummy_tool("t1")])
+        assert not any(
+            isinstance(mw, DeferredToolsMiddleware) for mw in agent._middleware
+        )
+
+    def test_explicit_middleware_still_works(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+        extra: dict = {}
+        mw = DeferredToolsMiddleware(
+            groups=[group],
+            extra_ref=lambda: extra,
+            catalog_header="Custom",
+        )
+        agent = Agent(
+            model=model,
+            middleware=[mw],
+        )
+        assert any(isinstance(m, DeferredToolsMiddleware) for m in agent._middleware)
+        tool_names = [t.name for t in agent._state.tools]
+        assert "expand_tools" in tool_names
+
+    def test_combined_explicit_middleware_and_deferred_groups(self) -> None:
+        model = _make_faux_model()
+        group = _make_group("mcp:github", ["t1"])
+
+        class _Marker(Middleware):
+            pass
+
+        marker = _Marker()
+        agent = Agent(
+            model=model,
+            middleware=[marker],
+            deferred_tool_groups=[group],
+        )
+        assert agent._middleware[0] is marker
+        assert any(
+            isinstance(mw, DeferredToolsMiddleware)
+            for mw in agent._middleware
+        )
+
+    def test_empty_deferred_groups_no_middleware(self) -> None:
+        model = _make_faux_model()
+        agent = Agent(model=model, deferred_tool_groups=[])
+        assert not any(
+            isinstance(mw, DeferredToolsMiddleware)
+            for mw in agent._middleware
+        )

--- a/tests/deferred/test_catalog.py
+++ b/tests/deferred/test_catalog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from cubepi.deferred._catalog import render_catalog, render_expanded_schemas
 from cubepi.deferred.types import DeferredToolGroup
 
 
@@ -22,3 +23,132 @@ class TestDeferredToolGroup:
         assert group.description == "Code hosting: issues, PRs, repos"
         assert group.tool_names == ["create_issue", "search_repos"]
         assert group.loader is _loader
+
+
+def _make_group(
+    group_id: str,
+    display_name: str,
+    description: str,
+    tool_names: list[str],
+) -> DeferredToolGroup:
+    async def _noop_loader():
+        return []
+
+    return DeferredToolGroup(
+        group_id=group_id,
+        display_name=display_name,
+        description=description,
+        tool_names=tool_names,
+        loader=_noop_loader,
+    )
+
+
+class TestRenderCatalog:
+    def test_no_groups_returns_empty(self) -> None:
+        result = render_catalog(groups=[], expanded={})
+        assert result == ""
+
+    def test_single_group_no_expansion(self) -> None:
+        groups = [_make_group("mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos"])]
+        result = render_catalog(groups=groups, expanded={})
+        assert "mcp:github" in result
+        assert "GitHub" in result
+        assert "Code hosting" in result
+        assert "2 tools" in result
+        assert "create_issue" in result
+        assert "search_repos" in result
+
+    def test_sorted_by_group_id(self) -> None:
+        groups = [
+            _make_group("z:last", "Last", "desc", ["t1"]),
+            _make_group("a:first", "First", "desc", ["t2"]),
+        ]
+        result = render_catalog(groups=groups, expanded={})
+        a_pos = result.index("a:first")
+        z_pos = result.index("z:last")
+        assert a_pos < z_pos
+
+    def test_byte_stable_across_input_orderings(self) -> None:
+        g1 = _make_group("mcp:a", "A", "desc", ["t1"])
+        g2 = _make_group("mcp:b", "B", "desc", ["t2"])
+        result_ab = render_catalog(groups=[g1, g2], expanded={})
+        result_ba = render_catalog(groups=[g2, g1], expanded={})
+        assert result_ab == result_ba
+
+    def test_fully_expanded_group_omitted(self) -> None:
+        groups = [
+            _make_group("mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos"]),
+            _make_group("mcp:linear", "Linear", "Issues", ["create_issue"]),
+        ]
+        expanded: dict[str, list[str] | None] = {"mcp:github": None}
+        result = render_catalog(groups=groups, expanded=expanded)
+        assert "mcp:github" not in result
+        assert "mcp:linear" in result
+
+    def test_partially_expanded_shows_remaining(self) -> None:
+        groups = [
+            _make_group(
+                "mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos", "create_pr"]
+            )
+        ]
+        expanded: dict[str, list[str] | None] = {"mcp:github": ["create_issue"]}
+        result = render_catalog(groups=groups, expanded=expanded)
+        assert "2 remaining tools" in result
+        assert "create_issue" not in result
+        assert "search_repos" in result
+        assert "create_pr" in result
+
+    def test_all_groups_fully_expanded_returns_empty(self) -> None:
+        groups = [_make_group("mcp:github", "GitHub", "desc", ["t1"])]
+        expanded: dict[str, list[str] | None] = {"mcp:github": None}
+        result = render_catalog(groups=groups, expanded=expanded)
+        assert result == ""
+
+    def test_custom_header(self) -> None:
+        groups = [_make_group("mcp:a", "A", "desc", ["t1"])]
+        result = render_catalog(groups=groups, expanded={}, header="Custom header text")
+        assert "Custom header text" in result
+
+
+class TestRenderExpandedSchemas:
+    def test_no_expansions_returns_empty(self) -> None:
+        result = render_expanded_schemas(expanded_schemas=[])
+        assert result == ""
+
+    def test_single_expansion(self) -> None:
+        schemas = [
+            (
+                "mcp:github",
+                [
+                    {
+                        "name": "create_issue",
+                        "description": "Create an issue",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                ],
+            )
+        ]
+        result = render_expanded_schemas(expanded_schemas=schemas)
+        assert "mcp:github" in result
+        assert "create_issue" in result
+        assert "Create an issue" in result
+
+    def test_expansion_order_preserved(self) -> None:
+        schemas = [
+            ("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}]),
+            ("mcp:github", [{"name": "t2", "description": "d2", "parameters": {}}]),
+        ]
+        result = render_expanded_schemas(expanded_schemas=schemas)
+        linear_pos = result.index("mcp:linear")
+        github_pos = result.index("mcp:github")
+        assert linear_pos < github_pos
+
+    def test_append_only_prefix_stable(self) -> None:
+        schemas_v1 = [("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}])]
+        schemas_v2 = [
+            ("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}]),
+            ("mcp:github", [{"name": "t2", "description": "d2", "parameters": {}}]),
+        ]
+        result_v1 = render_expanded_schemas(expanded_schemas=schemas_v1)
+        result_v2 = render_expanded_schemas(expanded_schemas=schemas_v2)
+        assert result_v2.startswith(result_v1)

--- a/tests/deferred/test_catalog.py
+++ b/tests/deferred/test_catalog.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from cubepi.deferred.types import DeferredToolGroup
+
+
+class TestDeferredToolGroup:
+    def test_basic_construction(self) -> None:
+        async def _loader():
+            return []
+
+        group = DeferredToolGroup(
+            group_id="mcp:github",
+            display_name="GitHub",
+            description="Code hosting: issues, PRs, repos",
+            tool_names=["create_issue", "search_repos"],
+            loader=_loader,
+        )
+        assert group.group_id == "mcp:github"
+        assert group.display_name == "GitHub"
+        assert group.description == "Code hosting: issues, PRs, repos"
+        assert group.tool_names == ["create_issue", "search_repos"]
+        assert group.loader is _loader

--- a/tests/deferred/test_catalog.py
+++ b/tests/deferred/test_catalog.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from cubepi.deferred._catalog import render_catalog, render_expanded_schemas
 from cubepi.deferred.types import DeferredToolGroup
 

--- a/tests/deferred/test_catalog.py
+++ b/tests/deferred/test_catalog.py
@@ -47,7 +47,11 @@ class TestRenderCatalog:
         assert result == ""
 
     def test_single_group_no_expansion(self) -> None:
-        groups = [_make_group("mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos"])]
+        groups = [
+            _make_group(
+                "mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos"]
+            )
+        ]
         result = render_catalog(groups=groups, expanded={})
         assert "mcp:github" in result
         assert "GitHub" in result
@@ -75,7 +79,9 @@ class TestRenderCatalog:
 
     def test_fully_expanded_group_omitted(self) -> None:
         groups = [
-            _make_group("mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos"]),
+            _make_group(
+                "mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos"]
+            ),
             _make_group("mcp:linear", "Linear", "Issues", ["create_issue"]),
         ]
         expanded: dict[str, list[str] | None] = {"mcp:github": None}
@@ -86,7 +92,10 @@ class TestRenderCatalog:
     def test_partially_expanded_shows_remaining(self) -> None:
         groups = [
             _make_group(
-                "mcp:github", "GitHub", "Code hosting", ["create_issue", "search_repos", "create_pr"]
+                "mcp:github",
+                "GitHub",
+                "Code hosting",
+                ["create_issue", "search_repos", "create_pr"],
             )
         ]
         expanded: dict[str, list[str] | None] = {"mcp:github": ["create_issue"]}
@@ -142,7 +151,9 @@ class TestRenderExpandedSchemas:
         assert linear_pos < github_pos
 
     def test_append_only_prefix_stable(self) -> None:
-        schemas_v1 = [("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}])]
+        schemas_v1 = [
+            ("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}])
+        ]
         schemas_v2 = [
             ("mcp:linear", [{"name": "t1", "description": "d1", "parameters": {}}]),
             ("mcp:github", [{"name": "t2", "description": "d2", "parameters": {}}]),

--- a/tests/deferred/test_expand_tool.py
+++ b/tests/deferred/test_expand_tool.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+from cubepi.deferred._expand_tool import (
+    ExpandToolsInput,
+    ExpandToolsOutput,
+    _make_expand_tools,
+)
+from cubepi.agent.types import AgentTool
+
+
+class TestExpandToolsInput:
+    def test_group_id_only(self) -> None:
+        inp = ExpandToolsInput(group_id="mcp:github")
+        assert inp.group_id == "mcp:github"
+        assert inp.tool_names is None
+
+    def test_group_id_with_tool_names(self) -> None:
+        inp = ExpandToolsInput(group_id="mcp:github", tool_names=["create_issue"])
+        assert inp.tool_names == ["create_issue"]
+
+
+class TestExpandToolsOutput:
+    def test_success_output(self) -> None:
+        out = ExpandToolsOutput(
+            group_id="mcp:github",
+            expanded=True,
+            tool_names=["create_issue"],
+            remaining=5,
+        )
+        assert out.expanded is True
+        assert out.error is None
+
+    def test_error_output(self) -> None:
+        out = ExpandToolsOutput(
+            group_id="bad:id",
+            expanded=False,
+            tool_names=[],
+            remaining=0,
+            error="Unknown group_id: bad:id",
+        )
+        assert out.expanded is False
+        assert out.error is not None
+
+
+class TestMakeExpandTools:
+    def test_returns_agent_tool(self) -> None:
+        tool = _make_expand_tools(expand_callback=_noop_callback)
+        assert isinstance(tool, AgentTool)
+        assert tool.name == "expand_tools"
+
+    def test_schema_has_group_id_and_tool_names(self) -> None:
+        tool = _make_expand_tools(expand_callback=_noop_callback)
+        defn = tool.to_definition()
+        props = defn.parameters.get("properties", {})
+        assert "group_id" in props
+        assert "tool_names" in props
+
+    async def test_execute_calls_callback(self) -> None:
+        calls: list[tuple[str, list[str] | None]] = []
+
+        async def _callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+            calls.append((group_id, tool_names))
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=True,
+                tool_names=["t1"],
+                remaining=0,
+            )
+
+        tool = _make_expand_tools(expand_callback=_callback)
+        result = await tool.execute("call-1", ExpandToolsInput(group_id="mcp:github"))
+        assert len(calls) == 1
+        assert calls[0] == ("mcp:github", None)
+        assert result.is_error is None or result.is_error is False
+
+    async def test_execute_with_tool_names(self) -> None:
+        calls: list[tuple[str, list[str] | None]] = []
+
+        async def _callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+            calls.append((group_id, tool_names))
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=True,
+                tool_names=tool_names or [],
+                remaining=0,
+            )
+
+        tool = _make_expand_tools(expand_callback=_callback)
+        result = await tool.execute(
+            "call-2",
+            ExpandToolsInput(group_id="mcp:github", tool_names=["create_issue"]),
+        )
+        assert calls[0] == ("mcp:github", ["create_issue"])
+
+    async def test_execute_error_sets_is_error(self) -> None:
+        async def _err_callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+            return ExpandToolsOutput(
+                group_id=group_id,
+                expanded=False,
+                tool_names=[],
+                remaining=0,
+                error="Unknown group_id: bad",
+            )
+
+        tool = _make_expand_tools(expand_callback=_err_callback)
+        result = await tool.execute("call-3", ExpandToolsInput(group_id="bad"))
+        assert result.is_error is True
+
+
+async def _noop_callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+    return ExpandToolsOutput(group_id=group_id, expanded=True, tool_names=[], remaining=0)

--- a/tests/deferred/test_expand_tool.py
+++ b/tests/deferred/test_expand_tool.py
@@ -58,7 +58,9 @@ class TestMakeExpandTools:
     async def test_execute_calls_callback(self) -> None:
         calls: list[tuple[str, list[str] | None]] = []
 
-        async def _callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+        async def _callback(
+            group_id: str, tool_names: list[str] | None
+        ) -> ExpandToolsOutput:
             calls.append((group_id, tool_names))
             return ExpandToolsOutput(
                 group_id=group_id,
@@ -76,7 +78,9 @@ class TestMakeExpandTools:
     async def test_execute_with_tool_names(self) -> None:
         calls: list[tuple[str, list[str] | None]] = []
 
-        async def _callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+        async def _callback(
+            group_id: str, tool_names: list[str] | None
+        ) -> ExpandToolsOutput:
             calls.append((group_id, tool_names))
             return ExpandToolsOutput(
                 group_id=group_id,
@@ -93,7 +97,9 @@ class TestMakeExpandTools:
         assert calls[0] == ("mcp:github", ["create_issue"])
 
     async def test_execute_error_sets_is_error(self) -> None:
-        async def _err_callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
+        async def _err_callback(
+            group_id: str, tool_names: list[str] | None
+        ) -> ExpandToolsOutput:
             return ExpandToolsOutput(
                 group_id=group_id,
                 expanded=False,
@@ -107,5 +113,9 @@ class TestMakeExpandTools:
         assert result.is_error is True
 
 
-async def _noop_callback(group_id: str, tool_names: list[str] | None) -> ExpandToolsOutput:
-    return ExpandToolsOutput(group_id=group_id, expanded=True, tool_names=[], remaining=0)
+async def _noop_callback(
+    group_id: str, tool_names: list[str] | None
+) -> ExpandToolsOutput:
+    return ExpandToolsOutput(
+        group_id=group_id, expanded=True, tool_names=[], remaining=0
+    )

--- a/tests/deferred/test_expand_tool.py
+++ b/tests/deferred/test_expand_tool.py
@@ -1,27 +1,28 @@
 from __future__ import annotations
 
 from cubepi.deferred._expand_tool import (
-    ExpandToolsInput,
-    ExpandToolsOutput,
-    _make_expand_tools,
+    TOOL_NAME,
+    LoadToolsInput,
+    LoadToolsOutput,
+    _make_load_tools,
 )
 from cubepi.agent.types import AgentTool
 
 
-class TestExpandToolsInput:
+class TestLoadToolsInput:
     def test_group_id_only(self) -> None:
-        inp = ExpandToolsInput(group_id="mcp:github")
+        inp = LoadToolsInput(group_id="mcp:github")
         assert inp.group_id == "mcp:github"
         assert inp.tool_names is None
 
     def test_group_id_with_tool_names(self) -> None:
-        inp = ExpandToolsInput(group_id="mcp:github", tool_names=["create_issue"])
+        inp = LoadToolsInput(group_id="mcp:github", tool_names=["create_issue"])
         assert inp.tool_names == ["create_issue"]
 
 
-class TestExpandToolsOutput:
+class TestLoadToolsOutput:
     def test_success_output(self) -> None:
-        out = ExpandToolsOutput(
+        out = LoadToolsOutput(
             group_id="mcp:github",
             expanded=True,
             tool_names=["create_issue"],
@@ -31,7 +32,7 @@ class TestExpandToolsOutput:
         assert out.error is None
 
     def test_error_output(self) -> None:
-        out = ExpandToolsOutput(
+        out = LoadToolsOutput(
             group_id="bad:id",
             expanded=False,
             tool_names=[],
@@ -42,14 +43,14 @@ class TestExpandToolsOutput:
         assert out.error is not None
 
 
-class TestMakeExpandTools:
+class TestMakeLoadTools:
     def test_returns_agent_tool(self) -> None:
-        tool = _make_expand_tools(expand_callback=_noop_callback)
+        tool = _make_load_tools(load_callback=_noop_callback)
         assert isinstance(tool, AgentTool)
-        assert tool.name == "expand_tools"
+        assert tool.name == TOOL_NAME
 
     def test_schema_has_group_id_and_tool_names(self) -> None:
-        tool = _make_expand_tools(expand_callback=_noop_callback)
+        tool = _make_load_tools(load_callback=_noop_callback)
         defn = tool.to_definition()
         props = defn.parameters.get("properties", {})
         assert "group_id" in props
@@ -60,17 +61,17 @@ class TestMakeExpandTools:
 
         async def _callback(
             group_id: str, tool_names: list[str] | None
-        ) -> ExpandToolsOutput:
+        ) -> LoadToolsOutput:
             calls.append((group_id, tool_names))
-            return ExpandToolsOutput(
+            return LoadToolsOutput(
                 group_id=group_id,
                 expanded=True,
                 tool_names=["t1"],
                 remaining=0,
             )
 
-        tool = _make_expand_tools(expand_callback=_callback)
-        result = await tool.execute("call-1", ExpandToolsInput(group_id="mcp:github"))
+        tool = _make_load_tools(load_callback=_callback)
+        result = await tool.execute("call-1", LoadToolsInput(group_id="mcp:github"))
         assert len(calls) == 1
         assert calls[0] == ("mcp:github", None)
         assert result.is_error is None or result.is_error is False
@@ -80,27 +81,27 @@ class TestMakeExpandTools:
 
         async def _callback(
             group_id: str, tool_names: list[str] | None
-        ) -> ExpandToolsOutput:
+        ) -> LoadToolsOutput:
             calls.append((group_id, tool_names))
-            return ExpandToolsOutput(
+            return LoadToolsOutput(
                 group_id=group_id,
                 expanded=True,
                 tool_names=tool_names or [],
                 remaining=0,
             )
 
-        tool = _make_expand_tools(expand_callback=_callback)
+        tool = _make_load_tools(load_callback=_callback)
         await tool.execute(
             "call-2",
-            ExpandToolsInput(group_id="mcp:github", tool_names=["create_issue"]),
+            LoadToolsInput(group_id="mcp:github", tool_names=["create_issue"]),
         )
         assert calls[0] == ("mcp:github", ["create_issue"])
 
     async def test_execute_error_sets_is_error(self) -> None:
         async def _err_callback(
             group_id: str, tool_names: list[str] | None
-        ) -> ExpandToolsOutput:
-            return ExpandToolsOutput(
+        ) -> LoadToolsOutput:
+            return LoadToolsOutput(
                 group_id=group_id,
                 expanded=False,
                 tool_names=[],
@@ -108,14 +109,12 @@ class TestMakeExpandTools:
                 error="Unknown group_id: bad",
             )
 
-        tool = _make_expand_tools(expand_callback=_err_callback)
-        result = await tool.execute("call-3", ExpandToolsInput(group_id="bad"))
+        tool = _make_load_tools(load_callback=_err_callback)
+        result = await tool.execute("call-3", LoadToolsInput(group_id="bad"))
         assert result.is_error is True
 
 
 async def _noop_callback(
     group_id: str, tool_names: list[str] | None
-) -> ExpandToolsOutput:
-    return ExpandToolsOutput(
-        group_id=group_id, expanded=True, tool_names=[], remaining=0
-    )
+) -> LoadToolsOutput:
+    return LoadToolsOutput(group_id=group_id, expanded=True, tool_names=[], remaining=0)

--- a/tests/deferred/test_expand_tool.py
+++ b/tests/deferred/test_expand_tool.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from cubepi.deferred._expand_tool import (
     ExpandToolsInput,
     ExpandToolsOutput,
@@ -88,7 +86,7 @@ class TestMakeExpandTools:
             )
 
         tool = _make_expand_tools(expand_callback=_callback)
-        result = await tool.execute(
+        await tool.execute(
             "call-2",
             ExpandToolsInput(group_id="mcp:github", tool_names=["create_issue"]),
         )

--- a/tests/deferred/test_middleware.py
+++ b/tests/deferred/test_middleware.py
@@ -46,12 +46,12 @@ def _make_group(
 
 
 class TestMiddlewareConstruction:
-    def test_tools_attribute_contains_expand_tools(self) -> None:
+    def test_tools_attribute_contains_load_tools(self) -> None:
         extra: dict = {}
         group = _make_group("mcp:a", ["t1"])
         mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
         assert len(mw.tools) == 1
-        assert mw.tools[0].name == "expand_tools"
+        assert mw.tools[0].name == "load_tools"
 
 
 class TestTransformSystemPrompt:
@@ -108,7 +108,7 @@ class TestAfterToolCallExpansion:
         assert output.expanded is True
         assert len(output.tool_names) == 2
         assert output.remaining == 0
-        assert len(context_tools) == 3  # expand_tools + 2 new
+        assert len(context_tools) == 3  # load_tools + 2 new
         assert extra["expanded_groups"] == {"mcp:github": None}
 
     async def test_expand_selective_injects_only_requested(self) -> None:
@@ -135,7 +135,7 @@ class TestAfterToolCallExpansion:
         assert output.expanded is True
         assert output.tool_names == ["create_issue"]
         assert output.remaining == 2
-        assert len(context_tools) == 2  # expand_tools + 1 new
+        assert len(context_tools) == 2  # load_tools + 1 new
         assert extra["expanded_groups"] == {"mcp:github": ["create_issue"]}
 
     async def test_incremental_expand_same_group(self) -> None:

--- a/tests/deferred/test_middleware.py
+++ b/tests/deferred/test_middleware.py
@@ -330,3 +330,106 @@ class TestPrepareResumedState:
         assert "mcp:github" in prompt
         assert "mcp:slack" in prompt
         assert "t1" in prompt
+
+    async def test_loader_cache_populated(self) -> None:
+        group = _make_group("mcp:github", ["t1", "t2"])
+        expanded: dict[str, list[str] | None] = {"mcp:github": None}
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group],
+            expanded=expanded,
+        )
+        assert "mcp:github" in resumed.loader_cache
+        assert len(resumed.loader_cache["mcp:github"]) == 2
+
+    async def test_resumed_loader_cache_skips_reload(self) -> None:
+        call_count = [0]
+        group = _make_group("mcp:github", ["t1"], loader_call_count=call_count)
+        expanded: dict[str, list[str] | None] = {"mcp:github": ["t1"]}
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group],
+            expanded=expanded,
+        )
+        assert call_count[0] == 1
+
+        extra: dict = {"expanded_groups": dict(expanded)}
+        mw = DeferredToolsMiddleware(
+            groups=resumed.remaining_groups,
+            extra_ref=lambda: extra,
+            resumed_schemas=resumed.expanded_schemas,
+            resumed_loader_cache=resumed.loader_cache,
+        )
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=list(mw.tools) + resumed.pre_loaded_tools,
+            extra=extra,
+        )
+        # Expanding remaining tools should NOT call loader again.
+        await mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        assert call_count[0] == 1  # still 1, not 2
+
+
+class TestOnToolsExpandedCallback:
+    async def test_callback_invoked_on_expansion(self) -> None:
+        expanded_tools: list[AgentTool] = []
+        extra: dict = {}
+        group = _make_group("mcp:github", ["t1", "t2"])
+        mw = DeferredToolsMiddleware(
+            groups=[group],
+            extra_ref=lambda: extra,
+            on_tools_expanded=lambda tools: expanded_tools.extend(tools),
+        )
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=list(mw.tools),
+            extra=extra,
+        )
+        await mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        assert len(expanded_tools) == 2
+        assert {t.name for t in expanded_tools} == {"t1", "t2"}
+
+    async def test_callback_not_invoked_on_idempotent(self) -> None:
+        call_count = [0]
+
+        def _on_expanded(tools: list[AgentTool]) -> None:
+            call_count[0] += 1
+
+        extra: dict = {}
+        group = _make_group("mcp:github", ["t1"])
+        mw = DeferredToolsMiddleware(
+            groups=[group],
+            extra_ref=lambda: extra,
+            on_tools_expanded=_on_expanded,
+        )
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=list(mw.tools),
+            extra=extra,
+        )
+        await mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        assert call_count[0] == 1
+        await mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        assert call_count[0] == 1  # no new tools, no callback
+
+
+class TestExpandedGroupsDictStability:
+    async def test_shared_dict_mutated_in_place(self) -> None:
+        """expanded_groups dict in extra is mutated in place, not replaced."""
+        extra: dict = {}
+        g1 = _make_group("mcp:a", ["t1"])
+        g2 = _make_group("mcp:b", ["t2"])
+        mw = DeferredToolsMiddleware(groups=[g1, g2], extra_ref=lambda: extra)
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=list(mw.tools),
+            extra=extra,
+        )
+        await mw._expand(group_id="mcp:a", tool_names=None, context=ctx)
+        dict_ref = extra["expanded_groups"]
+        await mw._expand(group_id="mcp:b", tool_names=None, context=ctx)
+        # Same dict object, not a new one.
+        assert extra["expanded_groups"] is dict_ref
+        assert set(dict_ref.keys()) == {"mcp:a", "mcp:b"}

--- a/tests/deferred/test_middleware.py
+++ b/tests/deferred/test_middleware.py
@@ -15,7 +15,9 @@ def _dummy_tool(name: str, description: str = "dummy") -> AgentTool:
     async def _exec(tool_call_id, args, *, signal=None, on_update=None):
         return AgentToolResult(content=[TextContent(text="ok")])
 
-    return AgentTool(name=name, description=description, parameters=_Empty, execute=_exec)
+    return AgentTool(
+        name=name, description=description, parameters=_Empty, execute=_exec
+    )
 
 
 def _make_group(
@@ -92,11 +94,16 @@ class TestAfterToolCallExpansion:
 
         context_tools: list[AgentTool] = [mw.tools[0]]
         ctx = AgentContext(
-            system_prompt="", messages=[], tools=context_tools, extra=extra,
+            system_prompt="",
+            messages=[],
+            tools=context_tools,
+            extra=extra,
         )
 
         output = await mw._expand(
-            group_id="mcp:github", tool_names=None, context=ctx,
+            group_id="mcp:github",
+            tool_names=None,
+            context=ctx,
         )
         assert output.expanded is True
         assert len(output.tool_names) == 2
@@ -107,17 +114,23 @@ class TestAfterToolCallExpansion:
     async def test_expand_selective_injects_only_requested(self) -> None:
         extra: dict = {}
         group = _make_group(
-            "mcp:github", ["create_issue", "search_repos", "create_pr"],
+            "mcp:github",
+            ["create_issue", "search_repos", "create_pr"],
         )
         mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
 
         context_tools: list[AgentTool] = [mw.tools[0]]
         ctx = AgentContext(
-            system_prompt="", messages=[], tools=context_tools, extra=extra,
+            system_prompt="",
+            messages=[],
+            tools=context_tools,
+            extra=extra,
         )
 
         output = await mw._expand(
-            group_id="mcp:github", tool_names=["create_issue"], context=ctx,
+            group_id="mcp:github",
+            tool_names=["create_issue"],
+            context=ctx,
         )
         assert output.expanded is True
         assert output.tool_names == ["create_issue"]
@@ -129,13 +142,18 @@ class TestAfterToolCallExpansion:
         extra: dict = {}
         call_count = [0]
         group = _make_group(
-            "mcp:github", ["t1", "t2", "t3"], loader_call_count=call_count,
+            "mcp:github",
+            ["t1", "t2", "t3"],
+            loader_call_count=call_count,
         )
         mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
 
         context_tools: list[AgentTool] = [mw.tools[0]]
         ctx = AgentContext(
-            system_prompt="", messages=[], tools=context_tools, extra=extra,
+            system_prompt="",
+            messages=[],
+            tools=context_tools,
+            extra=extra,
         )
 
         await mw._expand(group_id="mcp:github", tool_names=["t1"], context=ctx)
@@ -152,11 +170,16 @@ class TestAfterToolCallExpansion:
         extra: dict = {}
         mw = DeferredToolsMiddleware(groups=[], extra_ref=lambda: extra)
         ctx = AgentContext(
-            system_prompt="", messages=[], tools=[], extra=extra,
+            system_prompt="",
+            messages=[],
+            tools=[],
+            extra=extra,
         )
 
         output = await mw._expand(
-            group_id="bad:id", tool_names=None, context=ctx,
+            group_id="bad:id",
+            tool_names=None,
+            context=ctx,
         )
         assert output.expanded is False
         assert output.error is not None
@@ -169,16 +192,23 @@ class TestAfterToolCallExpansion:
 
         context_tools: list[AgentTool] = [mw.tools[0]]
         ctx = AgentContext(
-            system_prompt="", messages=[], tools=context_tools, extra=extra,
+            system_prompt="",
+            messages=[],
+            tools=context_tools,
+            extra=extra,
         )
 
         await mw._expand(
-            group_id="mcp:github", tool_names=None, context=ctx,
+            group_id="mcp:github",
+            tool_names=None,
+            context=ctx,
         )
         assert len(context_tools) == 2
 
         await mw._expand(
-            group_id="mcp:github", tool_names=None, context=ctx,
+            group_id="mcp:github",
+            tool_names=None,
+            context=ctx,
         )
         assert len(context_tools) == 2
 
@@ -196,11 +226,16 @@ class TestAfterToolCallExpansion:
         extra: dict = {}
         mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
         ctx = AgentContext(
-            system_prompt="", messages=[], tools=[], extra=extra,
+            system_prompt="",
+            messages=[],
+            tools=[],
+            extra=extra,
         )
 
         output = await mw._expand(
-            group_id="mcp:broken", tool_names=None, context=ctx,
+            group_id="mcp:broken",
+            tool_names=None,
+            context=ctx,
         )
         assert output.expanded is False
         assert "connection refused" in (output.error or "")
@@ -235,7 +270,8 @@ class TestPrepareResumedState:
         group = _make_group("mcp:github", ["t1", "t2"])
         expanded: dict[str, list[str] | None] = {"mcp:github": None}
         resumed = await DeferredToolsMiddleware.prepare_resumed_state(
-            groups=[group], expanded=expanded,
+            groups=[group],
+            expanded=expanded,
         )
         assert len(resumed.pre_loaded_tools) == 2
         assert len(resumed.remaining_groups) == 0
@@ -247,7 +283,8 @@ class TestPrepareResumedState:
         group = _make_group("mcp:github", ["t1", "t2", "t3"])
         expanded: dict[str, list[str] | None] = {"mcp:github": ["t1"]}
         resumed = await DeferredToolsMiddleware.prepare_resumed_state(
-            groups=[group], expanded=expanded,
+            groups=[group],
+            expanded=expanded,
         )
         assert len(resumed.pre_loaded_tools) == 1
         assert resumed.pre_loaded_tools[0].name == "t1"
@@ -259,7 +296,8 @@ class TestPrepareResumedState:
         group = _make_group("mcp:github", ["t1"])
         expanded: dict[str, list[str] | None] = {}
         resumed = await DeferredToolsMiddleware.prepare_resumed_state(
-            groups=[group], expanded=expanded,
+            groups=[group],
+            expanded=expanded,
         )
         assert len(resumed.pre_loaded_tools) == 0
         assert len(resumed.remaining_groups) == 1
@@ -273,7 +311,8 @@ class TestPrepareResumedState:
             "mcp:slack": ["s1"],
         }
         resumed = await DeferredToolsMiddleware.prepare_resumed_state(
-            groups=[group_a, group_b], expanded=expanded,
+            groups=[group_a, group_b],
+            expanded=expanded,
         )
         extra: dict[str, object] = {"expanded_groups": dict(expanded)}
         mw = DeferredToolsMiddleware(

--- a/tests/deferred/test_middleware.py
+++ b/tests/deferred/test_middleware.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
-import json
-
-import pytest
-
-from cubepi.agent.types import AgentContext, AgentTool, AgentToolResult, AfterToolCallContext
-from cubepi.deferred.middleware import DeferredToolsMiddleware, ResumedState
+from cubepi.agent.types import AgentContext, AgentTool, AgentToolResult
+from cubepi.deferred.middleware import DeferredToolsMiddleware
 from cubepi.deferred.types import DeferredToolGroup
-from cubepi.providers.base import AssistantMessage, TextContent, ToolCall
+from cubepi.providers.base import TextContent
 
 
 def _dummy_tool(name: str, description: str = "dummy") -> AgentTool:

--- a/tests/deferred/test_middleware.py
+++ b/tests/deferred/test_middleware.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cubepi.agent.types import AgentContext, AgentTool, AgentToolResult, AfterToolCallContext
+from cubepi.deferred.middleware import DeferredToolsMiddleware, ResumedState
+from cubepi.deferred.types import DeferredToolGroup
+from cubepi.providers.base import AssistantMessage, TextContent, ToolCall
+
+
+def _dummy_tool(name: str, description: str = "dummy") -> AgentTool:
+    from pydantic import BaseModel
+
+    class _Empty(BaseModel):
+        pass
+
+    async def _exec(tool_call_id, args, *, signal=None, on_update=None):
+        return AgentToolResult(content=[TextContent(text="ok")])
+
+    return AgentTool(name=name, description=description, parameters=_Empty, execute=_exec)
+
+
+def _make_group(
+    group_id: str,
+    tool_names: list[str],
+    *,
+    display_name: str = "Test",
+    description: str = "desc",
+    loader_tools: list[AgentTool] | None = None,
+    loader_call_count: list[int] | None = None,
+) -> DeferredToolGroup:
+    tools = loader_tools or [_dummy_tool(n) for n in tool_names]
+    call_count = loader_call_count if loader_call_count is not None else [0]
+
+    async def _loader() -> list[AgentTool]:
+        call_count[0] += 1
+        return list(tools)
+
+    return DeferredToolGroup(
+        group_id=group_id,
+        display_name=display_name,
+        description=description,
+        tool_names=tool_names,
+        loader=_loader,
+    )
+
+
+class TestMiddlewareConstruction:
+    def test_tools_attribute_contains_expand_tools(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:a", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        assert len(mw.tools) == 1
+        assert mw.tools[0].name == "expand_tools"
+
+
+class TestTransformSystemPrompt:
+    async def test_appends_catalog(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:github", ["create_issue", "search_repos"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        ctx = AgentContext(system_prompt="base", messages=[])
+        result = await mw.transform_system_prompt("base prompt", ctx=ctx)
+        assert "mcp:github" in result
+        assert "create_issue" in result
+        assert "base prompt" in result
+
+    async def test_fully_expanded_group_omitted_from_catalog(self) -> None:
+        extra: dict = {"expanded_groups": {"mcp:github": None}}
+        group = _make_group("mcp:github", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        ctx = AgentContext(system_prompt="", messages=[])
+        result = await mw.transform_system_prompt("base", ctx=ctx)
+        assert "mcp:github" not in result or "Expanded tool groups" in result
+
+    async def test_expanded_schemas_appended_after_catalog(self) -> None:
+        extra: dict = {"expanded_groups": {"mcp:a": None}}
+        group = _make_group("mcp:a", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        mw._expanded_schemas.append(
+            ("mcp:a", [{"name": "t1", "description": "Tool 1", "parameters": {}}])
+        )
+        ctx = AgentContext(system_prompt="", messages=[])
+        result = await mw.transform_system_prompt("base", ctx=ctx)
+        assert "Expanded tool groups" in result
+        assert "t1" in result
+
+
+class TestAfterToolCallExpansion:
+    async def test_expand_all_injects_tools(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:github", ["create_issue", "search_repos"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(
+            system_prompt="", messages=[], tools=context_tools, extra=extra,
+        )
+
+        output = await mw._expand(
+            group_id="mcp:github", tool_names=None, context=ctx,
+        )
+        assert output.expanded is True
+        assert len(output.tool_names) == 2
+        assert output.remaining == 0
+        assert len(context_tools) == 3  # expand_tools + 2 new
+        assert extra["expanded_groups"] == {"mcp:github": None}
+
+    async def test_expand_selective_injects_only_requested(self) -> None:
+        extra: dict = {}
+        group = _make_group(
+            "mcp:github", ["create_issue", "search_repos", "create_pr"],
+        )
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(
+            system_prompt="", messages=[], tools=context_tools, extra=extra,
+        )
+
+        output = await mw._expand(
+            group_id="mcp:github", tool_names=["create_issue"], context=ctx,
+        )
+        assert output.expanded is True
+        assert output.tool_names == ["create_issue"]
+        assert output.remaining == 2
+        assert len(context_tools) == 2  # expand_tools + 1 new
+        assert extra["expanded_groups"] == {"mcp:github": ["create_issue"]}
+
+    async def test_incremental_expand_same_group(self) -> None:
+        extra: dict = {}
+        call_count = [0]
+        group = _make_group(
+            "mcp:github", ["t1", "t2", "t3"], loader_call_count=call_count,
+        )
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(
+            system_prompt="", messages=[], tools=context_tools, extra=extra,
+        )
+
+        await mw._expand(group_id="mcp:github", tool_names=["t1"], context=ctx)
+        assert len(context_tools) == 2
+        assert extra["expanded_groups"] == {"mcp:github": ["t1"]}
+
+        await mw._expand(group_id="mcp:github", tool_names=["t2"], context=ctx)
+        assert len(context_tools) == 3
+        assert extra["expanded_groups"] == {"mcp:github": ["t1", "t2"]}
+
+        assert call_count[0] == 1
+
+    async def test_expand_unknown_group_returns_error(self) -> None:
+        extra: dict = {}
+        mw = DeferredToolsMiddleware(groups=[], extra_ref=lambda: extra)
+        ctx = AgentContext(
+            system_prompt="", messages=[], tools=[], extra=extra,
+        )
+
+        output = await mw._expand(
+            group_id="bad:id", tool_names=None, context=ctx,
+        )
+        assert output.expanded is False
+        assert output.error is not None
+        assert "expanded_groups" not in extra
+
+    async def test_expand_idempotent_no_duplicate(self) -> None:
+        extra: dict = {}
+        group = _make_group("mcp:github", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(
+            system_prompt="", messages=[], tools=context_tools, extra=extra,
+        )
+
+        await mw._expand(
+            group_id="mcp:github", tool_names=None, context=ctx,
+        )
+        assert len(context_tools) == 2
+
+        await mw._expand(
+            group_id="mcp:github", tool_names=None, context=ctx,
+        )
+        assert len(context_tools) == 2
+
+    async def test_loader_failure_returns_error(self) -> None:
+        async def _failing_loader() -> list[AgentTool]:
+            raise RuntimeError("connection refused")
+
+        group = DeferredToolGroup(
+            group_id="mcp:broken",
+            display_name="Broken",
+            description="desc",
+            tool_names=["t1"],
+            loader=_failing_loader,
+        )
+        extra: dict = {}
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        ctx = AgentContext(
+            system_prompt="", messages=[], tools=[], extra=extra,
+        )
+
+        output = await mw._expand(
+            group_id="mcp:broken", tool_names=None, context=ctx,
+        )
+        assert output.expanded is False
+        assert "connection refused" in (output.error or "")
+        assert "expanded_groups" not in extra
+
+
+class TestExpansionOrderPreserved:
+    async def test_expansion_order_in_schemas(self) -> None:
+        extra: dict = {}
+        g1 = _make_group("mcp:z", ["tz"])
+        g2 = _make_group("mcp:a", ["ta"])
+        mw = DeferredToolsMiddleware(groups=[g1, g2], extra_ref=lambda: extra)
+
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=list(mw.tools),
+            extra=extra,
+        )
+
+        await mw._expand(group_id="mcp:z", tool_names=None, context=ctx)
+        await mw._expand(group_id="mcp:a", tool_names=None, context=ctx)
+
+        assert list(extra["expanded_groups"].keys()) == ["mcp:z", "mcp:a"]
+        assert len(mw._expanded_schemas) == 2
+        assert mw._expanded_schemas[0][0] == "mcp:z"
+        assert mw._expanded_schemas[1][0] == "mcp:a"
+
+
+class TestPrepareResumedState:
+    async def test_fully_expanded_group(self) -> None:
+        group = _make_group("mcp:github", ["t1", "t2"])
+        expanded: dict[str, list[str] | None] = {"mcp:github": None}
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group], expanded=expanded,
+        )
+        assert len(resumed.pre_loaded_tools) == 2
+        assert len(resumed.remaining_groups) == 0
+
+    async def test_partially_expanded_group(self) -> None:
+        group = _make_group("mcp:github", ["t1", "t2", "t3"])
+        expanded: dict[str, list[str] | None] = {"mcp:github": ["t1"]}
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group], expanded=expanded,
+        )
+        assert len(resumed.pre_loaded_tools) == 1
+        assert resumed.pre_loaded_tools[0].name == "t1"
+        assert len(resumed.remaining_groups) == 1
+
+    async def test_unexpanded_group_stays_deferred(self) -> None:
+        group = _make_group("mcp:github", ["t1"])
+        expanded: dict[str, list[str] | None] = {}
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group], expanded=expanded,
+        )
+        assert len(resumed.pre_loaded_tools) == 0
+        assert len(resumed.remaining_groups) == 1

--- a/tests/deferred/test_middleware.py
+++ b/tests/deferred/test_middleware.py
@@ -243,6 +243,9 @@ class TestPrepareResumedState:
         )
         assert len(resumed.pre_loaded_tools) == 2
         assert len(resumed.remaining_groups) == 0
+        assert len(resumed.expanded_schemas) == 1
+        assert resumed.expanded_schemas[0][0] == "mcp:github"
+        assert len(resumed.expanded_schemas[0][1]) == 2
 
     async def test_partially_expanded_group(self) -> None:
         group = _make_group("mcp:github", ["t1", "t2", "t3"])
@@ -253,6 +256,8 @@ class TestPrepareResumedState:
         assert len(resumed.pre_loaded_tools) == 1
         assert resumed.pre_loaded_tools[0].name == "t1"
         assert len(resumed.remaining_groups) == 1
+        assert len(resumed.expanded_schemas) == 1
+        assert len(resumed.expanded_schemas[0][1]) == 1
 
     async def test_unexpanded_group_stays_deferred(self) -> None:
         group = _make_group("mcp:github", ["t1"])
@@ -262,3 +267,31 @@ class TestPrepareResumedState:
         )
         assert len(resumed.pre_loaded_tools) == 0
         assert len(resumed.remaining_groups) == 1
+        assert len(resumed.expanded_schemas) == 0
+
+    async def test_resumed_schemas_seed_middleware(self) -> None:
+        group_a = _make_group("mcp:github", ["t1", "t2"])
+        group_b = _make_group("mcp:slack", ["s1"])
+        expanded: dict[str, list[str] | None] = {
+            "mcp:github": None,
+            "mcp:slack": ["s1"],
+        }
+        resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+            groups=[group_a, group_b], expanded=expanded,
+        )
+        extra: dict[str, object] = {"expanded_groups": dict(expanded)}
+        mw = DeferredToolsMiddleware(
+            groups=resumed.remaining_groups,
+            extra_ref=lambda: extra,
+            resumed_schemas=resumed.expanded_schemas,
+        )
+        ctx = AgentContext(
+            system_prompt="base",
+            messages=[],
+            tools=list(mw.tools) + resumed.pre_loaded_tools,
+            extra=extra,
+        )
+        prompt = await mw.transform_system_prompt("base", ctx=ctx)
+        assert "mcp:github" in prompt
+        assert "mcp:slack" in prompt
+        assert "t1" in prompt

--- a/tests/deferred/test_middleware.py
+++ b/tests/deferred/test_middleware.py
@@ -414,6 +414,123 @@ class TestOnToolsExpandedCallback:
         assert call_count[0] == 1  # no new tools, no callback
 
 
+class TestAfterToolCallHook:
+    """Tests that exercise the after_tool_call hook directly (not via _expand)."""
+
+    async def test_drains_pending_on_load_tools_call(self) -> None:
+        from cubepi.agent.types import AfterToolCallContext
+        from cubepi.deferred._expand_tool import TOOL_NAME
+        from cubepi.providers.base import AssistantMessage, ToolCall
+
+        extra: dict = {}
+        group = _make_group("mcp:github", ["t1", "t2"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=context_tools,
+            extra=extra,
+        )
+
+        await mw._expand_callback("mcp:github", None)
+        assert len(mw._pending_injection) == 2
+
+        atc_ctx = AfterToolCallContext(
+            assistant_message=AssistantMessage(content=[]),
+            tool_call=ToolCall(id="c1", name=TOOL_NAME, arguments={}),
+            args={},
+            result=AgentToolResult(content=[TextContent(text="ok")]),
+            is_error=False,
+            context=ctx,
+        )
+        await mw.after_tool_call(atc_ctx)
+        assert len(context_tools) == 3
+        assert len(mw._pending_injection) == 0
+
+    async def test_skips_non_load_tools_call(self) -> None:
+        from cubepi.agent.types import AfterToolCallContext
+        from cubepi.providers.base import AssistantMessage, ToolCall
+
+        extra: dict = {}
+        group = _make_group("mcp:github", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        mw._pending_injection.append(_dummy_tool("t1"))
+
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=list(mw.tools),
+            extra=extra,
+        )
+        atc_ctx = AfterToolCallContext(
+            assistant_message=AssistantMessage(content=[]),
+            tool_call=ToolCall(id="c1", name="other_tool", arguments={}),
+            args={},
+            result=AgentToolResult(content=[TextContent(text="ok")]),
+            is_error=False,
+            context=ctx,
+        )
+        await mw.after_tool_call(atc_ctx)
+        assert len(mw._pending_injection) == 1  # not drained
+
+    async def test_skips_error_result(self) -> None:
+        from cubepi.agent.types import AfterToolCallContext
+        from cubepi.deferred._expand_tool import TOOL_NAME
+        from cubepi.providers.base import AssistantMessage, ToolCall
+
+        extra: dict = {}
+        group = _make_group("mcp:github", ["t1"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        mw._pending_injection.append(_dummy_tool("t1"))
+
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=list(mw.tools),
+            extra=extra,
+        )
+        atc_ctx = AfterToolCallContext(
+            assistant_message=AssistantMessage(content=[]),
+            tool_call=ToolCall(id="c1", name=TOOL_NAME, arguments={}),
+            args={},
+            result=AgentToolResult(content=[TextContent(text="err")], is_error=True),
+            is_error=True,
+            context=ctx,
+        )
+        await mw.after_tool_call(atc_ctx)
+        assert len(mw._pending_injection) == 1  # not drained
+
+
+class TestSelectiveExpandAfterFullExpand:
+    async def test_selective_after_full_is_noop(self) -> None:
+        """Selective expand on a fully-expanded group is a no-op (L158 coverage)."""
+        extra: dict = {}
+        group = _make_group("mcp:github", ["t1", "t2"])
+        mw = DeferredToolsMiddleware(groups=[group], extra_ref=lambda: extra)
+        context_tools: list[AgentTool] = [mw.tools[0]]
+        ctx = AgentContext(
+            system_prompt="",
+            messages=[],
+            tools=context_tools,
+            extra=extra,
+        )
+        await mw._expand(group_id="mcp:github", tool_names=None, context=ctx)
+        assert extra["expanded_groups"]["mcp:github"] is None
+        assert len(context_tools) == 3
+
+        output = await mw._expand(
+            group_id="mcp:github",
+            tool_names=["t1"],
+            context=ctx,
+        )
+        assert output.expanded is True
+        assert output.remaining == 0
+        assert extra["expanded_groups"]["mcp:github"] is None
+        assert len(context_tools) == 3
+
+
 class TestExpandedGroupsDictStability:
     async def test_shared_dict_mutated_in_place(self) -> None:
         """expanded_groups dict in extra is mutated in place, not replaced."""

--- a/website/docs/guides/middleware/deferred-tools.md
+++ b/website/docs/guides/middleware/deferred-tools.md
@@ -15,7 +15,7 @@ catalog, letting the model expand groups on demand.
 
 1. At construction time, the agent's system prompt includes a short
    catalog — one line per group with a description and tool list.
-2. The model sees a built-in `expand_tools` tool it can call to load a
+2. The model sees a built-in `load_tools` tool it can call to load a
    group (or specific tools within a group).
 3. On expansion, the loader runs once, the tools are injected into the
    live tool set, and their schemas are appended to the system prompt.
@@ -23,7 +23,7 @@ catalog, letting the model expand groups on demand.
 ```
 # Deferred tool groups
 
-These tool groups are available but not yet loaded. Call `expand_tools(group_id)`
+These tool groups are available but not yet loaded. Call `load_tools(group_id)`
 to load a group's tools for the rest of this conversation.
 
 - `mcp:github` — GitHub: Issues, PRs, repos, code search (4 tools)
@@ -68,22 +68,22 @@ agent = Agent(
 
 | Field | Type | Description |
 |---|---|---|
-| `group_id` | `str` | Unique identifier the model uses in `expand_tools` calls (e.g. `"mcp:github"`) |
+| `group_id` | `str` | Unique identifier the model uses in `load_tools` calls (e.g. `"mcp:github"`) |
 | `display_name` | `str` | Human-readable label shown in the catalog |
 | `description` | `str` | One-line summary of the group's capabilities |
 | `tool_names` | `list[str]` | Tool names shown in the catalog |
 | `loader` | `async () -> list[AgentTool]` | Callback that returns the full tool set for this group |
 
-## The `expand_tools` tool
+## The `load_tools` tool
 
-The model calls `expand_tools` to load a group's tools. Two modes:
+The model calls `load_tools` to load a group's tools. Two modes:
 
 ```
 # Expand everything in the group
-expand_tools(group_id="mcp:github")
+load_tools(group_id="mcp:github")
 
 # Expand specific tools only
-expand_tools(group_id="mcp:github", tool_names=["create_issue", "search_repos"])
+load_tools(group_id="mcp:github", tool_names=["create_issue", "search_repos"])
 ```
 
 The tool returns a structured result:
@@ -106,11 +106,11 @@ The model can expand a group incrementally — requesting one or two tools
 now and more later:
 
 ```
-expand_tools(group_id="mcp:github", tool_names=["create_issue"])
+load_tools(group_id="mcp:github", tool_names=["create_issue"])
 # → remaining: 3
 
 # later...
-expand_tools(group_id="mcp:github", tool_names=["search_repos"])
+load_tools(group_id="mcp:github", tool_names=["search_repos"])
 # → remaining: 2
 ```
 
@@ -119,7 +119,7 @@ Already-expanded tools are idempotent — re-requesting them is a no-op.
 ### Loader caching
 
 The `loader` callback is invoked exactly **once per group per run**.
-The first `expand_tools` call triggers it; subsequent selective
+The first `load_tools` call triggers it; subsequent selective
 expansions filter from the cached result. If the loader fails, the
 error is returned to the model and the group remains unexpanded.
 
@@ -130,7 +130,7 @@ The system prompt is designed for prompt-cache prefix stability:
 - **Catalog** is sorted by `group_id` alphabetically — input order
   doesn't matter, the rendered text is byte-stable.
 - **Expanded schemas** are appended in expansion order (the order the
-  model called `expand_tools`), never reordered. Each new expansion
+  model called `load_tools`), never reordered. Each new expansion
   appends to the end, preserving the existing prefix.
 
 This means the LLM API's prompt cache remains valid across turns: the
@@ -219,7 +219,7 @@ from cubepi.deferred import DeferredToolsMiddleware
 mw = DeferredToolsMiddleware(
     groups=[github_group, linear_group],
     extra_ref=lambda: agent_extra,
-    catalog_header="# Available integrations\n\nExpand with expand_tools().",
+    catalog_header="# Available integrations\n\nExpand with load_tools().",
     resumed_schemas=None,  # or pass schemas from a previous run
 )
 
@@ -255,7 +255,7 @@ is automatically bound to `self._extra`.
 **Skip it when:**
 
 - The agent has only a few tools — the overhead of the catalog and
-  `expand_tools` call isn't worth it.
+  `load_tools` call isn't worth it.
 - All tools are needed on every turn — deferring just adds a round trip.
 - Tool schemas are small — the context savings are minimal.
 

--- a/website/docs/guides/middleware/deferred-tools.md
+++ b/website/docs/guides/middleware/deferred-tools.md
@@ -180,6 +180,7 @@ agent = Agent(
 | `pre_loaded_tools` | Tools from previously-expanded groups, ready to use |
 | `remaining_groups` | Groups that were never expanded or only partially expanded |
 | `expanded_schemas` | Schema data for the system prompt (pass to `resumed_schemas` for advanced use) |
+| `loader_cache` | Pre-loaded tool cache (pass to `resumed_loader_cache` to avoid redundant loader calls) |
 
 Fully expanded groups are loaded and removed from the deferred set.
 Partially expanded groups load the selected tools but stay deferrable
@@ -197,6 +198,7 @@ mw = DeferredToolsMiddleware(
     groups=resumed.remaining_groups,
     extra_ref=lambda: agent_extra,
     resumed_schemas=resumed.expanded_schemas,
+    resumed_loader_cache=resumed.loader_cache,
 )
 
 agent = Agent(
@@ -236,6 +238,8 @@ agent = Agent(
 | `extra_ref` | `() -> dict` | required | Returns the live `ctx.extra` dict |
 | `catalog_header` | `str` | *(built-in)* | Header text for the catalog section |
 | `resumed_schemas` | `list[tuple[str, list[dict]]] \| None` | `None` | Schema data to seed from a previous run |
+| `resumed_loader_cache` | `dict[str, list[AgentTool]] \| None` | `None` | Pre-loaded tool cache from a previous run (avoids re-calling loaders on resume) |
+| `on_tools_expanded` | `(list[AgentTool]) -> None \| None` | `None` | Called after new tools are expanded (used internally for cross-turn persistence) |
 
 When using the `Agent(deferred_tool_groups=...)` shorthand, `extra_ref`
 is automatically bound to `self._extra`.

--- a/website/docs/guides/middleware/deferred-tools.md
+++ b/website/docs/guides/middleware/deferred-tools.md
@@ -1,0 +1,265 @@
+---
+title: Deferred Tool Groups
+description: "Hide MCP tool schemas from the model by default, expanding them on demand to reduce context bloat."
+---
+
+# Deferred Tool Groups
+
+When an agent connects to many MCP servers, their combined tool schemas
+can consume thousands of tokens of context on every turn — even if the
+model only needs one or two groups for the current task.
+`DeferredToolGroup` solves this by replacing full schemas with a compact
+catalog, letting the model expand groups on demand.
+
+## How it works
+
+1. At construction time, the agent's system prompt includes a short
+   catalog — one line per group with a description and tool list.
+2. The model sees a built-in `expand_tools` tool it can call to load a
+   group (or specific tools within a group).
+3. On expansion, the loader runs once, the tools are injected into the
+   live tool set, and their schemas are appended to the system prompt.
+
+```
+# Deferred tool groups
+
+These tool groups are available but not yet loaded. Call `expand_tools(group_id)`
+to load a group's tools for the rest of this conversation.
+
+- `mcp:github` — GitHub: Issues, PRs, repos, code search (4 tools)
+  create_issue, search_repos, create_pr, list_comments
+- `mcp:linear` — Linear: Project management and issue tracking (6 tools)
+  create_issue, update_issue, list_projects, ...
+```
+
+## Basic setup
+
+Pass `deferred_tool_groups` to `Agent`. The middleware is created
+automatically — no manual wiring needed:
+
+```python
+from cubepi import Agent
+from cubepi.deferred import DeferredToolGroup
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr", "list_comments"],
+    loader=github_mcp.load_tools,  # async () -> list[AgentTool]
+)
+
+linear_group = DeferredToolGroup(
+    group_id="mcp:linear",
+    display_name="Linear",
+    description="Project management and issue tracking",
+    tool_names=["create_issue", "update_issue", "list_projects"],
+    loader=linear_mcp.load_tools,
+)
+
+agent = Agent(
+    model=provider.model("claude-sonnet-4-6"),
+    tools=[search_tool, calculator],              # always-available tools
+    deferred_tool_groups=[github_group, linear_group],
+)
+```
+
+### `DeferredToolGroup` fields
+
+| Field | Type | Description |
+|---|---|---|
+| `group_id` | `str` | Unique identifier the model uses in `expand_tools` calls (e.g. `"mcp:github"`) |
+| `display_name` | `str` | Human-readable label shown in the catalog |
+| `description` | `str` | One-line summary of the group's capabilities |
+| `tool_names` | `list[str]` | Tool names shown in the catalog |
+| `loader` | `async () -> list[AgentTool]` | Callback that returns the full tool set for this group |
+
+## The `expand_tools` tool
+
+The model calls `expand_tools` to load a group's tools. Two modes:
+
+```
+# Expand everything in the group
+expand_tools(group_id="mcp:github")
+
+# Expand specific tools only
+expand_tools(group_id="mcp:github", tool_names=["create_issue", "search_repos"])
+```
+
+The tool returns a structured result:
+
+```json
+{
+  "group_id": "mcp:github",
+  "expanded": true,
+  "tool_names": ["create_issue", "search_repos", "create_pr", "list_comments"],
+  "remaining": 0
+}
+```
+
+After expansion, the tools are immediately available for the model to
+call in the same turn (via the `after_tool_call` hook).
+
+### Selective expansion
+
+The model can expand a group incrementally — requesting one or two tools
+now and more later:
+
+```
+expand_tools(group_id="mcp:github", tool_names=["create_issue"])
+# → remaining: 3
+
+# later...
+expand_tools(group_id="mcp:github", tool_names=["search_repos"])
+# → remaining: 2
+```
+
+Already-expanded tools are idempotent — re-requesting them is a no-op.
+
+### Loader caching
+
+The `loader` callback is invoked exactly **once per group per run**.
+The first `expand_tools` call triggers it; subsequent selective
+expansions filter from the cached result. If the loader fails, the
+error is returned to the model and the group remains unexpanded.
+
+## Prompt-cache stability
+
+The system prompt is designed for prompt-cache prefix stability:
+
+- **Catalog** is sorted by `group_id` alphabetically — input order
+  doesn't matter, the rendered text is byte-stable.
+- **Expanded schemas** are appended in expansion order (the order the
+  model called `expand_tools`), never reordered. Each new expansion
+  appends to the end, preserving the existing prefix.
+
+This means the LLM API's prompt cache remains valid across turns: the
+system prompt only grows, and only at the end.
+
+## Expansion state
+
+The middleware tracks which groups are expanded in `ctx.extra`:
+
+```python
+ctx.extra["expanded_groups"] = {
+    "mcp:github": None,                    # fully expanded (None = all tools)
+    "mcp:linear": ["create_issue"],        # partially expanded
+    # mcp:slack not present = unexpanded
+}
+```
+
+This state survives checkpointing and can be used for cross-run replay
+(see below).
+
+## Cross-run replay
+
+When resuming a conversation from a previous run, you need to restore
+the expansion state so the model has the same tools available.
+`prepare_resumed_state` handles this:
+
+```python
+from cubepi.deferred import DeferredToolsMiddleware
+
+# saved_extra is the persisted ctx.extra from the previous run
+resumed = await DeferredToolsMiddleware.prepare_resumed_state(
+    groups=all_groups,
+    expanded=saved_extra["expanded_groups"],
+)
+
+agent = Agent(
+    model=model,
+    tools=[*builtin_tools, *resumed.pre_loaded_tools],
+    deferred_tool_groups=resumed.remaining_groups,
+)
+```
+
+`prepare_resumed_state` returns a `ResumedState` with:
+
+| Field | Description |
+|---|---|
+| `pre_loaded_tools` | Tools from previously-expanded groups, ready to use |
+| `remaining_groups` | Groups that were never expanded or only partially expanded |
+| `expanded_schemas` | Schema data for the system prompt (pass to `resumed_schemas` for advanced use) |
+
+Fully expanded groups are loaded and removed from the deferred set.
+Partially expanded groups load the selected tools but stay deferrable
+(the model can still expand the rest).
+
+### Restoring schema text
+
+The `Agent(deferred_tool_groups=...)` shorthand handles the common case.
+For full prompt-cache continuity — where the resumed run's system prompt
+must match the previous run's final state byte-for-byte — construct the
+middleware directly with `resumed_schemas`:
+
+```python
+mw = DeferredToolsMiddleware(
+    groups=resumed.remaining_groups,
+    extra_ref=lambda: agent_extra,
+    resumed_schemas=resumed.expanded_schemas,
+)
+
+agent = Agent(
+    model=model,
+    tools=[*builtin_tools, *resumed.pre_loaded_tools],
+    middleware=[mw],
+)
+```
+
+## Advanced: constructing the middleware directly
+
+For full control over the catalog header, cross-run schema seeding, or
+other middleware options, construct `DeferredToolsMiddleware` yourself:
+
+```python
+from cubepi.deferred import DeferredToolsMiddleware
+
+mw = DeferredToolsMiddleware(
+    groups=[github_group, linear_group],
+    extra_ref=lambda: agent_extra,
+    catalog_header="# Available integrations\n\nExpand with expand_tools().",
+    resumed_schemas=None,  # or pass schemas from a previous run
+)
+
+agent = Agent(
+    model=model,
+    tools=[search_tool],
+    middleware=[mw],
+)
+```
+
+### Constructor parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `groups` | `list[DeferredToolGroup]` | required | Groups to defer |
+| `extra_ref` | `() -> dict` | required | Returns the live `ctx.extra` dict |
+| `catalog_header` | `str` | *(built-in)* | Header text for the catalog section |
+| `resumed_schemas` | `list[tuple[str, list[dict]]] \| None` | `None` | Schema data to seed from a previous run |
+
+When using the `Agent(deferred_tool_groups=...)` shorthand, `extra_ref`
+is automatically bound to `self._extra`.
+
+## When to use it
+
+**Good fit:**
+
+- Agent has access to 5+ MCP servers but typically uses 1–2 per conversation.
+- Tool schemas are large (many parameters, long descriptions).
+- You want to keep prompt-cache hit rates high across turns.
+
+**Skip it when:**
+
+- The agent has only a few tools — the overhead of the catalog and
+  `expand_tools` call isn't worth it.
+- All tools are needed on every turn — deferring just adds a round trip.
+- Tool schemas are small — the context savings are minimal.
+
+## See also
+
+- [Loading MCP Tools](../mcp/loading) — how to get `AgentTool` lists from
+  MCP servers.
+- [The 8 Hooks](./hooks) — the middleware hooks that power deferred tools
+  (`transform_system_prompt`, `after_tool_call`).
+- [Composition](./composition) — how middleware composes when stacked with
+  other middleware.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -45,6 +45,7 @@ const sidebars: SidebarsConfig = {
           'guides/middleware/compaction',
           'guides/middleware/subagents',
           'guides/middleware/todo',
+          'guides/middleware/deferred-tools',
         ]},
         { type: 'category', label: 'Human-in-the-Loop', items: [
           'guides/hitl/overview',


### PR DESCRIPTION
## Summary

Adds `DeferredToolGroup` — a middleware-based primitive that hides MCP tool schemas from the model by default and expands them on demand via an `expand_tools` builtin tool. Reduces context bloat when many tool groups are connected but only a few are needed per turn.

- **`DeferredToolGroup` dataclass** — group_id, display_name, description, tool_names, async loader callback
- **`DeferredToolsMiddleware`** — two-phase expansion (callback queues → `after_tool_call` injects into live `ctx.context.tools`), catalog rendering sorted by group_id (byte-stable), expanded schemas in append-only expansion order (prompt-cache prefix-stable)
- **`Agent(deferred_tool_groups=[...])`** — primary API, auto-creates middleware with `extra_ref` bound to `self._extra`
- **Cross-run replay** via `prepare_resumed_state()` — restores pre-loaded tools, remaining groups, and expanded schemas for prompt-cache continuity
- **Selective expansion** — expand all tools in a group or a specific subset; loader cached once per group per run

## Key design decisions

- Catalog sorted by `group_id` for byte-stable system prompt prefix
- Expanded schemas append-only (never reorder) for prompt-cache stability
- `_pending_injection` uses extend+clear (not assignment) to be safe under parallel tool execution
- `is_error` keyed on `not output.expanded` rather than `bool(output.error)` to avoid semantic mismatch
- `resumed_schemas` parameter on middleware constructor to seed `_expanded_schemas` from a previous run

## Test plan

- [x] 44 tests across 4 test files, all passing
- [x] `test_catalog.py` — 13 tests (construction, render_catalog sorting/stability, render_expanded_schemas append-only)
- [x] `test_expand_tool.py` — 9 tests (input/output models, tool factory, callback behavior)
- [x] `test_middleware.py` — 15 tests (construction, system prompt, expansion, idempotent, loader failure, order preservation, prepare_resumed_state with schema seeding)
- [x] `test_agent_wiring.py` — 7 tests (Agent param, auto-middleware, extra_ref binding, combined middleware, empty list)
- [x] 217 existing agent tests pass (no regression)
- [x] mypy clean

Closes #166