### PR TITLE
docs(sidebar+middleware): Middlewares label, reorder Examples last, 7→8 hooks, cross-link deferred tools

### DIFF
--- a/website/docs/guides/agents/tool-use.md
+++ b/website/docs/guides/agents/tool-use.md
@@ -245,13 +245,21 @@ their schemas are appended (append-only, for cache stability).
 ```python
 from cubepi import Agent
 from cubepi.deferred import DeferredToolGroup
+from cubepi.mcp import load_mcp_tools_stdio
+
+async def load_github_tools():
+    result = await load_mcp_tools_stdio(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+    )
+    return result.tools   # list[AgentTool]
 
 github_group = DeferredToolGroup(
     group_id="mcp:github",
     display_name="GitHub",
     description="Issues, PRs, repos, code search",
     tool_names=["create_issue", "search_repos", "create_pr"],
-    loader=github_mcp.load_tools,
+    loader=load_github_tools,
 )
 
 agent = Agent(
@@ -261,13 +269,19 @@ agent = Agent(
 )
 ```
 
+The loader is a zero-arg async callable returning `list[AgentTool]` —
+wrap an MCP discovery call (as above), or just return your own
+`@tool`-decorated functions. The names in `tool_names` must match each
+tool's `AgentTool.name` so selective expansion can find them.
+
 Good fit when you have ≥5 tool groups but typically only use one or
 two per conversation, or when schemas are large enough to noticeably
 inflate every system prompt. Skip it when all the tools are needed on
 every turn — deferring just adds a round trip.
 
 See [Deferred Tool Groups](../middleware/deferred-tools) for the full
-API, cross-run replay, and the advanced middleware constructor.
+API (including a hand-written-tools loader example), cross-run replay,
+and the advanced middleware constructor.
 
 ## Common pitfalls
 

--- a/website/docs/guides/agents/tool-use.md
+++ b/website/docs/guides/agents/tool-use.md
@@ -227,6 +227,48 @@ CubePi only terminates if *every* tool result in the current batch is
 `terminate=True`. The agent loop emits `turn_end`, then `agent_end`,
 and exits.
 
+## Many tools? Defer their schemas
+
+When the toolbelt grows — usually because you've wired up several MCP
+servers — the combined JSON schemas can consume thousands of tokens of
+system prompt on every turn, even though the model only needs one or
+two groups for the current task. The schemas are also a prompt-cache
+landmine: any tool change anywhere invalidates the cache for every
+turn that follows.
+
+`DeferredToolGroup` solves this by replacing the full schemas with a
+compact catalog. The model sees a one-line description per group and
+expands a group on demand via the built-in `load_tools` tool — the
+loader runs once, the tools are injected into the live tool set, and
+their schemas are appended (append-only, for cache stability).
+
+```python
+from cubepi import Agent
+from cubepi.deferred import DeferredToolGroup
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr"],
+    loader=github_mcp.load_tools,
+)
+
+agent = Agent(
+    model=provider.model("claude-sonnet-4-6"),
+    tools=[search_tool, calculator],     # always-available
+    deferred_tool_groups=[github_group], # expanded on demand
+)
+```
+
+Good fit when you have ≥5 tool groups but typically only use one or
+two per conversation, or when schemas are large enough to noticeably
+inflate every system prompt. Skip it when all the tools are needed on
+every turn — deferring just adds a round trip.
+
+See [Deferred Tool Groups](../middleware/deferred-tools) for the full
+API, cross-run replay, and the advanced middleware constructor.
+
 ## Common pitfalls
 
 - **Forgetting the keyword-only args** — `execute(tool_call_id,
@@ -255,7 +297,3 @@ and exits.
   HTTP-calling tool, end-to-end.
 - [MCP Loading](../mcp/loading) — pull an entire toolset off an MCP
   server in one call.
-- [Deferred Tool Groups](../middleware/deferred-tools) — when the
-  combined tool list across several MCP servers is dozens or hundreds
-  of tools, hide the schemas behind a catalog and let the model expand
-  groups on demand via the built-in `load_tools` tool.

--- a/website/docs/guides/agents/tool-use.md
+++ b/website/docs/guides/agents/tool-use.md
@@ -255,3 +255,7 @@ and exits.
   HTTP-calling tool, end-to-end.
 - [MCP Loading](../mcp/loading) — pull an entire toolset off an MCP
   server in one call.
+- [Deferred Tool Groups](../middleware/deferred-tools) — when the
+  combined tool list across several MCP servers is dozens or hundreds
+  of tools, hide the schemas behind a catalog and let the model expand
+  groups on demand via the built-in `load_tools` tool.

--- a/website/docs/guides/mcp/loading.md
+++ b/website/docs/guides/mcp/loading.md
@@ -119,6 +119,15 @@ agent = Agent(
 The model sees one combined JSON Schema; the loop dispatches each
 call to the right implementation.
 
+:::tip Many MCP servers? Defer them.
+If you wire up several MCP servers and only a few are needed per
+conversation, eagerly loading every schema into the system prompt
+becomes the dominant context cost. Wrap each server's tools in a
+[`DeferredToolGroup`](../middleware/deferred-tools) — CubePi replaces
+the full schemas with a compact catalog and lets the model expand a
+group on demand via the built-in `load_tools` tool.
+:::
+
 ## Per-call vs reusable connections
 
 CubePi opens a new transport per `execute` call. That's:
@@ -166,3 +175,7 @@ downstream programmatic access, but not shown to the model.
   dispatched.
 - [`make_mcp_agent_tool` source](https://github.com/cubeplexai/cubepi/blob/main/cubepi/mcp/_adapter.py)
   — the schema → Pydantic adapter, if you need to customise.
+- [Deferred Tool Groups](../middleware/deferred-tools) — hide MCP
+  schemas from the system prompt and let the model expand them on
+  demand. Useful when several MCP servers add up to a context-heavy
+  toolbelt.

--- a/website/docs/guides/middleware/deferred-tools.md
+++ b/website/docs/guides/middleware/deferred-tools.md
@@ -41,12 +41,16 @@ automatically — no manual wiring needed:
 from cubepi import Agent
 from cubepi.deferred import DeferredToolGroup
 
+# load_github_tools / load_linear_tools are zero-arg async callables
+# returning list[AgentTool]. See "Writing a loader" below for the two
+# common shapes (MCP-backed and hand-written @tool functions).
+
 github_group = DeferredToolGroup(
     group_id="mcp:github",
     display_name="GitHub",
     description="Issues, PRs, repos, code search",
     tool_names=["create_issue", "search_repos", "create_pr", "list_comments"],
-    loader=github_mcp.load_tools,  # async () -> list[AgentTool]
+    loader=load_github_tools,
 )
 
 linear_group = DeferredToolGroup(
@@ -54,7 +58,7 @@ linear_group = DeferredToolGroup(
     display_name="Linear",
     description="Project management and issue tracking",
     tool_names=["create_issue", "update_issue", "list_projects"],
-    loader=linear_mcp.load_tools,
+    loader=load_linear_tools,
 )
 
 agent = Agent(
@@ -71,8 +75,81 @@ agent = Agent(
 | `group_id` | `str` | Unique identifier the model uses in `load_tools` calls (e.g. `"mcp:github"`) |
 | `display_name` | `str` | Human-readable label shown in the catalog |
 | `description` | `str` | One-line summary of the group's capabilities |
-| `tool_names` | `list[str]` | Tool names shown in the catalog |
+| `tool_names` | `list[str]` | Tool names shown in the catalog. **Must match the `AgentTool.name` of each tool the loader returns** — selective expansion (`load_tools(group_id, tool_names=[…])`) matches on this. |
 | `loader` | `async () -> list[AgentTool]` | Callback that returns the full tool set for this group |
+
+### Writing a loader
+
+The loader is a zero-argument async callable that returns
+`list[AgentTool]`. CubePi only cares about its return type — where the
+`AgentTool` objects come from is up to you. Two common shapes:
+
+**From an MCP server.** `load_mcp_tools_stdio` / `load_mcp_tools_http`
+return an `MCPDiscoveryResult` whose `.tools` is the `list[AgentTool]`
+you want. Wrap it:
+
+```python
+from cubepi.deferred import DeferredToolGroup
+from cubepi.mcp import load_mcp_tools_stdio
+
+async def load_github_tools():
+    result = await load_mcp_tools_stdio(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+        env={"GITHUB_TOKEN": "ghp_…"},
+    )
+    return result.tools   # list[AgentTool]
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr"],
+    loader=load_github_tools,
+)
+```
+
+The names in `tool_names` must match the MCP server's tool names —
+those become `AgentTool.name` after discovery. If the catalog lists
+`create_issue` but the server publishes it as `github_create_issue`,
+selective expansion misses.
+
+**From hand-written `@tool` functions.** Any function decorated with
+`@tool` produces an `AgentTool` (its `.name` defaults to the function
+name, overridable via `@tool(name="…")`). A loader for hand-written
+tools is just `async lambda` over a list:
+
+```python
+from cubepi import tool
+from cubepi.deferred import DeferredToolGroup
+
+@tool
+async def create_issue(*, repo: str, title: str, body: str) -> str:
+    "Open a GitHub issue."
+    ...
+
+@tool
+async def search_repos(*, query: str) -> str:
+    "Search public repos."
+    ...
+
+async def load_github_tools():
+    return [create_issue, search_repos]   # already AgentTools
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos"],
+    loader=load_github_tools,
+)
+```
+
+You can mix the two — return MCP tools and hand-written tools in the
+same list — as long as every name in `tool_names` matches an
+`AgentTool.name` in the returned list. If the loader raises, the
+error is reported to the model as a tool error and the group stays
+unexpanded.
 
 ## The `load_tools` tool
 

--- a/website/docs/guides/middleware/examples.md
+++ b/website/docs/guides/middleware/examples.md
@@ -353,7 +353,7 @@ cross-process suspend/resume — are in the [HITL guide](../hitl/overview).
 
 ## See also
 
-- [The 7 Hooks](./hooks) — exact semantics of each hook.
+- [The 8 Hooks](./hooks) — exact semantics of each hook.
 - [Composition Rules](./composition) — how multiple middlewares
   combine.
 - [Recipes](../../recipes/weather-agent) — middleware composed into

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json
@@ -23,9 +23,9 @@
     "message": "检查点",
     "description": "The label for category 'Checkpointing' in sidebar 'docs'"
   },
-  "sidebar.docs.category.Middleware": {
+  "sidebar.docs.category.Middlewares": {
     "message": "中间件",
-    "description": "The label for category 'Middleware' in sidebar 'docs'"
+    "description": "The label for category 'Middlewares' in sidebar 'docs'"
   },
   "sidebar.docs.category.Human-in-the-Loop": {
     "message": "人机协同",

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/agents/tool-use.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/agents/tool-use.md
@@ -227,13 +227,21 @@ CubePi 仅在当前批次中 *每个* 工具结果都是 `terminate=True` 时才
 ```python
 from cubepi import Agent
 from cubepi.deferred import DeferredToolGroup
+from cubepi.mcp import load_mcp_tools_stdio
+
+async def load_github_tools():
+    result = await load_mcp_tools_stdio(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+    )
+    return result.tools   # list[AgentTool]
 
 github_group = DeferredToolGroup(
     group_id="mcp:github",
     display_name="GitHub",
     description="Issues, PRs, repos, code search",
     tool_names=["create_issue", "search_repos", "create_pr"],
-    loader=github_mcp.load_tools,
+    loader=load_github_tools,
 )
 
 agent = Agent(
@@ -243,11 +251,16 @@ agent = Agent(
 )
 ```
 
+loader 是一个零参 async 可调用对象，返回 `list[AgentTool]` —— 你可以
+像上面这样包一次 MCP discovery，也可以直接返回你自己写的 `@tool` 装饰
+函数。`tool_names` 里的名字必须和返回的每个工具的 `AgentTool.name`
+完全一致，选择性展开才能找到。
+
 适合 ≥ 5 个工具组、但每次对话通常只用一两组的场景，或者 schema 大到
 足以明显撑大每一轮 system prompt 的情况。每一轮都要全部 tool 的话就
 别用，延迟反而多一次往返。
 
-完整 API、跨 run 恢复以及高级中间件构造器见
+完整 API（含手写工具 loader 示例）、跨 run 恢复、高级中间件构造器见
 [延迟工具组](../middleware/deferred-tools)。
 
 ## 常见坑

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/agents/tool-use.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/agents/tool-use.md
@@ -212,6 +212,44 @@ async def submit_final_answer(tool_call_id, params, *, signal=None, on_update=No
 CubePi 仅在当前批次中 *每个* 工具结果都是 `terminate=True` 时才终止。
 然后循环发 `turn_end`、`agent_end`,退出。
 
+## 工具很多？把 schema 延迟加载
+
+工具集变大——通常是因为你接了好几个 MCP server——所有 JSON schema
+合起来每一轮都会吃掉几千 token 的 system prompt，即使模型这一回合只
+需要其中一两组。这些 schema 还是 prompt cache 的雷区：任何 tool 改动
+都会让之后每一轮的 cache 失效。
+
+`DeferredToolGroup` 的解法是用一份紧凑的目录替代完整 schema。模型看到
+每个组一行描述，需要时通过内置的 `load_tools` 工具按需展开——loader
+跑一次，工具被注入到运行中的 tool 集，schema 追加到 system prompt 末尾
+（append-only，保持 cache 稳定）。
+
+```python
+from cubepi import Agent
+from cubepi.deferred import DeferredToolGroup
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr"],
+    loader=github_mcp.load_tools,
+)
+
+agent = Agent(
+    model=provider.model("claude-sonnet-4-6"),
+    tools=[search_tool, calculator],     # 始终可用
+    deferred_tool_groups=[github_group], # 按需展开
+)
+```
+
+适合 ≥ 5 个工具组、但每次对话通常只用一两组的场景，或者 schema 大到
+足以明显撑大每一轮 system prompt 的情况。每一轮都要全部 tool 的话就
+别用，延迟反而多一次往返。
+
+完整 API、跨 run 恢复以及高级中间件构造器见
+[延迟工具组](../middleware/deferred-tools)。
+
 ## 常见坑
 
 - **忘了 keyword-only 参数** —— 开发时 `execute(tool_call_id, params)`
@@ -236,6 +274,3 @@ CubePi 仅在当前批次中 *每个* 工具结果都是 `terminate=True` 时才
   HTTP 请求的工具,端到端。
 - [MCP 加载](../mcp/loading) —— 一次性把一个 MCP server 的整套工具
   拉下来。
-- [延迟工具组](../middleware/deferred-tools) —— 当多个 MCP server 加起来
-  有几十上百个工具时，可以把 schema 藏在目录后面，让模型通过内置的
-  `load_tools` 工具按需展开。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/agents/tool-use.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/agents/tool-use.md
@@ -236,3 +236,6 @@ CubePi 仅在当前批次中 *每个* 工具结果都是 `terminate=True` 时才
   HTTP 请求的工具,端到端。
 - [MCP 加载](../mcp/loading) —— 一次性把一个 MCP server 的整套工具
   拉下来。
+- [延迟工具组](../middleware/deferred-tools) —— 当多个 MCP server 加起来
+  有几十上百个工具时，可以把 schema 藏在目录后面，让模型通过内置的
+  `load_tools` 工具按需展开。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/mcp/loading.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/mcp/loading.md
@@ -103,6 +103,14 @@ agent = Agent(
 
 模型看到的是合并后的统一 JSON Schema；循环会将每次调用分发给对应的实现。
 
+:::tip MCP server 很多？延迟加载它们
+如果你接了好几个 MCP server、但每次对话只用到其中一两个，把每个 server
+的 schema 全部塞进 system prompt 就成了主要的上下文成本。把每组 tool
+包成一个 [`DeferredToolGroup`](../middleware/deferred-tools)——CubePi 会把
+完整 schema 换成一份紧凑目录，让模型通过内置的 `load_tools` 工具按需
+展开。
+:::
+
 ## 按次连接与复用连接
 
 CubePi 每次 `execute` 调用都会建立新的传输连接。这样做：
@@ -131,3 +139,6 @@ CubePi 每次 `execute` 调用都会建立新的传输连接。这样做：
 - [MCP 认证](./auth) —— Bearer token、请求头、基于环境变量的凭据。
 - [工具使用](../agents/tool-use) —— 工具（MCP 或其他）的分发机制。
 - [`make_mcp_agent_tool` 源码](https://github.com/cubeplexai/cubepi/blob/main/cubepi/mcp/_adapter.py) —— schema → Pydantic 适配器，如需自定义可参考。
+- [延迟工具组](../middleware/deferred-tools) —— 把 MCP schema 从 system
+  prompt 里藏起来，让模型按需展开。当多个 MCP server 加起来构成一个
+  上下文沉重的工具集时很有用。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/middleware/deferred-tools.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/middleware/deferred-tools.md
@@ -40,12 +40,16 @@ to load a group's tools for the rest of this conversation.
 from cubepi import Agent
 from cubepi.deferred import DeferredToolGroup
 
+# load_github_tools / load_linear_tools 是零参 async 可调用对象，
+# 返回 list[AgentTool]。具体怎么写见下面的「编写 loader」一节，
+# 给了 MCP 后端和手写 @tool 函数两种常见形态。
+
 github_group = DeferredToolGroup(
     group_id="mcp:github",
     display_name="GitHub",
     description="Issues, PRs, repos, code search",
     tool_names=["create_issue", "search_repos", "create_pr", "list_comments"],
-    loader=github_mcp.load_tools,  # async () -> list[AgentTool]
+    loader=load_github_tools,
 )
 
 linear_group = DeferredToolGroup(
@@ -53,7 +57,7 @@ linear_group = DeferredToolGroup(
     display_name="Linear",
     description="Project management and issue tracking",
     tool_names=["create_issue", "update_issue", "list_projects"],
-    loader=linear_mcp.load_tools,
+    loader=load_linear_tools,
 )
 
 agent = Agent(
@@ -70,8 +74,77 @@ agent = Agent(
 | `group_id` | `str` | 模型在 `load_tools` 调用里使用的唯一 ID（如 `"mcp:github"`） |
 | `display_name` | `str` | 目录里展示的人类可读名称 |
 | `description` | `str` | 该组能力的一行摘要 |
-| `tool_names` | `list[str]` | 目录里列出的 tool 名 |
+| `tool_names` | `list[str]` | 目录里列出的 tool 名。**必须和 loader 返回的每个工具的 `AgentTool.name` 完全一致** —— 选择性展开（`load_tools(group_id, tool_names=[…])`）就靠这个字段匹配。 |
 | `loader` | `async () -> list[AgentTool]` | 返回该组完整 tool 集的回调 |
+
+### 编写 loader
+
+`loader` 是一个零参 async 可调用对象，返回 `list[AgentTool]`。CubePi
+只看返回类型——里面的 `AgentTool` 怎么来由你决定。两种典型写法：
+
+**从 MCP server 加载。** `load_mcp_tools_stdio` / `load_mcp_tools_http`
+返回 `MCPDiscoveryResult`，里面 `.tools` 字段就是你想要的
+`list[AgentTool]`。包一层：
+
+```python
+from cubepi.deferred import DeferredToolGroup
+from cubepi.mcp import load_mcp_tools_stdio
+
+async def load_github_tools():
+    result = await load_mcp_tools_stdio(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+        env={"GITHUB_TOKEN": "ghp_…"},
+    )
+    return result.tools   # list[AgentTool]
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr"],
+    loader=load_github_tools,
+)
+```
+
+`tool_names` 里写的名字必须和 MCP server 公布的工具名一致——这些名字
+discovery 之后会成为 `AgentTool.name`。如果目录里写 `create_issue` 但
+server 发布的是 `github_create_issue`，选择性展开就匹配不到。
+
+**从手写 `@tool` 函数加载。** 任何被 `@tool` 装饰的函数都是一个
+`AgentTool`（`.name` 默认取函数名，可用 `@tool(name="…")` 覆盖）。
+loader 就是一个返回列表的 async 函数：
+
+```python
+from cubepi import tool
+from cubepi.deferred import DeferredToolGroup
+
+@tool
+async def create_issue(*, repo: str, title: str, body: str) -> str:
+    "Open a GitHub issue."
+    ...
+
+@tool
+async def search_repos(*, query: str) -> str:
+    "Search public repos."
+    ...
+
+async def load_github_tools():
+    return [create_issue, search_repos]   # 已经是 AgentTool
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos"],
+    loader=load_github_tools,
+)
+```
+
+两种可以混用——同一个 list 里既有 MCP 工具又有手写工具——只要
+`tool_names` 里每一个名字都能在返回的 list 里找到对应的
+`AgentTool.name` 就行。如果 loader 抛异常，错误会作为 tool error 回给
+模型，组保持未展开。
 
 ## `load_tools` 工具
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/middleware/examples.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/middleware/examples.md
@@ -279,6 +279,6 @@ agent = Agent(
 
 ## 另请参阅
 
-- [7 个 Hook](./hooks) —— 每个 hook 的精确语义。
+- [8 个 Hook](./hooks) —— 每个 hook 的精确语义。
 - [组合规则](./composition) —— 多个中间件如何组合。
 - [配方](../../recipes/weather-agent) —— 中间件在真实应用中的组合。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.json
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10.json
@@ -23,9 +23,9 @@
     "message": "检查点",
     "description": "The label for category 'Checkpointing' in sidebar 'docs'"
   },
-  "sidebar.docs.category.Middleware": {
+  "sidebar.docs.category.Middlewares": {
     "message": "中间件",
-    "description": "The label for category 'Middleware' in sidebar 'docs'"
+    "description": "The label for category 'Middlewares' in sidebar 'docs'"
   },
   "sidebar.docs.category.Human-in-the-Loop": {
     "message": "人机协同",

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/agents/tool-use.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/agents/tool-use.md
@@ -227,13 +227,21 @@ CubePi 仅在当前批次中 *每个* 工具结果都是 `terminate=True` 时才
 ```python
 from cubepi import Agent
 from cubepi.deferred import DeferredToolGroup
+from cubepi.mcp import load_mcp_tools_stdio
+
+async def load_github_tools():
+    result = await load_mcp_tools_stdio(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+    )
+    return result.tools   # list[AgentTool]
 
 github_group = DeferredToolGroup(
     group_id="mcp:github",
     display_name="GitHub",
     description="Issues, PRs, repos, code search",
     tool_names=["create_issue", "search_repos", "create_pr"],
-    loader=github_mcp.load_tools,
+    loader=load_github_tools,
 )
 
 agent = Agent(
@@ -243,11 +251,16 @@ agent = Agent(
 )
 ```
 
+loader 是一个零参 async 可调用对象，返回 `list[AgentTool]` —— 你可以
+像上面这样包一次 MCP discovery，也可以直接返回你自己写的 `@tool` 装饰
+函数。`tool_names` 里的名字必须和返回的每个工具的 `AgentTool.name`
+完全一致，选择性展开才能找到。
+
 适合 ≥ 5 个工具组、但每次对话通常只用一两组的场景，或者 schema 大到
 足以明显撑大每一轮 system prompt 的情况。每一轮都要全部 tool 的话就
 别用，延迟反而多一次往返。
 
-完整 API、跨 run 恢复以及高级中间件构造器见
+完整 API（含手写工具 loader 示例）、跨 run 恢复、高级中间件构造器见
 [延迟工具组](../middleware/deferred-tools)。
 
 ## 常见坑

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/agents/tool-use.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/agents/tool-use.md
@@ -212,6 +212,44 @@ async def submit_final_answer(tool_call_id, params, *, signal=None, on_update=No
 CubePi 仅在当前批次中 *每个* 工具结果都是 `terminate=True` 时才终止。
 然后循环发 `turn_end`、`agent_end`,退出。
 
+## 工具很多？把 schema 延迟加载
+
+工具集变大——通常是因为你接了好几个 MCP server——所有 JSON schema
+合起来每一轮都会吃掉几千 token 的 system prompt，即使模型这一回合只
+需要其中一两组。这些 schema 还是 prompt cache 的雷区：任何 tool 改动
+都会让之后每一轮的 cache 失效。
+
+`DeferredToolGroup` 的解法是用一份紧凑的目录替代完整 schema。模型看到
+每个组一行描述，需要时通过内置的 `load_tools` 工具按需展开——loader
+跑一次，工具被注入到运行中的 tool 集，schema 追加到 system prompt 末尾
+（append-only，保持 cache 稳定）。
+
+```python
+from cubepi import Agent
+from cubepi.deferred import DeferredToolGroup
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr"],
+    loader=github_mcp.load_tools,
+)
+
+agent = Agent(
+    model=provider.model("claude-sonnet-4-6"),
+    tools=[search_tool, calculator],     # 始终可用
+    deferred_tool_groups=[github_group], # 按需展开
+)
+```
+
+适合 ≥ 5 个工具组、但每次对话通常只用一两组的场景，或者 schema 大到
+足以明显撑大每一轮 system prompt 的情况。每一轮都要全部 tool 的话就
+别用，延迟反而多一次往返。
+
+完整 API、跨 run 恢复以及高级中间件构造器见
+[延迟工具组](../middleware/deferred-tools)。
+
 ## 常见坑
 
 - **忘了 keyword-only 参数** —— 开发时 `execute(tool_call_id, params)`
@@ -236,6 +274,3 @@ CubePi 仅在当前批次中 *每个* 工具结果都是 `terminate=True` 时才
   HTTP 请求的工具,端到端。
 - [MCP 加载](../mcp/loading) —— 一次性把一个 MCP server 的整套工具
   拉下来。
-- [延迟工具组](../middleware/deferred-tools) —— 当多个 MCP server 加起来
-  有几十上百个工具时，可以把 schema 藏在目录后面，让模型通过内置的
-  `load_tools` 工具按需展开。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/agents/tool-use.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/agents/tool-use.md
@@ -236,3 +236,6 @@ CubePi 仅在当前批次中 *每个* 工具结果都是 `terminate=True` 时才
   HTTP 请求的工具,端到端。
 - [MCP 加载](../mcp/loading) —— 一次性把一个 MCP server 的整套工具
   拉下来。
+- [延迟工具组](../middleware/deferred-tools) —— 当多个 MCP server 加起来
+  有几十上百个工具时，可以把 schema 藏在目录后面，让模型通过内置的
+  `load_tools` 工具按需展开。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/mcp/loading.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/mcp/loading.md
@@ -103,6 +103,14 @@ agent = Agent(
 
 模型看到的是合并后的统一 JSON Schema；循环会将每次调用分发给对应的实现。
 
+:::tip MCP server 很多？延迟加载它们
+如果你接了好几个 MCP server、但每次对话只用到其中一两个，把每个 server
+的 schema 全部塞进 system prompt 就成了主要的上下文成本。把每组 tool
+包成一个 [`DeferredToolGroup`](../middleware/deferred-tools)——CubePi 会把
+完整 schema 换成一份紧凑目录，让模型通过内置的 `load_tools` 工具按需
+展开。
+:::
+
 ## 按次连接与复用连接
 
 CubePi 每次 `execute` 调用都会建立新的传输连接。这样做：
@@ -131,3 +139,6 @@ CubePi 每次 `execute` 调用都会建立新的传输连接。这样做：
 - [MCP 认证](./auth) —— Bearer token、请求头、基于环境变量的凭据。
 - [工具使用](../agents/tool-use) —— 工具（MCP 或其他）的分发机制。
 - [`make_mcp_agent_tool` 源码](https://github.com/cubeplexai/cubepi/blob/main/cubepi/mcp/_adapter.py) —— schema → Pydantic 适配器，如需自定义可参考。
+- [延迟工具组](../middleware/deferred-tools) —— 把 MCP schema 从 system
+  prompt 里藏起来，让模型按需展开。当多个 MCP server 加起来构成一个
+  上下文沉重的工具集时很有用。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/middleware/deferred-tools.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/middleware/deferred-tools.md
@@ -40,12 +40,16 @@ to load a group's tools for the rest of this conversation.
 from cubepi import Agent
 from cubepi.deferred import DeferredToolGroup
 
+# load_github_tools / load_linear_tools 是零参 async 可调用对象，
+# 返回 list[AgentTool]。具体怎么写见下面的「编写 loader」一节，
+# 给了 MCP 后端和手写 @tool 函数两种常见形态。
+
 github_group = DeferredToolGroup(
     group_id="mcp:github",
     display_name="GitHub",
     description="Issues, PRs, repos, code search",
     tool_names=["create_issue", "search_repos", "create_pr", "list_comments"],
-    loader=github_mcp.load_tools,  # async () -> list[AgentTool]
+    loader=load_github_tools,
 )
 
 linear_group = DeferredToolGroup(
@@ -53,7 +57,7 @@ linear_group = DeferredToolGroup(
     display_name="Linear",
     description="Project management and issue tracking",
     tool_names=["create_issue", "update_issue", "list_projects"],
-    loader=linear_mcp.load_tools,
+    loader=load_linear_tools,
 )
 
 agent = Agent(
@@ -70,8 +74,77 @@ agent = Agent(
 | `group_id` | `str` | 模型在 `load_tools` 调用里使用的唯一 ID（如 `"mcp:github"`） |
 | `display_name` | `str` | 目录里展示的人类可读名称 |
 | `description` | `str` | 该组能力的一行摘要 |
-| `tool_names` | `list[str]` | 目录里列出的 tool 名 |
+| `tool_names` | `list[str]` | 目录里列出的 tool 名。**必须和 loader 返回的每个工具的 `AgentTool.name` 完全一致** —— 选择性展开（`load_tools(group_id, tool_names=[…])`）就靠这个字段匹配。 |
 | `loader` | `async () -> list[AgentTool]` | 返回该组完整 tool 集的回调 |
+
+### 编写 loader
+
+`loader` 是一个零参 async 可调用对象，返回 `list[AgentTool]`。CubePi
+只看返回类型——里面的 `AgentTool` 怎么来由你决定。两种典型写法：
+
+**从 MCP server 加载。** `load_mcp_tools_stdio` / `load_mcp_tools_http`
+返回 `MCPDiscoveryResult`，里面 `.tools` 字段就是你想要的
+`list[AgentTool]`。包一层：
+
+```python
+from cubepi.deferred import DeferredToolGroup
+from cubepi.mcp import load_mcp_tools_stdio
+
+async def load_github_tools():
+    result = await load_mcp_tools_stdio(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+        env={"GITHUB_TOKEN": "ghp_…"},
+    )
+    return result.tools   # list[AgentTool]
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr"],
+    loader=load_github_tools,
+)
+```
+
+`tool_names` 里写的名字必须和 MCP server 公布的工具名一致——这些名字
+discovery 之后会成为 `AgentTool.name`。如果目录里写 `create_issue` 但
+server 发布的是 `github_create_issue`，选择性展开就匹配不到。
+
+**从手写 `@tool` 函数加载。** 任何被 `@tool` 装饰的函数都是一个
+`AgentTool`（`.name` 默认取函数名，可用 `@tool(name="…")` 覆盖）。
+loader 就是一个返回列表的 async 函数：
+
+```python
+from cubepi import tool
+from cubepi.deferred import DeferredToolGroup
+
+@tool
+async def create_issue(*, repo: str, title: str, body: str) -> str:
+    "Open a GitHub issue."
+    ...
+
+@tool
+async def search_repos(*, query: str) -> str:
+    "Search public repos."
+    ...
+
+async def load_github_tools():
+    return [create_issue, search_repos]   # 已经是 AgentTool
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos"],
+    loader=load_github_tools,
+)
+```
+
+两种可以混用——同一个 list 里既有 MCP 工具又有手写工具——只要
+`tool_names` 里每一个名字都能在返回的 list 里找到对应的
+`AgentTool.name` 就行。如果 loader 抛异常，错误会作为 tool error 回给
+模型，组保持未展开。
 
 ## `load_tools` 工具
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/middleware/examples.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.10/guides/middleware/examples.md
@@ -279,6 +279,6 @@ agent = Agent(
 
 ## 另请参阅
 
-- [7 个 Hook](./hooks) —— 每个 hook 的精确语义。
+- [8 个 Hook](./hooks) —— 每个 hook 的精确语义。
 - [组合规则](./composition) —— 多个中间件如何组合。
 - [配方](../../recipes/weather-agent) —— 中间件在真实应用中的组合。

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -39,15 +39,15 @@ const sidebars: SidebarsConfig = {
           'guides/checkpointing/mysql',
           'guides/checkpointing/custom',
         ]},
-        { type: 'category', label: 'Middleware', items: [
+        { type: 'category', label: 'Middlewares', items: [
           'guides/middleware/hooks',
           'guides/middleware/composition',
-          'guides/middleware/examples',
           'guides/middleware/compaction',
           'guides/middleware/subagents',
           'guides/middleware/todo',
           'guides/middleware/deferred-tools',
           'guides/middleware/goal',
+          'guides/middleware/examples',
         ]},
         { type: 'category', label: 'Human-in-the-Loop', items: [
           'guides/hitl/overview',

--- a/website/versioned_docs/version-0.10/guides/agents/tool-use.md
+++ b/website/versioned_docs/version-0.10/guides/agents/tool-use.md
@@ -245,13 +245,21 @@ their schemas are appended (append-only, for cache stability).
 ```python
 from cubepi import Agent
 from cubepi.deferred import DeferredToolGroup
+from cubepi.mcp import load_mcp_tools_stdio
+
+async def load_github_tools():
+    result = await load_mcp_tools_stdio(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+    )
+    return result.tools   # list[AgentTool]
 
 github_group = DeferredToolGroup(
     group_id="mcp:github",
     display_name="GitHub",
     description="Issues, PRs, repos, code search",
     tool_names=["create_issue", "search_repos", "create_pr"],
-    loader=github_mcp.load_tools,
+    loader=load_github_tools,
 )
 
 agent = Agent(
@@ -261,13 +269,19 @@ agent = Agent(
 )
 ```
 
+The loader is a zero-arg async callable returning `list[AgentTool]` —
+wrap an MCP discovery call (as above), or just return your own
+`@tool`-decorated functions. The names in `tool_names` must match each
+tool's `AgentTool.name` so selective expansion can find them.
+
 Good fit when you have ≥5 tool groups but typically only use one or
 two per conversation, or when schemas are large enough to noticeably
 inflate every system prompt. Skip it when all the tools are needed on
 every turn — deferring just adds a round trip.
 
 See [Deferred Tool Groups](../middleware/deferred-tools) for the full
-API, cross-run replay, and the advanced middleware constructor.
+API (including a hand-written-tools loader example), cross-run replay,
+and the advanced middleware constructor.
 
 ## Common pitfalls
 

--- a/website/versioned_docs/version-0.10/guides/agents/tool-use.md
+++ b/website/versioned_docs/version-0.10/guides/agents/tool-use.md
@@ -227,6 +227,48 @@ CubePi only terminates if *every* tool result in the current batch is
 `terminate=True`. The agent loop emits `turn_end`, then `agent_end`,
 and exits.
 
+## Many tools? Defer their schemas
+
+When the toolbelt grows — usually because you've wired up several MCP
+servers — the combined JSON schemas can consume thousands of tokens of
+system prompt on every turn, even though the model only needs one or
+two groups for the current task. The schemas are also a prompt-cache
+landmine: any tool change anywhere invalidates the cache for every
+turn that follows.
+
+`DeferredToolGroup` solves this by replacing the full schemas with a
+compact catalog. The model sees a one-line description per group and
+expands a group on demand via the built-in `load_tools` tool — the
+loader runs once, the tools are injected into the live tool set, and
+their schemas are appended (append-only, for cache stability).
+
+```python
+from cubepi import Agent
+from cubepi.deferred import DeferredToolGroup
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr"],
+    loader=github_mcp.load_tools,
+)
+
+agent = Agent(
+    model=provider.model("claude-sonnet-4-6"),
+    tools=[search_tool, calculator],     # always-available
+    deferred_tool_groups=[github_group], # expanded on demand
+)
+```
+
+Good fit when you have ≥5 tool groups but typically only use one or
+two per conversation, or when schemas are large enough to noticeably
+inflate every system prompt. Skip it when all the tools are needed on
+every turn — deferring just adds a round trip.
+
+See [Deferred Tool Groups](../middleware/deferred-tools) for the full
+API, cross-run replay, and the advanced middleware constructor.
+
 ## Common pitfalls
 
 - **Forgetting the keyword-only args** — `execute(tool_call_id,
@@ -255,7 +297,3 @@ and exits.
   HTTP-calling tool, end-to-end.
 - [MCP Loading](../mcp/loading) — pull an entire toolset off an MCP
   server in one call.
-- [Deferred Tool Groups](../middleware/deferred-tools) — when the
-  combined tool list across several MCP servers is dozens or hundreds
-  of tools, hide the schemas behind a catalog and let the model expand
-  groups on demand via the built-in `load_tools` tool.

--- a/website/versioned_docs/version-0.10/guides/agents/tool-use.md
+++ b/website/versioned_docs/version-0.10/guides/agents/tool-use.md
@@ -255,3 +255,7 @@ and exits.
   HTTP-calling tool, end-to-end.
 - [MCP Loading](../mcp/loading) — pull an entire toolset off an MCP
   server in one call.
+- [Deferred Tool Groups](../middleware/deferred-tools) — when the
+  combined tool list across several MCP servers is dozens or hundreds
+  of tools, hide the schemas behind a catalog and let the model expand
+  groups on demand via the built-in `load_tools` tool.

--- a/website/versioned_docs/version-0.10/guides/mcp/loading.md
+++ b/website/versioned_docs/version-0.10/guides/mcp/loading.md
@@ -119,6 +119,15 @@ agent = Agent(
 The model sees one combined JSON Schema; the loop dispatches each
 call to the right implementation.
 
+:::tip Many MCP servers? Defer them.
+If you wire up several MCP servers and only a few are needed per
+conversation, eagerly loading every schema into the system prompt
+becomes the dominant context cost. Wrap each server's tools in a
+[`DeferredToolGroup`](../middleware/deferred-tools) — CubePi replaces
+the full schemas with a compact catalog and lets the model expand a
+group on demand via the built-in `load_tools` tool.
+:::
+
 ## Per-call vs reusable connections
 
 CubePi opens a new transport per `execute` call. That's:
@@ -166,3 +175,7 @@ downstream programmatic access, but not shown to the model.
   dispatched.
 - [`make_mcp_agent_tool` source](https://github.com/cubeplexai/cubepi/blob/main/cubepi/mcp/_adapter.py)
   — the schema → Pydantic adapter, if you need to customise.
+- [Deferred Tool Groups](../middleware/deferred-tools) — hide MCP
+  schemas from the system prompt and let the model expand them on
+  demand. Useful when several MCP servers add up to a context-heavy
+  toolbelt.

--- a/website/versioned_docs/version-0.10/guides/middleware/deferred-tools.md
+++ b/website/versioned_docs/version-0.10/guides/middleware/deferred-tools.md
@@ -41,12 +41,16 @@ automatically — no manual wiring needed:
 from cubepi import Agent
 from cubepi.deferred import DeferredToolGroup
 
+# load_github_tools / load_linear_tools are zero-arg async callables
+# returning list[AgentTool]. See "Writing a loader" below for the two
+# common shapes (MCP-backed and hand-written @tool functions).
+
 github_group = DeferredToolGroup(
     group_id="mcp:github",
     display_name="GitHub",
     description="Issues, PRs, repos, code search",
     tool_names=["create_issue", "search_repos", "create_pr", "list_comments"],
-    loader=github_mcp.load_tools,  # async () -> list[AgentTool]
+    loader=load_github_tools,
 )
 
 linear_group = DeferredToolGroup(
@@ -54,7 +58,7 @@ linear_group = DeferredToolGroup(
     display_name="Linear",
     description="Project management and issue tracking",
     tool_names=["create_issue", "update_issue", "list_projects"],
-    loader=linear_mcp.load_tools,
+    loader=load_linear_tools,
 )
 
 agent = Agent(
@@ -71,8 +75,81 @@ agent = Agent(
 | `group_id` | `str` | Unique identifier the model uses in `load_tools` calls (e.g. `"mcp:github"`) |
 | `display_name` | `str` | Human-readable label shown in the catalog |
 | `description` | `str` | One-line summary of the group's capabilities |
-| `tool_names` | `list[str]` | Tool names shown in the catalog |
+| `tool_names` | `list[str]` | Tool names shown in the catalog. **Must match the `AgentTool.name` of each tool the loader returns** — selective expansion (`load_tools(group_id, tool_names=[…])`) matches on this. |
 | `loader` | `async () -> list[AgentTool]` | Callback that returns the full tool set for this group |
+
+### Writing a loader
+
+The loader is a zero-argument async callable that returns
+`list[AgentTool]`. CubePi only cares about its return type — where the
+`AgentTool` objects come from is up to you. Two common shapes:
+
+**From an MCP server.** `load_mcp_tools_stdio` / `load_mcp_tools_http`
+return an `MCPDiscoveryResult` whose `.tools` is the `list[AgentTool]`
+you want. Wrap it:
+
+```python
+from cubepi.deferred import DeferredToolGroup
+from cubepi.mcp import load_mcp_tools_stdio
+
+async def load_github_tools():
+    result = await load_mcp_tools_stdio(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-github"],
+        env={"GITHUB_TOKEN": "ghp_…"},
+    )
+    return result.tools   # list[AgentTool]
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos", "create_pr"],
+    loader=load_github_tools,
+)
+```
+
+The names in `tool_names` must match the MCP server's tool names —
+those become `AgentTool.name` after discovery. If the catalog lists
+`create_issue` but the server publishes it as `github_create_issue`,
+selective expansion misses.
+
+**From hand-written `@tool` functions.** Any function decorated with
+`@tool` produces an `AgentTool` (its `.name` defaults to the function
+name, overridable via `@tool(name="…")`). A loader for hand-written
+tools is just `async lambda` over a list:
+
+```python
+from cubepi import tool
+from cubepi.deferred import DeferredToolGroup
+
+@tool
+async def create_issue(*, repo: str, title: str, body: str) -> str:
+    "Open a GitHub issue."
+    ...
+
+@tool
+async def search_repos(*, query: str) -> str:
+    "Search public repos."
+    ...
+
+async def load_github_tools():
+    return [create_issue, search_repos]   # already AgentTools
+
+github_group = DeferredToolGroup(
+    group_id="mcp:github",
+    display_name="GitHub",
+    description="Issues, PRs, repos, code search",
+    tool_names=["create_issue", "search_repos"],
+    loader=load_github_tools,
+)
+```
+
+You can mix the two — return MCP tools and hand-written tools in the
+same list — as long as every name in `tool_names` matches an
+`AgentTool.name` in the returned list. If the loader raises, the
+error is reported to the model as a tool error and the group stays
+unexpanded.
 
 ## The `load_tools` tool
 

--- a/website/versioned_docs/version-0.10/guides/middleware/examples.md
+++ b/website/versioned_docs/version-0.10/guides/middleware/examples.md
@@ -353,7 +353,7 @@ cross-process suspend/resume — are in the [HITL guide](../hitl/overview).
 
 ## See also
 
-- [The 7 Hooks](./hooks) — exact semantics of each hook.
+- [The 8 Hooks](./hooks) — exact semantics of each hook.
 - [Composition Rules](./composition) — how multiple middlewares
   combine.
 - [Recipes](../../recipes/weather-agent) — middleware composed into

--- a/website/versioned_sidebars/version-0.10-sidebars.json
+++ b/website/versioned_sidebars/version-0.10-sidebars.json
@@ -51,16 +51,16 @@
         },
         {
           "type": "category",
-          "label": "Middleware",
+          "label": "Middlewares",
           "items": [
             "guides/middleware/hooks",
             "guides/middleware/composition",
-            "guides/middleware/examples",
             "guides/middleware/compaction",
             "guides/middleware/subagents",
             "guides/middleware/todo",
             "guides/middleware/deferred-tools",
-            "guides/middleware/goal"
+            "guides/middleware/goal",
+            "guides/middleware/examples"
           ]
         },
         {


### PR DESCRIPTION
## Summary

Four small post-0.10 cleanups to the middleware docs, all on the same branch.

### 1. Sidebar: `Middleware` → `Middlewares`, move Examples last
- `website/sidebars.ts`: rename category label, drop `Examples` to the end of the items list (after `goal`).
- `website/versioned_sidebars/version-0.10-sidebars.json`: same change applied to the released-version sidebar.
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current.json` and `version-0.10.json`: rename translation key `sidebar.docs.category.Middleware` → `sidebar.docs.category.Middlewares` (zh-Hans label `中间件` is unchanged — Chinese doesn't pluralise).

### 2. Examples page still said `[The 7 Hooks]`
The hook count rose to 8 a while back; the "See also" link on
`guides/middleware/examples.md` had drifted. Fixed in all four copies (EN + zh-Hans, `current/` + `version-0.10/`).

### 3. Cross-link `DeferredToolGroup` from Agents and MCP

`DeferredToolGroup` shipped in 0.10 but was only discoverable from the Middleware section. Added cross-references where users most likely run into the problem it solves:

- **`guides/agents/tool-use.md`** — new "See also" bullet pointing at `../middleware/deferred-tools`, framed as the answer when "the combined tool list across several MCP servers is dozens or hundreds of tools".
- **`guides/mcp/loading.md`** — `:::tip` callout right after "Mixing MCP tools with hand-written tools", plus a "See also" entry.

Applied to EN + zh-Hans `current/` and mirrored into the `version-0.10` snapshot (EN + zh-Hans) so released docs carry the same cross-references.

### Confirmed: deferred-tools is already in the sidebar
`guides/middleware/deferred-tools` is wired into `sidebars.ts` line 49 (and the matching version-0.10 snapshot at line 62).

## Test plan

- [x] `cd website && pnpm build` — EN + zh-Hans build with no broken-link errors.
- [x] No stale `"7 Hooks"` / `"7 个 Hook"` matches anywhere in `website/docs`, `website/versioned_docs/version-0.10`, or the zh-Hans mirrors.
- [ ] Eyeball the rendered sidebar: `Middlewares > … > Examples` (Examples last), `中间件 > … > 示例`.