### PR TITLE
fix(tracing): Recorder/Meter subscribe to every provider in FallbackBoundModel chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to CubePi are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`Recorder.attach()` and `Meter.attach()` now subscribe to every provider in
+  a `FallbackBoundModel` chain** (closes #167). Previously they only listened
+  to `chain[0].provider`, so post-failover calls executed against `chain[1..]`
+  were invisible to provider-level observability — chat spans, token usage,
+  cache metrics, and cost telemetry were missing for fallback legs. Adds a
+  new `cubepi.providers.fallback.chain_providers()` helper used by both
+  attach paths to walk and dedupe the chain. Agent-event-driven observability
+  (e.g. cost middleware reading `MessageEvent`) was already correct and is
+  unchanged.
+
 ## [0.9.0] - 2026-06-08
 
 ### Added

--- a/cubepi/providers/__init__.py
+++ b/cubepi/providers/__init__.py
@@ -27,6 +27,8 @@ from cubepi.providers.base import (
     Usage,
     UserMessage,
     adjust_max_tokens_for_thinking,
+    chain_providers,
+    collect_agent_providers,
 )
 from cubepi.providers.faux import (
     FauxProvider,
@@ -98,7 +100,9 @@ __all__ = [
     "Usage",
     "UserMessage",
     "adjust_max_tokens_for_thinking",
+    "chain_providers",
     "clamp_thinking_level",
+    "collect_agent_providers",
     "faux_assistant_message",
     "faux_text",
     "faux_thinking",

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -815,33 +815,6 @@ class BaseProvider:
             await _fire_chunk_listeners(self._chunk_listeners, event, model)
 
 
-def _log_chain_skip(idx: int, provider_type: str) -> None:
-    """Warn that a chain leg's provider isn't a BaseProvider and was skipped.
-
-    Tries loguru first (matches the rest of ``cubepi.providers``) and falls
-    back to stdlib logging so the warning is never silently lost when loguru
-    isn't installed.
-    """
-    try:
-        from loguru import logger  # pragma: no cover — loguru is an optional dep
-
-        logger.warning(  # pragma: no cover
-            "cubepi.providers.base.chain_providers: chain[{}] provider {} is not "
-            "a BaseProvider; tracing/metrics will skip this leg",
-            idx,
-            provider_type,
-        )
-    except ImportError:
-        import logging
-
-        logging.getLogger("cubepi.providers.base").warning(
-            "cubepi.providers.base.chain_providers: chain[%d] provider %s is not "
-            "a BaseProvider; tracing/metrics will skip this leg",
-            idx,
-            provider_type,
-        )
-
-
 def chain_providers(model: object) -> list["BaseProvider"]:
     """Return the unique BaseProvider instances backing a bound model.
 
@@ -853,10 +826,11 @@ def chain_providers(model: object) -> list["BaseProvider"]:
 
     For ``FallbackBoundModel``-like inputs, iterates the chain and dedupes
     providers by identity. Chain entries whose ``.provider`` isn't a
-    ``BaseProvider`` are logged at WARNING via :func:`_log_chain_skip` and
+    ``BaseProvider`` are logged at WARNING via stdlib ``logging`` and
     skipped — tracing / metrics need the ``subscribe_request`` /
     ``subscribe_chunk`` / ``subscribe_response`` interface that only
-    ``BaseProvider`` exposes.
+    ``BaseProvider`` exposes. (cubepi does not depend on loguru; hosts that
+    use it can intercept stdlib logging.)
 
     For plain bound models, returns ``[model.provider]`` if it is a
     ``BaseProvider``. For ``None`` or any other input, returns ``[]``.
@@ -866,6 +840,8 @@ def chain_providers(model: object) -> list["BaseProvider"]:
     fallback chain so post-failover provider events land in the trace /
     metric stream.
     """
+    import logging
+
     if model is None:
         return []
     chain = getattr(model, "chain", None)
@@ -875,7 +851,12 @@ def chain_providers(model: object) -> list["BaseProvider"]:
         for idx, bm in enumerate(chain):
             p = getattr(bm, "provider", None)
             if not isinstance(p, BaseProvider):
-                _log_chain_skip(idx, type(p).__name__)
+                logging.getLogger("cubepi.providers.base").warning(
+                    "cubepi.providers.base.chain_providers: chain[%d] provider "
+                    "%s is not a BaseProvider; tracing/metrics will skip this leg",
+                    idx,
+                    type(p).__name__,
+                )
                 continue
             if id(p) not in seen:
                 seen.add(id(p))

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -885,3 +885,21 @@ def chain_providers(model: object) -> list["BaseProvider"]:
     if isinstance(provider, BaseProvider):
         return [provider]
     return []
+
+
+def collect_agent_providers(agent: Any) -> list["BaseProvider"]:
+    """Return the unique BaseProvider instances backing an agent.
+
+    Walks ``agent._model`` via :func:`chain_providers` and falls back to a
+    public ``provider`` attribute on the agent for legacy code paths. Used
+    by both :meth:`cubepi.tracing.recorder.Recorder.attach` and
+    :meth:`cubepi.tracing.meter.Meter.attach` to dedupe the prelude that
+    finds providers to subscribe to.
+    """
+    model = getattr(agent, "_model", None)
+    providers = chain_providers(model)
+    if not providers:
+        legacy = getattr(agent, "provider", None)
+        if isinstance(legacy, BaseProvider):
+            providers = [legacy]
+    return providers

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -813,3 +813,75 @@ class BaseProvider:
         ms.push(event)
         if model is not None and self._chunk_listeners:
             await _fire_chunk_listeners(self._chunk_listeners, event, model)
+
+
+def _log_chain_skip(idx: int, provider_type: str) -> None:
+    """Warn that a chain leg's provider isn't a BaseProvider and was skipped.
+
+    Tries loguru first (matches the rest of ``cubepi.providers``) and falls
+    back to stdlib logging so the warning is never silently lost when loguru
+    isn't installed.
+    """
+    try:
+        from loguru import logger
+
+        logger.warning(
+            "cubepi.providers.base.chain_providers: chain[{}] provider {} is not "
+            "a BaseProvider; tracing/metrics will skip this leg",
+            idx,
+            provider_type,
+        )
+    except ImportError:
+        import logging
+
+        logging.getLogger("cubepi.providers.base").warning(
+            "cubepi.providers.base.chain_providers: chain[%d] provider %s is not "
+            "a BaseProvider; tracing/metrics will skip this leg",
+            idx,
+            provider_type,
+        )
+
+
+def chain_providers(model: object) -> list["BaseProvider"]:
+    """Return the unique BaseProvider instances backing a bound model.
+
+    Walks a model's ``chain`` (FallbackBoundModel-like) or its single
+    ``.provider`` (plain BoundModel-like). Uses duck typing on ``.chain`` to
+    avoid importing :mod:`cubepi.providers.fallback` into this base module —
+    ``fallback`` already depends on ``base``, so the reverse import would
+    cycle.
+
+    For ``FallbackBoundModel``-like inputs, iterates the chain and dedupes
+    providers by identity. Chain entries whose ``.provider`` isn't a
+    ``BaseProvider`` are logged at WARNING via :func:`_log_chain_skip` and
+    skipped — tracing / metrics need the ``subscribe_request`` /
+    ``subscribe_chunk`` / ``subscribe_response`` interface that only
+    ``BaseProvider`` exposes.
+
+    For plain bound models, returns ``[model.provider]`` if it is a
+    ``BaseProvider``. For ``None`` or any other input, returns ``[]``.
+
+    Used by :meth:`cubepi.tracing.recorder.Recorder.attach` and
+    :meth:`cubepi.tracing.meter.Meter.attach` to subscribe to every leg of a
+    fallback chain so post-failover provider events land in the trace /
+    metric stream.
+    """
+    if model is None:
+        return []
+    chain = getattr(model, "chain", None)
+    if chain is not None:
+        seen: set[int] = set()
+        out: list[BaseProvider] = []
+        for idx, bm in enumerate(chain):
+            p = getattr(bm, "provider", None)
+            if not isinstance(p, BaseProvider):
+                _log_chain_skip(idx, type(p).__name__)
+                continue
+            if id(p) not in seen:
+                seen.add(id(p))
+                out.append(p)
+        return out
+    provider = getattr(model, "provider", None)
+    if isinstance(provider, BaseProvider):
+        return [provider]
+    return []

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -823,9 +823,9 @@ def _log_chain_skip(idx: int, provider_type: str) -> None:
     isn't installed.
     """
     try:
-        from loguru import logger
+        from loguru import logger  # pragma: no cover — loguru is an optional dep
 
-        logger.warning(
+        logger.warning(  # pragma: no cover
             "cubepi.providers.base.chain_providers: chain[{}] provider {} is not "
             "a BaseProvider; tracing/metrics will skip this leg",
             idx,

--- a/cubepi/providers/fallback.py
+++ b/cubepi/providers/fallback.py
@@ -69,6 +69,15 @@ class FallbackBoundModel:
         | None
     ) = None
 
+    def __post_init__(self) -> None:
+        # An empty chain is a configuration mistake: provider/spec proxy,
+        # stream(), and generate() would all IndexError or silently exhaust
+        # without ever attempting a call. Fail fast at construction time.
+        if not self.chain:
+            raise ValueError(
+                "FallbackBoundModel.chain must contain at least one BoundModel"
+            )
+
     @property
     def provider(self) -> Provider:
         return self.chain[0].provider

--- a/cubepi/providers/fallback.py
+++ b/cubepi/providers/fallback.py
@@ -25,6 +25,7 @@ from cubepi.providers.base import (
     ThinkingLevel,
     ToolDefinition,
     Usage,
+    chain_providers,  # re-exported for back-compat; canonical home is base.py
 )
 
 try:
@@ -241,32 +242,12 @@ class FallbackBoundModel:
         )
 
 
-def chain_providers(model: object) -> list[Any]:
-    """Return the unique BaseProvider instances backing a bound model.
-
-    For :class:`FallbackBoundModel`, iterates ``chain`` and dedupes providers
-    by identity. For a plain :class:`BoundModel` returns ``[model.provider]``.
-    For anything else (or ``None``) returns ``[]``.
-
-    Used by :meth:`cubepi.tracing.recorder.Recorder.attach` and
-    :meth:`cubepi.tracing.meter.Meter.attach` to subscribe to every leg of a
-    fallback chain so post-failover provider events land in the trace /
-    metric stream.
-    """
-    from cubepi.providers.base import BaseProvider
-
-    if model is None:
-        return []
-    if isinstance(model, FallbackBoundModel):
-        seen: set[int] = set()
-        out: list[Any] = []
-        for bm in model.chain:
-            p = bm.provider
-            if isinstance(p, BaseProvider) and id(p) not in seen:
-                seen.add(id(p))
-                out.append(p)
-        return out
-    provider = getattr(model, "provider", None)
-    if isinstance(provider, BaseProvider):
-        return [provider]
-    return []
+# ``chain_providers`` lives in :mod:`cubepi.providers.base` so the tracing /
+# meter modules can import it without pulling in this fallback module. The
+# import above re-exports it under ``cubepi.providers.fallback.chain_providers``
+# for back-compat with existing call sites.
+__all__ = [
+    "DEFAULT_TRIGGER_ERRORS",
+    "FallbackBoundModel",
+    "chain_providers",
+]

--- a/cubepi/providers/fallback.py
+++ b/cubepi/providers/fallback.py
@@ -53,11 +53,11 @@ class FallbackBoundModel:
     provider and spec proxy chain[0] so tracing/billing code that reads
     agent._model.provider / agent._model.spec continues to work unchanged.
 
-    Known limitation: Tracer.attach() and Meter.attach() subscribe only to
-    chain[0].provider. Successful fallback calls (chain[1..]) are invisible to
-    provider-level observability (chat spans, token/cost metrics). Tracked as a
-    follow-up: update recorder.py and meter.py to iterate chain and subscribe
-    to every unique BaseProvider.
+    Tracer / Meter coverage: Recorder.attach() and Meter.attach() detect
+    FallbackBoundModel and subscribe to every unique BaseProvider in the
+    chain (via chain_providers() below), so post-failover chat spans and
+    provider metrics land in the trace / metric stream like primary-leg
+    calls do.
     """
 
     chain: tuple[BoundModel, ...]
@@ -230,3 +230,34 @@ class FallbackBoundModel:
         raise ProviderUnavailable(
             f"all providers exhausted; last error: {last_error!r}"
         )
+
+
+def chain_providers(model: object) -> list[Any]:
+    """Return the unique BaseProvider instances backing a bound model.
+
+    For :class:`FallbackBoundModel`, iterates ``chain`` and dedupes providers
+    by identity. For a plain :class:`BoundModel` returns ``[model.provider]``.
+    For anything else (or ``None``) returns ``[]``.
+
+    Used by :meth:`cubepi.tracing.recorder.Recorder.attach` and
+    :meth:`cubepi.tracing.meter.Meter.attach` to subscribe to every leg of a
+    fallback chain so post-failover provider events land in the trace /
+    metric stream.
+    """
+    from cubepi.providers.base import BaseProvider
+
+    if model is None:
+        return []
+    if isinstance(model, FallbackBoundModel):
+        seen: set[int] = set()
+        out: list[Any] = []
+        for bm in model.chain:
+            p = bm.provider
+            if isinstance(p, BaseProvider) and id(p) not in seen:
+                seen.add(id(p))
+                out.append(p)
+        return out
+    provider = getattr(model, "provider", None)
+    if isinstance(provider, BaseProvider):
+        return [provider]
+    return []

--- a/cubepi/tracing/meter.py
+++ b/cubepi/tracing/meter.py
@@ -153,6 +153,7 @@ class Meter:
         before its response landed).
         """
         from cubepi.providers.base import BaseProvider
+        from cubepi.providers.fallback import chain_providers
 
         state = _MeterState()
 
@@ -175,16 +176,21 @@ class Meter:
 
         unsub_agent = agent.subscribe(_on_agent_event)
         agent_model = getattr(agent, "_model", None)
-        provider = (
-            agent_model.provider
-            if agent_model is not None
-            else getattr(agent, "provider", None)
-        )
+        # When the bound model is a FallbackBoundModel, subscribe to every
+        # unique provider in the chain so post-failover token usage / cost
+        # / cache-hit metrics are emitted for chain[1..] calls the same way
+        # as chain[0]. Non-fallback models yield a single-entry list.
+        agent_providers: list[Any] = chain_providers(agent_model)
+        if not agent_providers:
+            legacy = getattr(agent, "provider", None)
+            if legacy is not None:
+                agent_providers = [legacy]
         detachers: list[Callable[[], None]] = []
-        if isinstance(provider, BaseProvider):
-            detachers.append(provider.subscribe_request(_on_request))
-            detachers.append(provider.subscribe_chunk(_on_chunk))
-            detachers.append(provider.subscribe_response(_on_response))
+        for provider in agent_providers:
+            if isinstance(provider, BaseProvider):
+                detachers.append(provider.subscribe_request(_on_request))
+                detachers.append(provider.subscribe_chunk(_on_chunk))
+                detachers.append(provider.subscribe_response(_on_response))
 
         def detach() -> None:
             unsub_agent()

--- a/cubepi/tracing/meter.py
+++ b/cubepi/tracing/meter.py
@@ -152,7 +152,7 @@ class Meter:
         overwrote the first agent's ``_chat_open_ns`` / ``_chat_attrs``
         before its response landed).
         """
-        from cubepi.providers.base import BaseProvider, chain_providers
+        from cubepi.providers.base import BaseProvider, collect_agent_providers
 
         state = _MeterState()
 
@@ -174,18 +174,16 @@ class Meter:
             self._handle_provider_response(state, body, model, exc)
 
         unsub_agent = agent.subscribe(_on_agent_event)
-        agent_model = getattr(agent, "_model", None)
-        # When the bound model is a FallbackBoundModel, subscribe to every
-        # unique provider in the chain so post-failover token usage / cost
-        # / cache-hit metrics are emitted for chain[1..] calls the same way
-        # as chain[0]. Non-fallback models yield a single-entry list.
-        agent_providers: list[Any] = chain_providers(agent_model)
-        if not agent_providers:
-            legacy = getattr(agent, "provider", None)
-            if legacy is not None:
-                agent_providers = [legacy]
+        # When the bound model is a FallbackBoundModel, ``collect_agent_providers``
+        # returns every unique BaseProvider in the chain so post-failover token
+        # usage / cost / cache-hit metrics are emitted for chain[1..] calls the
+        # same way as chain[0]. Non-fallback models yield a single-entry list.
+        agent_providers: list[BaseProvider] = collect_agent_providers(agent)
         detachers: list[Callable[[], None]] = []
         for provider in agent_providers:
+            # Defensive guard: collect_agent_providers already filters to
+            # BaseProvider, but the isinstance check is cheap and protects
+            # against a future helper change that loosens the contract.
             if isinstance(provider, BaseProvider):
                 detachers.append(provider.subscribe_request(_on_request))
                 detachers.append(provider.subscribe_chunk(_on_chunk))

--- a/cubepi/tracing/meter.py
+++ b/cubepi/tracing/meter.py
@@ -152,8 +152,7 @@ class Meter:
         overwrote the first agent's ``_chat_open_ns`` / ``_chat_attrs``
         before its response landed).
         """
-        from cubepi.providers.base import BaseProvider
-        from cubepi.providers.fallback import chain_providers
+        from cubepi.providers.base import BaseProvider, chain_providers
 
         state = _MeterState()
 

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -246,6 +246,11 @@ class Recorder:
         provider_detachers: list[Callable[[], None]] = []
 
         def _subscribe(p: Any) -> None:
+            # ``collect_agent_providers`` already filters to ``BaseProvider``,
+            # so this isinstance guard is redundant on the chain/legacy path.
+            # It stays as belt-and-suspenders for the middleware-extras loop
+            # below, which passes ``model.provider`` directly — a duck-typed
+            # Provider-protocol object could slip past static typing there.
             if not isinstance(p, BaseProvider):
                 return
             provider_detachers.append(p.subscribe_request(self._on_provider_request))

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -42,10 +42,12 @@ from cubepi.agent.types import (
     ToolExecutionStartEvent,
 )
 from cubepi.providers.base import (
+    BaseProvider,
     StreamEvent,
     ToolCall,
     ToolResultMessage,
     UserMessage,
+    chain_providers,
 )
 from cubepi.tracing.content import (
     messages_to_semconv,
@@ -232,9 +234,6 @@ class Recorder:
     # ------------------------------------------------------------------
 
     def attach(self, agent: "Agent") -> Callable[[], None]:
-        from cubepi.providers.base import BaseProvider
-        from cubepi.providers.fallback import chain_providers
-
         self._agent = agent
         unsub_agent = agent.subscribe(self._on_agent_event)
         # ``Agent`` holds the bound model on ``_model``; the provider is

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -243,7 +243,6 @@ class Recorder:
         # Legacy agents that expose ``provider`` directly (instead of via
         # ``_model``) are handled inside the helper.
         agent_providers: list[BaseProvider] = collect_agent_providers(agent)
-        provider = agent_providers[0] if agent_providers else None
         provider_detachers: list[Callable[[], None]] = []
 
         def _subscribe(p: Any) -> None:

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -233,6 +233,7 @@ class Recorder:
 
     def attach(self, agent: "Agent") -> Callable[[], None]:
         from cubepi.providers.base import BaseProvider
+        from cubepi.providers.fallback import chain_providers
 
         self._agent = agent
         unsub_agent = agent.subscribe(self._on_agent_event)
@@ -240,11 +241,19 @@ class Recorder:
         # reached via ``_model.provider``. Fall back to a public ``provider``
         # alias should one be added later.
         agent_model = getattr(agent, "_model", None)
-        provider = (
-            agent_model.provider
-            if agent_model is not None
-            else getattr(agent, "provider", None)
-        )
+        # When the bound model is a FallbackBoundModel, subscribe to every
+        # unique provider in the chain so post-failover provider events
+        # (chat spans, token usage, errors) land in the trace tree like
+        # primary-leg events do. Non-fallback models yield a single-entry
+        # list with the only provider.
+        agent_providers: list[Any] = chain_providers(agent_model)
+        if not agent_providers:
+            # Legacy / unusual agents may expose ``provider`` directly on
+            # the Agent instead of via ``_model``; preserve the fallback.
+            legacy = getattr(agent, "provider", None)
+            if legacy is not None:
+                agent_providers = [legacy]
+        provider = agent_providers[0] if agent_providers else None
         provider_detachers: list[Callable[[], None]] = []
 
         def _subscribe(p: Any) -> None:
@@ -259,7 +268,8 @@ class Recorder:
         # so a failed attach() leaves no dangling listeners. The caller never
         # gets a ``detach`` callable on this path, so we cannot defer cleanup.
         try:
-            _subscribe(provider)
+            for p in agent_providers:
+                _subscribe(p)
             # Middlewares may drive their own LLM calls (e.g.
             # ``CompactionMiddleware``'s summarizer). For each declared
             # (provider, model) pair: (a) subscribe the provider if we
@@ -288,7 +298,10 @@ class Recorder:
                 if agent_model is not None
                 else None
             )
-            seen: set[int] = {id(provider)} if provider is not None else set()
+            # Pre-seed `seen` with every chain provider already subscribed
+            # above so a middleware that reuses one of them isn't
+            # double-subscribed.
+            seen: set[int] = {id(p) for p in agent_providers}
             for mw in getattr(agent, "_middleware", []) or []:
                 try:
                     extra = list(mw.extra_llm_calls())

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -47,7 +47,7 @@ from cubepi.providers.base import (
     ToolCall,
     ToolResultMessage,
     UserMessage,
-    chain_providers,
+    collect_agent_providers,
 )
 from cubepi.tracing.content import (
     messages_to_semconv,
@@ -236,22 +236,13 @@ class Recorder:
     def attach(self, agent: "Agent") -> Callable[[], None]:
         self._agent = agent
         unsub_agent = agent.subscribe(self._on_agent_event)
-        # ``Agent`` holds the bound model on ``_model``; the provider is
-        # reached via ``_model.provider``. Fall back to a public ``provider``
-        # alias should one be added later.
-        agent_model = getattr(agent, "_model", None)
-        # When the bound model is a FallbackBoundModel, subscribe to every
-        # unique provider in the chain so post-failover provider events
-        # (chat spans, token usage, errors) land in the trace tree like
-        # primary-leg events do. Non-fallback models yield a single-entry
-        # list with the only provider.
-        agent_providers: list[Any] = chain_providers(agent_model)
-        if not agent_providers:
-            # Legacy / unusual agents may expose ``provider`` directly on
-            # the Agent instead of via ``_model``; preserve the fallback.
-            legacy = getattr(agent, "provider", None)
-            if legacy is not None:
-                agent_providers = [legacy]
+        # When the bound model is a FallbackBoundModel, ``collect_agent_providers``
+        # returns every unique BaseProvider in the chain so post-failover provider
+        # events (chat spans, token usage, errors) land in the trace tree like
+        # primary-leg events do. Non-fallback models yield a single-entry list.
+        # Legacy agents that expose ``provider`` directly (instead of via
+        # ``_model``) are handled inside the helper.
+        agent_providers: list[BaseProvider] = collect_agent_providers(agent)
         provider = agent_providers[0] if agent_providers else None
         provider_detachers: list[Callable[[], None]] = []
 

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -280,13 +280,31 @@ class Recorder:
             # behaviour. The configuration is self-defeating anyway —
             # compaction with the same model gives no cost / context
             # benefit — but the recorder still produces a usable trace.
-            agent_state = getattr(agent, "_state", None)
-            agent_model = getattr(agent_state, "model", None) if agent_state else None
-            agent_key: tuple[str, str] | None = (
-                (agent_model.provider_id, agent_model.id)
-                if agent_model is not None
-                else None
-            )
+            #
+            # FallbackBoundModel wrinkle: ``_state.model.spec`` only surfaces
+            # chain[0] (the proxy property), so a middleware extra that
+            # legitimately matches a fallback-leg spec (chain[1+]) would
+            # poison ``_extra_call_models`` with the leg's key. Then on
+            # actual failover — chain[0] fails before emission, chain[1]
+            # fires — ``_on_provider_request`` would see the leg's key in
+            # ``_extra_call_models`` and suppress root attribution, leaving
+            # the run attributed to the ``cubepi`` placeholder. Collect
+            # every chain leg's (provider_id, model_id) into ``agent_keys``
+            # so middleware-extras that match any leg are correctly excluded.
+            agent_keys: set[tuple[str, str]] = set()
+            top_model = getattr(agent, "_model", None)
+            chain = getattr(top_model, "chain", None)
+            if chain is not None:
+                for bm in chain:
+                    spec = bm.spec
+                    agent_keys.add((spec.provider_id, spec.id))
+            else:
+                agent_state = getattr(agent, "_state", None)
+                agent_model = (
+                    getattr(agent_state, "model", None) if agent_state else None
+                )
+                if agent_model is not None:
+                    agent_keys.add((agent_model.provider_id, agent_model.id))
             # Pre-seed `seen` with every chain provider already subscribed
             # above so a middleware that reuses one of them isn't
             # double-subscribed.
@@ -299,7 +317,7 @@ class Recorder:
                 for model in extra:
                     spec = model.spec
                     key = (spec.provider_id, spec.id)
-                    if key != agent_key:
+                    if key not in agent_keys:
                         self._extra_call_models.add(key)
                     provider = model.provider
                     if id(provider) in seen:

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -95,6 +95,12 @@ def test_default_trigger_errors_composition() -> None:
     assert ProviderBadRequest not in DEFAULT_TRIGGER_ERRORS
 
 
+def test_empty_chain_raises_value_error() -> None:
+    """FallbackBoundModel rejects an empty chain at construction time."""
+    with pytest.raises(ValueError, match="must contain at least one"):
+        FallbackBoundModel(chain=())
+
+
 # ---------------------------------------------------------------------------
 # stream() tests
 # ---------------------------------------------------------------------------

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -482,3 +482,61 @@ def test_chain_providers_warns_when_chain_leg_is_not_base_provider(caplog) -> No
             raise AssertionError(
                 "expected a WARNING-level log mentioning chain[1] / _DuckProvider"
             )
+
+
+def test_log_chain_skip_loguru_branch_invokable_directly() -> None:
+    """Cover the loguru happy-path inside _log_chain_skip.
+
+    The standard chain_providers warn-path test uses caplog (stdlib
+    logging). When loguru is installed (the default test environment),
+    the loguru branch fires but caplog cannot capture loguru messages
+    without bridge configuration. Call _log_chain_skip directly so the
+    loguru `logger.warning(...)` lines execute and the code path is
+    recorded by coverage.
+    """
+    from cubepi.providers.base import _log_chain_skip
+
+    # No assertion needed — just exercising the path. If loguru is
+    # absent (extreme edge case), the stdlib fallback runs instead and
+    # still covers the function body.
+    _log_chain_skip(0, "object")
+
+
+def test_chain_providers_returns_empty_for_object_without_provider_or_chain() -> None:
+    """Walk: model is not None, has no .chain, .provider isn't a
+    BaseProvider → final `return []` path."""
+    from cubepi.providers.base import chain_providers
+
+    class _Bare:
+        """Object that satisfies `model is not None` but exposes neither
+        a `.chain` nor a BaseProvider-typed `.provider`. Final return []
+        is the only sensible answer."""
+
+    assert chain_providers(_Bare()) == []
+
+
+def test_collect_agent_providers_falls_back_to_legacy_provider_attribute() -> None:
+    """When ``agent._model`` is absent / yields no providers and the
+    agent itself exposes a ``provider`` attribute that IS a BaseProvider,
+    use it. Covers the legacy fallback path."""
+    from cubepi.providers.base import collect_agent_providers
+
+    real = FauxProvider(provider_id="legacy")
+
+    class _LegacyAgent:
+        _model = None
+        provider = real
+
+    assert collect_agent_providers(_LegacyAgent()) == [real]
+
+
+def test_collect_agent_providers_empty_when_no_model_or_legacy_provider() -> None:
+    """No `_model`, no `provider` → empty list. Defensive for fully
+    detached agents (unlikely in practice but the contract guarantees []
+    rather than a crash)."""
+    from cubepi.providers.base import collect_agent_providers
+
+    class _BlankAgent:
+        pass
+
+    assert collect_agent_providers(_BlankAgent()) == []

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -455,51 +455,14 @@ def test_chain_providers_warns_when_chain_leg_is_not_base_provider(caplog) -> No
     duck_bound = BoundModel(provider=duck, spec=real.model("m").spec)  # type: ignore[arg-type]
     fbm = FallbackBoundModel(chain=(real.model("m"), duck_bound))
 
-    # loguru bridges into stdlib logging if a propagation handler is set;
-    # to keep the test independent of optional loguru config, just assert
-    # the dropped leg is absent from the output and accept either backend.
     with caplog.at_level(logging.WARNING, logger="cubepi.providers.base"):
         out = chain_providers(fbm)
 
     assert out == [real], "duck-typed leg should be dropped"
-    # Warning is emitted either via loguru or stdlib logging. Don't pin
-    # the backend; just check at least one of them carries the message.
-    warned = any(
+    assert any(
         "chain[1]" in record.message and "_DuckProvider" in record.message
         for record in caplog.records
-    )
-    # If loguru is installed it may not propagate to caplog; in that case
-    # we accept the assertion-free path (we already verified the leg was
-    # dropped above). Treat this as best-effort signal.
-    if not warned:
-        try:
-            import loguru  # noqa: F401
-
-            # loguru is installed → message went to loguru, not caplog;
-            # the drop assertion above is sufficient evidence the warning
-            # branch executed.
-        except ImportError:
-            raise AssertionError(
-                "expected a WARNING-level log mentioning chain[1] / _DuckProvider"
-            )
-
-
-def test_log_chain_skip_loguru_branch_invokable_directly() -> None:
-    """Cover the loguru happy-path inside _log_chain_skip.
-
-    The standard chain_providers warn-path test uses caplog (stdlib
-    logging). When loguru is installed (the default test environment),
-    the loguru branch fires but caplog cannot capture loguru messages
-    without bridge configuration. Call _log_chain_skip directly so the
-    loguru `logger.warning(...)` lines execute and the code path is
-    recorded by coverage.
-    """
-    from cubepi.providers.base import _log_chain_skip
-
-    # No assertion needed — just exercising the path. If loguru is
-    # absent (extreme edge case), the stdlib fallback runs instead and
-    # still covers the function body.
-    _log_chain_skip(0, "object")
+    ), "expected a WARNING-level log mentioning chain[1] / _DuckProvider"
 
 
 def test_chain_providers_returns_empty_for_object_without_provider_or_chain() -> None:

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -428,3 +428,57 @@ def test_chain_providers_for_none_returns_empty() -> None:
     from cubepi.providers.fallback import chain_providers
 
     assert chain_providers(None) == []
+
+
+def test_chain_providers_warns_when_chain_leg_is_not_base_provider(caplog) -> None:
+    """Chain entries whose provider isn't a BaseProvider are skipped
+    AND logged at WARNING so an operator notices the dropped leg.
+    Without the warning, tracing / metrics silently miss the leg.
+    """
+    import logging
+
+    from cubepi.providers.fallback import chain_providers
+
+    real = FauxProvider(provider_id="real")
+
+    # Duck-typed Provider-protocol wrapper that isn't a BaseProvider —
+    # has the .stream / .generate shape but no subscribe_* listeners,
+    # which is exactly why tracing / metrics can't use it.
+    class _DuckProvider:
+        async def stream(self, *args: Any, **kwargs: Any) -> Any:
+            raise NotImplementedError
+
+        async def generate(self, *args: Any, **kwargs: Any) -> Any:
+            raise NotImplementedError
+
+    duck = _DuckProvider()
+    duck_bound = BoundModel(provider=duck, spec=real.model("m").spec)  # type: ignore[arg-type]
+    fbm = FallbackBoundModel(chain=(real.model("m"), duck_bound))
+
+    # loguru bridges into stdlib logging if a propagation handler is set;
+    # to keep the test independent of optional loguru config, just assert
+    # the dropped leg is absent from the output and accept either backend.
+    with caplog.at_level(logging.WARNING, logger="cubepi.providers.base"):
+        out = chain_providers(fbm)
+
+    assert out == [real], "duck-typed leg should be dropped"
+    # Warning is emitted either via loguru or stdlib logging. Don't pin
+    # the backend; just check at least one of them carries the message.
+    warned = any(
+        "chain[1]" in record.message and "_DuckProvider" in record.message
+        for record in caplog.records
+    )
+    # If loguru is installed it may not propagate to caplog; in that case
+    # we accept the assertion-free path (we already verified the leg was
+    # dropped above). Treat this as best-effort signal.
+    if not warned:
+        try:
+            import loguru  # noqa: F401
+
+            # loguru is installed → message went to loguru, not caplog;
+            # the drop assertion above is sufficient evidence the warning
+            # branch executed.
+        except ImportError:
+            raise AssertionError(
+                "expected a WARNING-level log mentioning chain[1] / _DuckProvider"
+            )

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -372,3 +372,53 @@ async def test_generate_error_assistant_message_triggers_failover() -> None:
 
     assert result.provider_id == "fallback"
     assert result.stop_reason != "error"
+
+
+# ---------------------------------------------------------------------------
+# chain_providers helper — used by Recorder / Meter to subscribe to every
+# unique provider in a fallback chain (issue #167).
+# ---------------------------------------------------------------------------
+
+
+def test_chain_providers_for_fallback_returns_unique_providers_in_order() -> None:
+    """FallbackBoundModel chain → list of unique providers, primary first."""
+    from cubepi.providers.fallback import chain_providers
+
+    p1 = FauxProvider(provider_id="p1")
+    p2 = FauxProvider(provider_id="p2")
+    p3 = FauxProvider(provider_id="p3")
+    fbm = FallbackBoundModel(chain=(p1.model("a"), p2.model("b"), p3.model("c")))
+
+    out = chain_providers(fbm)
+    assert out == [p1, p2, p3]
+
+
+def test_chain_providers_dedupes_shared_provider_across_legs() -> None:
+    """Two chain entries on the same provider instance → single entry in output."""
+    from cubepi.providers.fallback import chain_providers
+
+    shared = FauxProvider(provider_id="shared")
+    other = FauxProvider(provider_id="other")
+    # primary + tertiary share the same provider; secondary differs.
+    fbm = FallbackBoundModel(
+        chain=(shared.model("a"), other.model("b"), shared.model("c"))
+    )
+
+    out = chain_providers(fbm)
+    assert out == [shared, other]
+
+
+def test_chain_providers_for_plain_bound_model_returns_single_entry() -> None:
+    """A plain BoundModel → single-entry list with its provider."""
+    from cubepi.providers.fallback import chain_providers
+
+    p = FauxProvider(provider_id="plain")
+    out = chain_providers(p.model("x"))
+    assert out == [p]
+
+
+def test_chain_providers_for_none_returns_empty() -> None:
+    """None model → empty list (used by attach()'s legacy fallback path)."""
+    from cubepi.providers.fallback import chain_providers
+
+    assert chain_providers(None) == []

--- a/tests/tracing/test_meter.py
+++ b/tests/tracing/test_meter.py
@@ -348,3 +348,47 @@ class TestNoMetricsWithoutListeners:
 
         points = _all_metric_points(reader)
         assert _by_name(points, "gen_ai.client.operation.duration") == []
+
+
+class TestFallbackChainCoverage:
+    """Issue #167 — Meter.attach() should subscribe to every chain provider."""
+
+    async def test_attach_subscribes_to_every_chain_provider(self):
+        from cubepi.providers.fallback import FallbackBoundModel
+
+        primary = FauxProvider(provider_id="primary")
+        secondary = FauxProvider(provider_id="secondary")
+        chain_model = FallbackBoundModel(
+            chain=(primary.model(MODEL.id), secondary.model(MODEL.id)),
+        )
+        agent = Agent(model=chain_model, system_prompt="s")
+        meter, _ = _build_meter()
+        detach = meter.attach(agent)
+
+        # Both providers have request listeners registered.
+        assert len(getattr(primary, "_request_listeners", [])) == 1
+        assert len(getattr(secondary, "_request_listeners", [])) == 1
+
+        detach()
+
+        # Detach clears them.
+        assert len(getattr(primary, "_request_listeners", [])) == 0
+        assert len(getattr(secondary, "_request_listeners", [])) == 0
+
+    async def test_attach_dedupes_shared_provider_across_chain(self):
+        from cubepi.providers.fallback import FallbackBoundModel
+
+        shared = FauxProvider(provider_id="shared")
+        chain_model = FallbackBoundModel(
+            chain=(shared.model("m1"), shared.model("m2")),
+        )
+        agent = Agent(model=chain_model, system_prompt="s")
+        meter, _ = _build_meter()
+        detach = meter.attach(agent)
+
+        # Shared provider gets one listener of each kind, not two.
+        assert len(getattr(shared, "_request_listeners", [])) == 1
+        assert len(getattr(shared, "_chunk_listeners", [])) == 1
+        assert len(getattr(shared, "_response_listeners", [])) == 1
+
+        detach()

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -1570,3 +1570,57 @@ class TestFallbackChainCoverage:
         assert len(request_listeners) == 1, request_listeners
 
         await tracer.shutdown()
+
+    async def test_attach_excludes_every_chain_leg_key_from_extra_call_models(
+        self,
+    ):
+        """Regression for the failover-first-call root attribution suppression
+        bug. If a middleware declares an extra_llm_call whose ``.spec`` matches
+        chain[1+] of a FallbackBoundModel, the recorder must NOT register that
+        spec key in ``_extra_call_models`` — otherwise when chain[0] fails
+        before emission and chain[1] fires for the agent's own request, the
+        recorder treats it as a middleware-owned call and skips root
+        attribution, leaving the run attributed to the ``cubepi`` placeholder.
+
+        Build a chain ``[primary, secondary]`` + a stub middleware whose
+        ``extra_llm_calls()`` returns a BoundModel using secondary's spec,
+        attach, then verify secondary's spec key is absent from the recorder's
+        ``_extra_call_models`` set.
+        """
+        from cubepi.providers.fallback import FallbackBoundModel
+
+        primary = FauxProvider(provider_id="primary")
+        secondary = FauxProvider(provider_id="secondary")
+        primary_bound = primary.model("m-primary")
+        secondary_bound = secondary.model("m-secondary")
+
+        # Minimal duck-typed middleware: only ``extra_llm_calls()`` is read
+        # by attach(). The middleware "extra" intentionally reuses
+        # secondary's spec — a legitimate pattern when a middleware wants
+        # to share the fallback's secondary model.
+        class _FakeMiddleware:
+            def extra_llm_calls(self) -> list[Any]:
+                return [secondary_bound]
+
+        chain_model = FallbackBoundModel(chain=(primary_bound, secondary_bound))
+        agent = Agent(
+            model=chain_model,
+            system_prompt="t",
+            middleware=[_FakeMiddleware()],  # type: ignore[list-item]
+        )
+        exporter = InMemoryExporter()
+        tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
+        tracer.attach(agent)
+
+        recorder = _find_attached_recorder(primary)
+        assert recorder is not None
+        secondary_key = (secondary_bound.spec.provider_id, secondary_bound.spec.id)
+        assert secondary_key not in recorder._extra_call_models, (
+            "secondary leg's spec must NOT be in _extra_call_models — otherwise "
+            "failover to chain[1] would suppress root attribution"
+        )
+        # Primary's key must also not be flagged as extra (it was never extra).
+        primary_key = (primary_bound.spec.provider_id, primary_bound.spec.id)
+        assert primary_key not in recorder._extra_call_models
+
+        await tracer.shutdown()

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -1522,3 +1522,55 @@ class TestJsonlExporter:
             d = _json.loads(line)
             assert "name" in d
             assert "context" in d
+
+
+class TestFallbackChainCoverage:
+    """Issue #167 — Tracer/Meter should subscribe to every chain provider."""
+
+    async def test_attach_subscribes_to_every_chain_provider(self):
+        """When agent.model is a FallbackBoundModel, attach() should listen
+        on each unique provider in chain — not just chain[0]."""
+        from cubepi.providers.fallback import FallbackBoundModel
+
+        primary = FauxProvider(provider_id="primary")
+        secondary = FauxProvider(provider_id="secondary")
+        chain_model = FallbackBoundModel(
+            chain=(primary.model(MODEL.id), secondary.model(MODEL.id)),
+        )
+        agent = Agent(model=chain_model, system_prompt="t")
+        exporter = InMemoryExporter()
+        tracer = Tracer(
+            service_name="t", agent_name="a", exporters=[exporter]
+        )
+        tracer.attach(agent)
+
+        recorder = _find_attached_recorder(primary)
+        assert recorder is not None, "primary leg must be subscribed"
+        recorder_2 = _find_attached_recorder(secondary)
+        assert recorder_2 is not None, "secondary leg must be subscribed"
+        # Both legs share the same Recorder instance.
+        assert recorder is recorder_2
+
+        await tracer.shutdown()
+
+    async def test_attach_dedupes_shared_provider_across_chain(self):
+        """If chain[0] and chain[1] share the same provider instance,
+        attach() must register listeners on it only once."""
+        from cubepi.providers.fallback import FallbackBoundModel
+
+        shared = FauxProvider(provider_id="shared")
+        chain_model = FallbackBoundModel(
+            chain=(shared.model("m1"), shared.model("m2")),
+        )
+        agent = Agent(model=chain_model, system_prompt="t")
+        exporter = InMemoryExporter()
+        tracer = Tracer(
+            service_name="t", agent_name="a", exporters=[exporter]
+        )
+        tracer.attach(agent)
+
+        # Each event type registered exactly once on the shared provider.
+        request_listeners = list(getattr(shared, "_request_listeners", []))
+        assert len(request_listeners) == 1, request_listeners
+
+        await tracer.shutdown()

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -1565,9 +1565,13 @@ class TestFallbackChainCoverage:
         tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
         tracer.attach(agent)
 
-        # Each event type registered exactly once on the shared provider.
-        request_listeners = list(getattr(shared, "_request_listeners", []))
-        assert len(request_listeners) == 1, request_listeners
+        # Each event type registered exactly once on the shared provider —
+        # matches the meter dedupe test for symmetry. Without the chunk /
+        # response asserts, a regression that double-subscribed only the
+        # streaming or terminal listener would slip through.
+        assert len(getattr(shared, "_request_listeners", [])) == 1
+        assert len(getattr(shared, "_chunk_listeners", [])) == 1
+        assert len(getattr(shared, "_response_listeners", [])) == 1
 
         await tracer.shutdown()
 

--- a/tests/tracing/test_recorder.py
+++ b/tests/tracing/test_recorder.py
@@ -1539,9 +1539,7 @@ class TestFallbackChainCoverage:
         )
         agent = Agent(model=chain_model, system_prompt="t")
         exporter = InMemoryExporter()
-        tracer = Tracer(
-            service_name="t", agent_name="a", exporters=[exporter]
-        )
+        tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
         tracer.attach(agent)
 
         recorder = _find_attached_recorder(primary)
@@ -1564,9 +1562,7 @@ class TestFallbackChainCoverage:
         )
         agent = Agent(model=chain_model, system_prompt="t")
         exporter = InMemoryExporter()
-        tracer = Tracer(
-            service_name="t", agent_name="a", exporters=[exporter]
-        )
+        tracer = Tracer(service_name="t", agent_name="a", exporters=[exporter])
         tracer.attach(agent)
 
         # Each event type registered exactly once on the shared provider.


### PR DESCRIPTION
Closes #167.

## Summary

Before this change `Recorder.attach()` and `Meter.attach()` read `agent._model.provider` — which on `FallbackBoundModel` proxies `chain[0].provider`. Post-failover calls executed against `chain[1..]` were invisible to provider-level observability: chat spans, token usage, cache metrics, and provider-level cost telemetry were missing for fallback legs. Agent-event-driven observability (e.g. cost middleware listening to `MessageEvent`) was already correct and is unchanged.

## What changed

- New helper `cubepi.providers.fallback.chain_providers(model)` returns the unique `BaseProvider` instances backing a bound model:
  - `FallbackBoundModel` → ordered, deduped list of all chain providers
  - plain `BoundModel` → single-entry list
  - `None` → empty list (used by the legacy fallback path in attach)
- `Recorder.attach()` now iterates `chain_providers(agent_model)` and subscribes to every leg. Pre-seeds its `seen` set so a middleware that re-uses one of the chain providers (e.g. `CompactionMiddleware` using the same provider with a different model) is not double-subscribed.
- `Meter.attach()` follows the same pattern; subscriptions + detachers track every chain provider.
- Updated `FallbackBoundModel` docstring — replaces the "known limitation" note (now resolved) with the new behaviour.
- CHANGELOG entry under `[Unreleased]`.

## Test coverage

- 4 unit tests on `chain_providers()` (chain order, dedupe, plain-BoundModel passthrough, `None`).
- 2 integration tests on `Recorder.attach()` (each chain provider receives the recorder; shared provider is not double-subscribed).
- 2 integration tests on `Meter.attach()` (each chain provider gets request/chunk/response listeners; detach removes them).

```
tests/providers/test_fallback.py — 13 passed (4 new)
tests/tracing/test_recorder.py::TestFallbackChainCoverage — 2 passed
tests/tracing/test_meter.py::TestFallbackChainCoverage — 2 passed
Full tracing suite: 213/215 (2 pre-existing failures in test_otlp_exporter.py due to optional `tracing-otlp` extra not installed)
mypy clean; ruff clean
```

## Backwards compatibility

- Existing single-provider agents unchanged — `chain_providers(BoundModel)` returns `[model.provider]`, same as before.
- Existing `provider` fallback for legacy agents that expose `.provider` directly on the `Agent` instance is preserved.