### PR TITLE
docs(changelog): wire 0.10.0 reference link; runbook gotcha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -564,7 +564,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.2.0]** - 2026-05-10 — see the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.2.0).
 - **[0.1.0]** - 2026-05-09 — initial release. See the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/cubeplexai/cubepi/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/cubeplexai/cubepi/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/cubeplexai/cubepi/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/cubeplexai/cubepi/compare/v0.6.0...v0.7.0

--- a/dev/runbooks/cut-doc-version.md
+++ b/dev/runbooks/cut-doc-version.md
@@ -225,6 +225,41 @@ After the snapshot, open the new `version-X.Y.json` and update:
 Once this version is later demoted (at X+1.Y), change the message to just
 `"X.Y"` (drop "（最新）") to match the EN config pattern.
 
+### 11. Add the `[X.Y.0]` CHANGELOG reference-link and bump `[Unreleased]`
+
+`CHANGELOG.md` follows Keep a Changelog with reference-style links — the
+`## [X.Y.0] - YYYY-MM-DD` heading only renders as a link to the compare
+view when there is a matching `[X.Y.0]: https://...compare/v(X.Y-1).0...vX.Y.0`
+entry in the link block at the bottom of the file. The `[Unreleased]`
+entry must also be re-pointed each release.
+
+The 0.9 and 0.10 cuts both shipped with `## [X.Y.0]` rendering as plain
+text because the link block wasn't bumped. The `/changelog` docs page
+and the GitHub blob view both make the broken reference visually
+obvious — readers expect the prior-version pattern.
+
+When promoting `[Unreleased]` → `[X.Y.0] - YYYY-MM-DD`, also patch the
+link block at the bottom of `CHANGELOG.md`:
+
+```diff
+-[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v(X.Y-1).0...HEAD
++[Unreleased]: https://github.com/cubeplexai/cubepi/compare/vX.Y.0...HEAD
++[X.Y.0]: https://github.com/cubeplexai/cubepi/compare/v(X.Y-1).0...vX.Y.0
+ [(X.Y-1).0]: https://github.com/cubeplexai/cubepi/compare/v(X.Y-2).0...v(X.Y-1).0
+```
+
+Verify before commit — every `## [N.M.0]` heading must have a matching
+`[N.M.0]:` reference. Use a subset check, not a strict equality diff,
+because reference IDs are also reused inline (e.g. `**[0.4.0]**` in the
+"Earlier releases" prose):
+
+```bash
+# Lists any version heading missing a reference target. Empty output = clean.
+comm -23 \
+  <(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '# ' | sort -u) \
+  <(grep -oE '^\[[0-9]+\.[0-9]+\.[0-9]+\]'    CHANGELOG.md | sort -u)
+```
+
 ## Post-cut verification
 
 After committing the cut, before opening the PR / tagging:
@@ -234,6 +269,12 @@ cd website
 pnpm apiref               # regenerate (idempotent)
 pnpm build                # must pass with no broken-link errors
 pnpm test                 # vitest suite covers the version-aware nav
+cd ..
+# CHANGELOG link sanity (see gotcha #11). Empty output = every
+# "## [N.M.0]" heading has a matching reference target.
+comm -23 \
+  <(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '# ' | sort -u) \
+  <(grep -oE '^\[[0-9]+\.[0-9]+\.[0-9]+\]'    CHANGELOG.md | sort -u)
 ```
 
 Then in the rendered site (`pnpm start` or the preview deploy):


### PR DESCRIPTION
## Summary

The Keep-a-Changelog reference-style link block at the bottom of `CHANGELOG.md` was not updated when `0.10.0` promoted out of `[Unreleased]`:

- `[Unreleased]:` still pointed to `compare/v0.9.0...HEAD`
- `[0.10.0]:` had no reference target at all

Without a target, GitHub's blob view and the `/changelog` docs page rendered `## [0.10.0] - 2026-06-10` as plain text — the brackets had nowhere to resolve to. Every prior version heading is a link to the GitHub compare view; readers spot the inconsistency. The 0.9 cut shipped with the same bug.

## Changes

- **`CHANGELOG.md`** — re-point `[Unreleased]:` to `compare/v0.10.0...HEAD`, add `[0.10.0]: compare/v0.9.0...v0.10.0`.
- **`dev/runbooks/cut-doc-version.md`** — add gotcha #11 explaining the trap with a concrete diff-style example of the link-block edit needed each release, plus a verification command using `comm -23` (subset check, not strict equality — IDs are also reused inline as `**[0.x.0]**` in the "Earlier releases" prose section). Also added the same check to the "Post-cut verification" block so it appears in the routine checklist, not only in the gotchas list.

## Test plan

- [x] After the fix, the subset check is empty:
  ```
  comm -23 \
    <(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '# ' | sort -u) \
    <(grep -oE '^\[[0-9]+\.[0-9]+\.[0-9]+\]'    CHANGELOG.md | sort -u)
  ```
- [x] Before the fix, the same command outputs `0.10.0` — i.e. it catches the bug it's documented to prevent.
- [ ] Post-merge: `## [0.10.0] - 2026-06-10` renders as a link on github.com and on `/changelog`.