### PR TITLE
fix(apiref): wrap long signatures, drop self from class constructors

### DIFF
--- a/website/scripts/build_api_reference.py
+++ b/website/scripts/build_api_reference.py
@@ -469,9 +469,19 @@ def render_signature(name: str, parameters: list, returns: str | None) -> str:
             rendered += f" = {pdefault}"
         parts.append(rendered)
 
-    sig = f"{name}({', '.join(parts)})"
-    if returns:
-        sig += f" -> {returns}"
+    ret_suffix = f" -> {returns}" if returns else ""
+
+    # Single line when it comfortably fits; otherwise fall back to a
+    # black-style multiline layout (one parameter per indented line) so
+    # wide constructors like Agent(...) stay readable instead of
+    # overflowing as one giant line in the rendered code block.
+    single = f"{name}({', '.join(parts)}){ret_suffix}"
+    if len(single) <= 88 or not parts:
+        sig = single
+    else:
+        body = ",\n".join(f"    {part}" for part in parts)
+        sig = f"{name}(\n{body},\n){ret_suffix}"
+
     return f"```python\n{sig}\n```"
 
 
@@ -651,7 +661,10 @@ def render_symbol(
     if kind == "attribute":
         _render_attribute_symbol(symbol, ref_index, block)
     else:
-        params = _params_of(symbol)
+        # Classes render their __init__ signature; drop the leading
+        # ``self`` just like methods do (users call ``Agent(model=...)``,
+        # never pass ``self``).
+        params = _params_of(symbol, skip_self=(kind == "class"))
         returns = str(symbol.returns) if getattr(symbol, "returns", None) else None
         if params or returns:
             block.append(render_signature(name, params, returns))


### PR DESCRIPTION
## 问题

生成的 API 文档里：
1. 宽签名（如 `Agent` 25+ 参数构造）渲染成一条超长单行，溢出代码块、无法阅读。
2. 类构造签名漏出了 `self`（用户调用是 `Agent(model=...)`，从不传 self）。

## 修复

- `render_signature`：单行超过 88 字符时，回退为 black 风格的多行布局（每参数一行、4 空格缩进）；短签名仍保持单行。
- 类构造跳过 `self`，与方法的渲染方式一致。

仅改生成脚本（生成的 `docs/api/*.mdx` 已 gitignore，构建时由 prebuild 重新生成）。本地 `pnpm build` 通过（EN + zh-Hans 全绿）。