### PR TITLE
fix(docs): remove stale (latest) labels from Chinese 0.7 and 0.8 versions

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.7.json
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.7.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "0.7（最新）",
+    "message": "0.7",
     "description": "The label for version 0.7"
   },
   "sidebar.docs.category.Getting Started": {

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.8.json
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.8.json
@@ -1,6 +1,6 @@
 {
   "version.label": {
-    "message": "0.8（最新）",
+    "message": "0.8",
     "description": "The label for version 0.8"
   },
   "sidebar.docs.category.Getting Started": {


### PR DESCRIPTION
Fixes stale '(最新)' labels in the Chinese version doc strings that were left over from previous releases.

Only 0.11 should be marked as the latest version.