### PR TITLE
chore(release): prepare 0.13.3 — OpenAI effort mapping + live tool-result run_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.3] - 2026-08-02
+
 ### Fixed
 
 - **OpenAI `chat_completions`/`responses` capability profiles no longer emit
@@ -15,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now-stale `"minimal"` value outright. The built-in "off" mode payload and
   the `minimal` → wire-value mapping in `_OPENAI_EFFORT_VALUES` both now emit
   `"none"`.
+- **Live `ToolResultMessage`s now carry the owning turn's `run_id`.** On a
+  run-aware Agent, tool results emitted during the live turn (events, hooks,
+  live context, and the next provider call) previously had `run_id=None`
+  while the checkpointer copy was stamped correctly. The assistant message is
+  now stamped in place at the message-end seam so tool-result construction
+  can inherit the active run ID for every sequential, parallel, salvage, and
+  HITL-sibling outcome. Direct `execute_tool_calls` with an unstamped
+  assistant still produces `run_id=None`.
 
 ## [0.13.2] - 2026-07-23
 
@@ -724,7 +734,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.2.0]** - 2026-05-10 — see the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.2.0).
 - **[0.1.0]** - 2026-05-09 — initial release. See the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.2...HEAD
+[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.3...HEAD
+[0.13.3]: https://github.com/cubeplexai/cubepi/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/cubeplexai/cubepi/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/cubeplexai/cubepi/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/cubeplexai/cubepi/compare/v0.12.0...v0.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cubepi"
-version = "0.13.2"
+version = "0.13.3"
 description = "Pythonic async-native agent framework"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "cubepi"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Patch release **0.13.3** — version bump and changelog only (no docs snapshot; same minor line as 0.13).

Covers two fixes merged after `v0.13.2`:

1. **OpenAI `reasoning_effort`**: stop emitting stale `"minimal"`; built-in off mode and the `minimal` → wire mapping now emit `"none"` (gpt-5.5+ / OpenAI-compatible proxies).
2. **Live tool-result `run_id`**: run-aware Agents stamp the assistant turn in place so live `ToolResultMessage`s inherit the owning `run_id` (events, hooks, live context, next provider call). Checkpointed path was already correct.

## Changes

- `pyproject.toml` / `uv.lock`: `0.13.2` → `0.13.3`
- `CHANGELOG.md`: new `## [0.13.3] - 2026-08-02` section + compare links

## After merge

1. Create GitHub release `v0.13.3` from `main` (triggers `publish.yml` → TestPyPI → PyPI).
2. No docs version cut (patch within existing `0.13` snapshot).

## Test plan

- [ ] CI green (pytest / ruff / mypy)
- [ ] Changelog entries match the two post-0.13.2 commits
- [ ] After merge: publish GitHub release `v0.13.3` and confirm PyPI upload