### PR TITLE
chore(release): 0.13.2 - record gen_ai.output.messages on the chat span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-07-23
+
+### Fixed
+
+- **`gen_ai.output.messages` now recorded on the `chat` span.** Per the
+  tracing design spec (§10.3/§10.5), the provider-level `chat` span's
+  `gen_ai.output.messages` should reflect what the provider actually
+  returned - independent of the turn/agent-level rollup. A code comment
+  in `_on_provider_response` already claimed it would record "the
+  normalized output messages where derivable", but only
+  `cubepi.llm.raw_response` was ever set on this span;
+  `gen_ai.output.messages` was written only on `invoke_agent` and
+  `cubepi.turn`. The recorder now reconstructs the semconv
+  output-message parts (text / reasoning / tool_call) directly from the
+  assembled response body via a new `_derive_output_message_from_body()`
+  helper, mirroring the existing three-way provider-shape dispatch
+  (Anthropic-shaped, OpenAI `chat.completion`-shaped, OpenAI
+  Responses-shaped). Unrecognized shapes or empty content set nothing,
+  identical to prior behavior (no regression).
+
 ## [0.13.1] - 2026-07-15
 
 ### Fixed
@@ -695,7 +715,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.2.0]** - 2026-05-10 — see the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.2.0).
 - **[0.1.0]** - 2026-05-09 — initial release. See the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/cubeplexai/cubepi/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/cubeplexai/cubepi/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/cubeplexai/cubepi/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/cubeplexai/cubepi/compare/v0.11.0...v0.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cubepi"
-version = "0.13.1"
+version = "0.13.2"
 description = "Pythonic async-native agent framework"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- **`gen_ai.output.messages` on the `chat` span** - per the tracing design spec (§10.3/§10.5), the provider-level `chat` span now records `gen_ai.output.messages` reflecting what the provider actually returned, independent of the turn/agent-level rollup. Previously only `cubepi.llm.raw_response` was set on this span; `gen_ai.output.messages` was written only on `invoke_agent` and `cubepi.turn`. A new `_derive_output_message_from_body()` reconstructs the semconv output-message parts (text / reasoning / tool_call) directly from the assembled response body, mirroring the existing three-way provider-shape dispatch (Anthropic-shaped, OpenAI `chat.completion`-shaped, OpenAI Responses-shaped). Unrecognized shapes set nothing - no regression.

Patch release on the 0.13 line - no docs version snapshot cut (mirrors 0.13.1).

## Commits

- `c8fde15` `chore(release): prepare 0.13.2 - bump version and changelog`

(Fix landed on main before this prep branch: `4546104`)

## Test plan

- [ ] CI passes (pytest + ruff + mypy on Python 3.11–3.14)
- [ ] `tests/tracing/test_recorder.py::TestChatSpanOutputMessages` covers all three provider shapes + the unrecognized-shape no-op
- [ ] Version picker shows `0.13.2` after merge + tag