### PR TITLE
feat(providers): drop the "minimal" ThinkingLevel

### DIFF
--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -49,7 +49,7 @@ CacheRetention = Literal["short", "long", "none"]
 #  - reasoning_on_payload writes {"thinking": {"type": "enabled"}}, then
 #    reasoning_level adds budget_tokens at thinking.budget_tokens.
 #  - level_budgets mirrors cubepi.providers.base.ThinkingBudgets defaults
-#    (minimal=1024, low=2048, medium=8192, high=16384). xhigh clamps to high
+#    (low=2048, medium=8192, high=16384). xhigh clamps to high
 #    to match adjust_max_tokens_for_thinking's "xhigh -> high" mapping.
 #    "off" is included for completeness but reasoning_level is never written
 #    on the off-branch.
@@ -65,7 +65,6 @@ _ANTHROPIC_DEFAULT_CAPABILITY = CapabilityDescriptor(
         kind="int_budget",
         level_budgets={
             "off": 0,
-            "minimal": 1024,
             "low": 2048,
             "medium": 8192,
             "high": 16384,

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -21,7 +21,7 @@ from cubepi.types import JsonObject, StructuredValue
 
 BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
 
-ThinkingLevel = Literal["off", "minimal", "low", "medium", "high", "xhigh"]
+ThinkingLevel = Literal["off", "low", "medium", "high", "xhigh"]
 
 ToolChoice = Literal["auto", "required", "none"] | str
 
@@ -29,7 +29,6 @@ ToolChoice = Literal["auto", "required", "none"] | str
 class ThinkingBudgets(BaseModel):
     """Token budgets for each thinking level."""
 
-    minimal: int = 1024
     low: int = 2048
     medium: int = 8192
     high: int = 16384

--- a/cubepi/providers/models.py
+++ b/cubepi/providers/models.py
@@ -11,7 +11,6 @@ from cubepi.providers.base import Model, ThinkingLevel
 # Ordered list of all thinking levels from lowest to highest.
 THINKING_LEVELS: list[ThinkingLevel] = [
     "off",
-    "minimal",
     "low",
     "medium",
     "high",

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -38,10 +38,8 @@ from cubepi.providers.capability import (
 
 # Map cubepi ThinkingLevel to OpenAI reasoning.effort values.
 # "off" means no reasoning parameter is sent.
-# "minimal" is not a valid OpenAI effort level, so we map it to "low".
 _THINKING_TO_EFFORT: dict[ThinkingLevel, str | None] = {
     "off": None,
-    "minimal": "low",
     "low": "low",
     "medium": "medium",
     "high": "high",

--- a/tests/providers/test_models.py
+++ b/tests/providers/test_models.py
@@ -44,7 +44,6 @@ class TestGetSupportedThinkingLevels:
         model = _model(reasoning=True)
         assert get_supported_thinking_levels(model) == [
             "off",
-            "minimal",
             "low",
             "medium",
             "high",
@@ -58,7 +57,7 @@ class TestGetSupportedThinkingLevels:
         levels = get_supported_thinking_levels(model)
         assert "xhigh" in levels
         # All standard levels should still be present
-        for lvl in ("off", "minimal", "low", "medium", "high"):
+        for lvl in ("off", "low", "medium", "high"):
             assert lvl in levels
 
     def test_xhigh_mapped_to_none_is_excluded(self):
@@ -71,10 +70,9 @@ class TestGetSupportedThinkingLevels:
     def test_level_mapped_to_none_is_excluded(self):
         model = _model(
             reasoning=True,
-            thinking_level_map={"minimal": None, "low": None},
+            thinking_level_map={"low": None},
         )
         levels = get_supported_thinking_levels(model)
-        assert "minimal" not in levels
         assert "low" not in levels
         # Others remain
         assert "off" in levels
@@ -84,13 +82,12 @@ class TestGetSupportedThinkingLevels:
     def test_empty_map_same_as_no_map(self):
         model = _model(reasoning=True, thinking_level_map={})
         levels = get_supported_thinking_levels(model)
-        assert levels == ["off", "minimal", "low", "medium", "high"]
+        assert levels == ["off", "low", "medium", "high"]
 
     def test_all_levels_disabled_except_off(self):
         model = _model(
             reasoning=True,
             thinking_level_map={
-                "minimal": None,
                 "low": None,
                 "medium": None,
                 "high": None,
@@ -126,10 +123,10 @@ class TestClampThinkingLevel:
         """When a level is disabled, search downward first (prefer cheaper)."""
         model = _model(
             reasoning=True,
-            thinking_level_map={"low": None},
+            thinking_level_map={"medium": None},
         )
-        # "low" disabled -> next down is "minimal"
-        assert clamp_thinking_level(model, "low") == "minimal"
+        # "medium" disabled -> next down is "low"
+        assert clamp_thinking_level(model, "medium") == "low"
 
     def test_clamp_down_when_nothing_above(self):
         """When all higher levels are disabled, clamp down."""
@@ -150,7 +147,6 @@ class TestClampThinkingLevel:
         model = _model(
             reasoning=True,
             thinking_level_map={
-                "minimal": None,
                 "low": None,
                 "medium": None,
                 "high": None,
@@ -209,7 +205,6 @@ class TestThinkingLevelsOrdering:
     def test_correct_order(self):
         assert THINKING_LEVELS == [
             "off",
-            "minimal",
             "low",
             "medium",
             "high",
@@ -217,5 +212,5 @@ class TestThinkingLevelsOrdering:
         ]
 
     def test_all_levels_present(self):
-        expected = {"off", "minimal", "low", "medium", "high", "xhigh"}
+        expected = {"off", "low", "medium", "high", "xhigh"}
         assert set(THINKING_LEVELS) == expected

--- a/tests/providers/test_thinking_budgets.py
+++ b/tests/providers/test_thinking_budgets.py
@@ -4,14 +4,13 @@ from cubepi.providers.base import ThinkingBudgets, adjust_max_tokens_for_thinkin
 class TestThinkingBudgets:
     def test_defaults(self):
         b = ThinkingBudgets()
-        assert b.minimal == 1024
         assert b.low == 2048
         assert b.medium == 8192
         assert b.high == 16384
 
     def test_custom_values(self):
-        b = ThinkingBudgets(minimal=512, low=1024, medium=4096, high=8192)
-        assert b.minimal == 512
+        b = ThinkingBudgets(low=1024, medium=4096, high=8192)
+        assert b.low == 1024
         assert b.high == 8192
 
 
@@ -24,15 +23,6 @@ class TestAdjustMaxTokensForThinking:
         )
         assert max_tokens == 8192
         assert budget == 0
-
-    def test_minimal_adds_1024(self):
-        max_tokens, budget = adjust_max_tokens_for_thinking(
-            base_max_tokens=8192,
-            model_max_tokens=128_000,
-            reasoning_level="minimal",
-        )
-        assert budget == 1024
-        assert max_tokens == 8192 + 1024
 
     def test_low_adds_2048(self):
         max_tokens, budget = adjust_max_tokens_for_thinking(
@@ -105,7 +95,7 @@ class TestAdjustMaxTokensForThinking:
         assert budget == 0
 
     def test_custom_budgets_override_defaults(self):
-        custom = ThinkingBudgets(minimal=256, low=512, medium=2048, high=4096)
+        custom = ThinkingBudgets(low=512, medium=2048, high=4096)
         max_tokens, budget = adjust_max_tokens_for_thinking(
             base_max_tokens=8192,
             model_max_tokens=128_000,
@@ -128,26 +118,27 @@ class TestAdjustMaxTokensForThinking:
 
     def test_exact_model_cap_equals_budget(self):
         # Edge case: model cap exactly equals the budget
-        # max_tokens = min(8192 + 1024, 1024) = 1024
-        # 1024 <= 1024 so budget = max(0, 1024 - 1024) = 0
+        # max_tokens = min(8192 + 2048, 2048) = 2048
+        # 2048 - 2048 = 0 < min_output_tokens(1024), budget = max(0, 2048 - 1024) = 1024
         max_tokens, budget = adjust_max_tokens_for_thinking(
             base_max_tokens=8192,
-            model_max_tokens=1024,
-            reasoning_level="minimal",
+            model_max_tokens=2048,
+            reasoning_level="low",
         )
-        assert max_tokens == 1024
-        assert budget == 0
+        assert max_tokens == 2048
+        assert budget == 1024
 
     def test_model_cap_just_above_budget(self):
-        # max_tokens = min(8192 + 1024, 1025) = 1025
-        # 1025 - 1024 = 1 < min_output_tokens(1024), so budget reduced
+        # base=8192, model=2049, low budget=2048
+        # max_tokens = min(8192 + 2048, 2049) = 2049
+        # 2049 - 2048 = 1 < min_output_tokens(1024), budget = max(0, 2049 - 1024) = 1025
         max_tokens, budget = adjust_max_tokens_for_thinking(
             base_max_tokens=8192,
-            model_max_tokens=1025,
-            reasoning_level="minimal",
+            model_max_tokens=2049,
+            reasoning_level="low",
         )
-        assert max_tokens == 1025
-        assert budget == 1  # max(0, 1025 - 1024)
+        assert max_tokens == 2049
+        assert budget == 1025
 
     def test_output_tokens_minimum_guaranteed(self):
         # Bug case: base=8192, model=9000, medium budget=8192


### PR DESCRIPTION
## Summary

- DeepSeek's Anthropic-shape endpoint rejects `effort: minimal` on `output_config` (only `high/low/medium/max/xhigh` are accepted), so any cubebox user that picked "Minimal" tripped a 400 and silently fell back to qwen. The OpenAI Responses path was no better — it remapped `minimal → low` downstream and never had a meaningful mapping of its own.
- Cut the level entirely instead of keeping a footgun:
  - `ThinkingLevel` literal in `providers/base.py`
  - `ThinkingBudgets` drops the `.minimal` field
  - `THINKING_LEVELS` ordering in `providers/models.py`
  - Anthropic capability defaults (`level_budgets`) and the cap comment
  - OpenAI Responses `_THINKING_TO_EFFORT` map
- Callers that fed `"minimal"` must now pass `"low"` (or `"off"`).

Pairs with cubebox `feat/thinking-fix-and-drop-minimal`, which drops the level from the YAML capability catalog, the frontend `ThinkingLevel` type, the composer dropdown, and adds a localStorage `minimal → low` migration. Cubebox bumps the cubepi pin after this merges.

## Test plan

- [x] `pytest tests/` — 1724 passed, 45 skipped
- [x] focused: `tests/providers/test_thinking_budgets.py` + `test_models.py` + `test_anthropic_capability.py` + `test_openai_responses_capability.py` — 65 passed