### PR TITLE
fix(tracing): classify durable HITL pauses and gate raw diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   turn, chat, and tool spans end with `cubepi.run.outcome="suspended"`; observer
   failures cannot hide the terminal event, cancellation still propagates, and
   `respond()` opens a distinct correlated activation trace.
+- **Raw provider error details now follow the content-recording opt-in.** With
+  `record_content=False`, traces retain typed error classification and ERROR
+  status but use bounded generic descriptions and omit exception messages and
+  stack traces. `record_content=True` preserves the prior diagnostic detail.
 
 ## [0.13.3] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   turn, chat, and tool spans end with `cubepi.run.outcome="suspended"`; observer
   failures cannot hide the terminal event, cancellation still propagates, and
   `respond()` opens a distinct correlated activation trace.
-- **Raw provider error details now follow the content-recording opt-in.** With
-  `record_content=False`, traces retain typed error classification and ERROR
-  status but use bounded generic descriptions and omit exception messages and
-  stack traces. `record_content=True` preserves the prior diagnostic detail.
+- **Raw tracing diagnostics now follow the content-recording opt-in.** With
+  `record_content=False`, provider, turn, one-shot, and MCP spans retain typed
+  error classification and ERROR status but use bounded generic descriptions
+  and omit exception messages and stack traces. Stream logs retain structural
+  timing/size fields while omitting tool-argument previews and raw error text.
+  `record_content=True` preserves the prior diagnostic detail for failures.
+- **One-shot cancellation now matches Agent and MCP cancellation semantics.** It
+  records `cubepi.aborted=true` with status UNSET and does not emit an exception
+  event, because cancellation is a control signal rather than a failure.
 
 ## [0.13.3] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Durable HITL pauses now finalize traces as suspended rather than aborted.**
+  `Agent.detach()` commits the pending request first, then the owning activation
+  emits a terminal suspension event after runtime-state cleanup. Open agent,
+  turn, chat, and tool spans end with `cubepi.run.outcome="suspended"`; observer
+  failures cannot hide the terminal event, cancellation still propagates, and
+  `respond()` opens a distinct correlated activation trace.
+
 ## [0.13.3] - 2026-08-02
 
 ### Fixed

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -50,6 +50,13 @@ from cubepi.types import JsonObject, StructuredValue
 
 TMessage = TypeVar("TMessage")
 
+
+def _consume_control_exception(future: asyncio.Future[StructuredValue]) -> None:
+    """Mark a detach control exception retrieved without changing awaiters."""
+    if not future.cancelled():
+        future.exception()
+
+
 if TYPE_CHECKING:
     from cubepi.deferred.types import DeferredStrategy, DeferredToolGroup
     from cubepi.providers.fallback import FallbackBoundModel
@@ -287,6 +294,7 @@ class Agent(Generic[TMessage]):
             and hasattr(self.checkpointer, "mark_run_complete")
         )
         self._channel = channel
+        self._pending_suspension_event: HitlRequest | None = None
         # _bind_emit is a _BaseChannel internal, not part of the HitlChannel
         # protocol. Third-party channels that only implement the public
         # protocol won't have it — skip the wiring instead of crashing.
@@ -383,6 +391,19 @@ class Agent(Generic[TMessage]):
                 run_id=run_id,
                 cause=exc,
             ) from exc
+
+    async def _emit_suspended_event(self, outcome: RunOutcome) -> None:
+        """Publish suspension only after the run transition is committed."""
+        if outcome != "suspended":
+            self._pending_suspension_event = None
+            return
+        pending = self._pending_suspension_event
+        if pending is None:
+            return
+        self._pending_suspension_event = None
+        from cubepi.agent.types import AgentSuspendedEvent
+
+        await self._process_event(AgentSuspendedEvent(pending_request=pending))
 
     def _validate_hitl_bindings(self, run_id: str | None, *, caller: str) -> None:
         """Reject HITL-bound tools/middleware that disagree with `run_id`.
@@ -518,6 +539,7 @@ class Agent(Generic[TMessage]):
                 await self._run_prompt(messages)
         except BaseException:
             # Spec §3.7: leave active_run_id SET on failure.
+            self._pending_suspension_event = None
             raise
         else:
             outcome: RunOutcome = self._state.last_outcome or "abandoned"
@@ -526,6 +548,7 @@ class Agent(Generic[TMessage]):
             # the clear line below is unreachable on the exception path.
             await self._dispatch_outcome(outcome, effective_run_id)
             self._state.active_run_id = None
+            await self._emit_suspended_event(outcome)
             return effective_run_id
 
     async def fork(
@@ -723,11 +746,13 @@ class Agent(Generic[TMessage]):
         except BaseException:
             # Spec §3.7 parity: leave active_run_id SET on failure so callers
             # can observe which run failed.
+            self._pending_suspension_event = None
             raise
         else:
             outcome: RunOutcome = self._state.last_outcome or "abandoned"
             await self._dispatch_outcome(outcome, effective_run_id)
             self._state.active_run_id = None
+            await self._emit_suspended_event(outcome)
             return effective_run_id
 
     def _build_stream_options(self, signal: asyncio.Event) -> StreamOptions:
@@ -803,8 +828,6 @@ class Agent(Generic[TMessage]):
         )
 
     async def detach(self) -> None:
-        from cubepi.agent.types import AgentSuspendedEvent
-
         if self._channel is None:
             raise HitlError("agent has no channel bound")
         pending = self._channel.pending
@@ -814,11 +837,14 @@ class Agent(Generic[TMessage]):
             or self._channel._future.done()
         ):
             return  # nothing to detach
-        # Emit the suspended event BEFORE triggering the exception, so listeners
-        # see the real pending payload (codex pass 2 BLOCKING: previous draft
-        # emitted from the loop with pending=None — fundamentally wrong).
-        await self._process_event(AgentSuspendedEvent(pending_request=pending))
-        self._channel._future.set_exception(HitlDetached())
+        # Snapshot the payload before the channel clears its in-memory pending slot,
+        # then commit the control-flow transition. The owning prompt/resume task
+        # publishes AgentSuspendedEvent only after it records the suspended outcome
+        # and clears active_run_id, so observers cannot report an uncommitted pause.
+        self._pending_suspension_event = pending
+        future = self._channel._future
+        future.add_done_callback(_consume_control_exception)
+        future.set_exception(HitlDetached())
 
     async def load_pending_hitl_request(self) -> HitlRequest | None:
         if self.checkpointer is None or self.thread_id is None:
@@ -898,14 +924,16 @@ class Agent(Generic[TMessage]):
                 await self._run_hitl_resume()
             except BaseException:
                 # Spec §3.7: leave active_run_id SET on raise.
+                self._pending_suspension_event = None
                 raise
             else:
                 # Legacy guard: pending persisted without run_id (older
                 # save_pending_request callers) cannot drive dispatch.
+                outcome: RunOutcome = self._state.last_outcome or "abandoned"
                 if recovered_run_id is not None:
-                    outcome: RunOutcome = self._state.last_outcome or "abandoned"
                     await self._dispatch_outcome(outcome, recovered_run_id)
                 self._state.active_run_id = None
+                await self._emit_suspended_event(outcome)
 
     async def abort_pending(
         self, reason: str = "aborted by host"
@@ -1233,7 +1261,23 @@ class Agent(Generic[TMessage]):
         await self._emit_to_listeners(event)
 
     async def _emit_to_listeners(self, event: AgentEvent) -> None:
-        for listener in self._listeners:
-            result = listener(event, self._active_signal)
-            if asyncio.iscoroutine(result):
-                await result
+        cancellation: asyncio.CancelledError | None = None
+        first_error: Exception | None = None
+        for listener in tuple(self._listeners):
+            try:
+                result = listener(event, self._active_signal)
+                if asyncio.iscoroutine(result):
+                    await result
+            except asyncio.CancelledError as exc:
+                if cancellation is None:
+                    cancellation = exc
+            except Exception as exc:
+                # One observer must not hide an event from later observers.
+                # Preserve existing error propagation after every listener had
+                # the chance to see the same committed state transition.
+                if first_error is None:
+                    first_error = exc
+        if cancellation is not None:
+            raise cancellation
+        if first_error is not None:
+            raise first_error

--- a/cubepi/mcp/_tracing.py
+++ b/cubepi/mcp/_tracing.py
@@ -65,18 +65,17 @@ except ImportError:  # pragma: no cover — exercised only without the extra.
 # multiple agents (each attach pushes a token; each detach pops just
 # its own entry) and supports detaches in any order without clearing
 # routing for the still-attached agents.
-_provider_stack: list[tuple[object, Any]] = []
+_provider_stack: list[tuple[object, Any, bool]] = []
 
 
-def register_provider(provider: Any) -> object:
-    """Push ``provider`` onto the routing stack as the preferred source
-    for MCP spans. Returns an opaque token that
-    :func:`unregister_provider` uses to remove this exact entry.
+def register_provider(provider: Any, *, record_content: bool = False) -> object:
+    """Push ``provider`` and its content policy onto the routing stack.
 
-    Called by :meth:`cubepi.tracing.Tracer.attach`.
+    Returns an opaque token that :func:`unregister_provider` uses to remove
+    this exact entry. Called by :meth:`cubepi.tracing.Tracer.attach`.
     """
     token = object()
-    _provider_stack.append((token, provider))
+    _provider_stack.append((token, provider, record_content))
     return token
 
 
@@ -93,26 +92,28 @@ def unregister_provider(token: object | None = None) -> None:
     if token is None:
         _provider_stack.pop()
         return
-    for i, (t, _p) in enumerate(_provider_stack):
+    for i, (t, _p, _record_content) in enumerate(_provider_stack):
         if t is token:
             _provider_stack.pop(i)
             return
 
 
-def _get_tracer(scope_name: str) -> Any:
-    """Resolve the tracer to use for emitting an MCP span.
-
-    Prefers the most recently-registered provider over OTel's global
-    default (which is a no-op unless the user separately called
-    ``set_tracer_provider``).
-    """
+def _get_tracer_route(scope_name: str) -> tuple[Any, bool]:
+    """Resolve the tracer and content policy for an MCP span."""
     if _provider_stack:
-        return _provider_stack[-1][1].get_tracer(scope_name)
-    return _otel_trace.get_tracer(scope_name)
+        _token, provider, record_content = _provider_stack[-1]
+        return provider.get_tracer(scope_name), record_content
+    return _otel_trace.get_tracer(scope_name), False
+
+
+def _get_tracer(scope_name: str) -> Any:
+    """Resolve the tracer to use for emitting an MCP span."""
+    tracer, _record_content = _get_tracer_route(scope_name)
+    return tracer
 
 
 # When the cubepi Recorder opens an ``execute_tool`` span, it publishes
-# ``(span, owning_provider)`` here so an MCP tool call running inside
+# ``(span, owning_provider, record_content)`` here so an MCP tool call running inside
 # the AgentTool body can make its CLIENT span a child of this span
 # (rather than starting an orphan root trace — recorder doesn't bother
 # installing ``execute_tool`` as the OTel current span; see
@@ -122,7 +123,7 @@ def _get_tracer(scope_name: str) -> Any:
 #
 # Lookup uses a per-task ``ContextVar`` holding a STACK of opaque
 # handles (outermost first, innermost last), with the actual
-# ``(span, provider)`` payload stored in a module-level
+# ``(span, provider, record_content)`` payload stored in a module-level
 # ``_active_entries`` dict. The dict is the source of truth for which
 # handles are still live; the contextvar stack records nesting order
 # per task.
@@ -148,9 +149,12 @@ def _get_tracer(scope_name: str) -> Any:
 # is found. Dead handles linger only in a task's local stack tuple and
 # are GC'd when that task ends; ``_active_entries`` stays bounded by
 # live registrations.
-_active_entries: dict[object, tuple[Any, Any]] = {}
+_active_entries: dict[object, tuple[Any, Any, bool]] = {}
 _handle_stack: contextvars.ContextVar[tuple[object, ...]] = contextvars.ContextVar(
     "_cubepi_mcp_tool_handle_stack", default=()
+)
+_record_content_context: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_cubepi_mcp_record_content", default=False
 )
 
 
@@ -158,6 +162,8 @@ def register_tool_span(
     tool_call_id: str,
     span: Any,
     provider: Any = None,
+    *,
+    record_content: bool = False,
 ) -> tuple[object, contextvars.Token[tuple[object, ...]]]:
     """Publish ``span`` (and its owning ``provider``) as the current
     ``execute_tool`` parent for the calling task.
@@ -173,7 +179,7 @@ def register_tool_span(
     """
     del tool_call_id
     handle = object()
-    _active_entries[handle] = (span, provider)
+    _active_entries[handle] = (span, provider, record_content)
     cv_token = _handle_stack.set(_handle_stack.get() + (handle,))
     return (handle, cv_token)
 
@@ -205,9 +211,10 @@ def unregister_tool_span(
         pass
 
 
-def _get_tool_span_entry() -> tuple[Any, Any] | None:
-    """Return the (span, provider) entry for the current task, or
-    ``None`` when no live ``execute_tool`` is in scope.
+def _get_tool_span_entry() -> tuple[Any, Any, bool] | None:
+    """Return the active span, provider, and content policy for this task.
+
+    Returns ``None`` when no live ``execute_tool`` is in scope.
 
     Walks the per-task handle stack inner→outer and returns the first
     handle whose payload is still live in ``_active_entries``. A nested
@@ -287,16 +294,19 @@ async def mcp_client_span(
     del parent_tool_call_id
     entry = _get_tool_span_entry()
     if entry is not None:
-        parent_span, parent_provider = entry
+        parent_span, parent_provider, record_content = entry
         parent_context = _otel_trace.set_span_in_context(parent_span)
-        tracer = (
-            parent_provider.get_tracer(_SCOPE_NAME)
-            if parent_provider is not None
-            else _get_tracer(_SCOPE_NAME)
-        )
+        if parent_provider is not None:
+            tracer = parent_provider.get_tracer(_SCOPE_NAME)
+        else:
+            tracer, _fallback_record_content = _get_tracer_route(_SCOPE_NAME)
     else:
         parent_context = None
         tracer = _get_tracer(_SCOPE_NAME)
+        # Without an execute_tool parent there is no task-scoped owner.
+        # The provider stack is process-global, so borrowing its content flag
+        # could leak details from a different concurrent Tracer. Fail closed.
+        record_content = False
     attrs: dict[str, Any] = {
         _MCP_METHOD_NAME: method,
         _GEN_AI_OPERATION_NAME: "execute_tool",
@@ -318,35 +328,48 @@ async def mcp_client_span(
         attributes=attrs,
         context=parent_context,
     )
+    content_token = _record_content_context.set(record_content)
     try:
-        # Disable use_span's default record_exception / set_status_on_exception
-        # so we are the single source of the exception event and ERROR
-        # status — otherwise OTel would auto-record on context exit AND
-        # this ``except`` block would record again, double-counting.
-        with _otel_trace.use_span(
-            span,
-            record_exception=False,
-            set_status_on_exception=False,
-        ):
-            yield span
-    except BaseException as exc:
         try:
-            error_type = _error_type_for(exc)
-            span.set_attribute(_ERROR_TYPE, error_type)
-            # Cancellation is a control signal, not a failure — match the
-            # convention from the chat / turn / invoke_agent spans: leave
-            # Status UNSET and mark cubepi.aborted=true, do NOT record an
-            # exception event.
-            if error_type == "cubepi.aborted":
-                span.set_attribute("cubepi.aborted", True)
-            else:
-                span.set_status(Status(StatusCode.ERROR, str(exc)[:256]))
-                span.record_exception(exc)
-        finally:
+            # Disable use_span's default record_exception / set_status_on_exception
+            # so we are the single source of the exception event and ERROR
+            # status — otherwise OTel would auto-record on context exit AND
+            # this ``except`` block would record again, double-counting.
+            with _otel_trace.use_span(
+                span,
+                record_exception=False,
+                set_status_on_exception=False,
+            ):
+                yield span
+        except BaseException as exc:
+            try:
+                error_type = _error_type_for(exc)
+                span.set_attribute(_ERROR_TYPE, error_type)
+                # Cancellation is a control signal, not a failure — match the
+                # convention from the chat / turn / invoke_agent spans: leave
+                # Status UNSET and mark cubepi.aborted=true, do NOT record an
+                # exception event.
+                if error_type == "cubepi.aborted":
+                    span.set_attribute("cubepi.aborted", True)
+                else:
+                    description = (
+                        str(exc)[:256] if record_content else "mcp client error"
+                    )
+                    span.set_status(Status(StatusCode.ERROR, description))
+                    if record_content:
+                        span.record_exception(exc)
+                    else:
+                        span.add_event(
+                            "exception",
+                            attributes={"exception.type": type(exc).__name__},
+                        )
+            finally:
+                span.end()
+            raise
+        else:
             span.end()
-        raise
-    else:
-        span.end()
+    finally:
+        _record_content_context.reset(content_token)
 
 
 def mark_span_mcp_error(span: Any, message: str) -> None:
@@ -362,7 +385,10 @@ def mark_span_mcp_error(span: Any, message: str) -> None:
     """
     if span is None or not _OTEL_AVAILABLE:
         return
-    span.set_status(Status(StatusCode.ERROR, message[:256]))
+    description = (
+        message[:256] if _record_content_context.get() else "mcp protocol error"
+    )
+    span.set_status(Status(StatusCode.ERROR, description))
     span.set_attribute(_ERROR_TYPE, "mcp.is_error")
 
 

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -34,6 +34,7 @@ from opentelemetry.trace import SpanKind, Status, StatusCode
 from cubepi.agent.types import (
     AgentEndEvent,
     AgentStartEvent,
+    AgentSuspendedEvent,
     MessageEndEvent,
     MessageStartEvent,
     TurnEndEvent,
@@ -66,6 +67,7 @@ from cubepi.tracing.schema import (
     CUBEPI_LLM_THINKING_LEVEL,
     CUBEPI_OUTPUT_MESSAGES_COUNT,
     CUBEPI_RUN_ID,
+    CUBEPI_RUN_OUTCOME,
     CUBEPI_TOOL_BLOCK_REASON,
     CUBEPI_TOOL_BLOCKED_BY_HOOK,
     CUBEPI_TOOL_EXECUTION_MODE,
@@ -413,6 +415,8 @@ class Recorder:
                 self._on_message_end(event)
             elif isinstance(event, TurnEndEvent):
                 self._on_turn_end(event)
+            elif isinstance(event, AgentSuspendedEvent):
+                self._on_agent_suspended()
             elif isinstance(event, AgentEndEvent):
                 self._on_agent_end(event)
             # MessageUpdateEvent / ToolExecutionUpdateEvent: IGNORED.
@@ -679,6 +683,49 @@ class Recorder:
             if history:
                 self._run.transcript.extend(history)
 
+    def _on_agent_suspended(self) -> None:
+        """Finalize a durable HITL pause without classifying it as abort."""
+        run = self._run
+        if run is None:
+            return
+        for span in list(run.tool_spans.values()):
+            try:
+                span.set_attribute(CUBEPI_RUN_OUTCOME, "suspended")
+                span.end()
+            except Exception:
+                pass
+        run.tool_spans.clear()
+        if run.chat_span is not None:
+            try:
+                run.chat_span.set_attribute(CUBEPI_RUN_OUTCOME, "suspended")
+                run.chat_span.end()
+            except Exception:
+                pass
+            run.chat_span = None
+            run.chat_open_ns = None
+            run.chat_first_chunk_recorded = False
+        if run.turn_span is not None:
+            try:
+                run.turn_span.set_attribute(CUBEPI_RUN_OUTCOME, "suspended")
+                run.turn_span.end()
+            except Exception:
+                pass
+            run.turn_span = None
+        run.agent_span.set_attribute(CUBEPI_RUN_OUTCOME, "suspended")
+        run.agent_span.set_attribute(
+            CUBEPI_OUTPUT_MESSAGES_COUNT, len(run.output_messages)
+        )
+        run.agent_span.end()
+        self._sweep_tool_span_tokens(run)
+        if run.stream_file is not None:
+            try:
+                run.stream_file.close()
+            except Exception:
+                pass
+            run.stream_file = None
+        self._reset_active_run()
+        self._run = None
+
     def _on_agent_end(self, event: AgentEndEvent) -> None:
         run = self._run
         if run is None:
@@ -760,9 +807,8 @@ class Recorder:
         if run is None or run.turn_span is None:
             return
         msg = event.message
-        # Track output messages: assistant + any tool_results from this turn.
-        run.turn_output_messages.append(msg)
-        run.output_messages.append(msg)
+        # Assistant output is captured at MessageEnd so a HITL suspension before
+        # TurnEnd still records it. Add only this turn's tool results here.
         for tr in getattr(event, "tool_results", []) or []:
             run.turn_output_messages.append(tr)
             run.output_messages.append(tr)
@@ -948,6 +994,8 @@ class Recorder:
         msg = event.message
         if getattr(msg, "role", None) == "assistant":
             run.transcript.append(msg)
+            run.turn_output_messages.append(msg)
+            run.output_messages.append(msg)
 
     # ------------------------------------------------------------------
     # Provider listeners — drive the chat span lifetime

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -844,7 +844,11 @@ class Recorder:
         # "error", mark turn ERROR. Abort path leaves UNSET + sets
         # cubepi.aborted on the invoke_agent root.
         if stop_reason == "error":
-            err_msg = getattr(msg, "error_message", None) or "model error"
+            err_msg = (
+                getattr(msg, "error_message", None) or "model error"
+                if self._record_content
+                else "model error"
+            )
             run.turn_span.set_status(Status(StatusCode.ERROR, err_msg[:256]))
             run.turn_span.set_attribute(ERROR_TYPE, "cubepi.error")
         elif stop_reason == "aborted":
@@ -1267,17 +1271,24 @@ class Recorder:
                 span.set_attribute(CUBEPI_ABORTED, True)
                 span.set_attribute(ERROR_TYPE, "cubepi.aborted")
             else:
-                span.set_status(Status(StatusCode.ERROR, str(exc)[:256]))
+                description = (
+                    str(exc)[:256] if self._record_content else "provider error"
+                )
+                span.set_status(Status(StatusCode.ERROR, description))
                 span.set_attribute(ERROR_TYPE, cubepi_error_type_for(exc))
+                exception_attrs = {"exception.type": type(exc).__name__}
+                if self._record_content:
+                    exception_attrs.update(
+                        {
+                            "exception.message": str(exc),
+                            "exception.stacktrace": "".join(
+                                traceback.format_exception(exc)
+                            ),
+                        }
+                    )
                 span.add_event(
                     name=EVENT_GEN_AI_EXCEPTION,
-                    attributes={
-                        "exception.type": type(exc).__name__,
-                        "exception.message": str(exc),
-                        "exception.stacktrace": "".join(
-                            traceback.format_exception(exc)
-                        ),
-                    },
+                    attributes=exception_attrs,
                 )
         finally:
             span.end()

--- a/cubepi/tracing/recorder.py
+++ b/cubepi/tracing/recorder.py
@@ -585,7 +585,7 @@ class Recorder:
 
             entry = _mcp_tracing._get_tool_span_entry()
             if entry is not None:
-                tool_span, _tool_provider = entry
+                tool_span, _tool_provider, _record_content = entry
                 parent_ctx = trace.set_span_in_context(tool_span)
         except ImportError:  # pragma: no cover — mcp module always present
             parent_ctx = None
@@ -845,7 +845,7 @@ class Recorder:
         # cubepi.aborted on the invoke_agent root.
         if stop_reason == "error":
             err_msg = (
-                getattr(msg, "error_message", None) or "model error"
+                (getattr(msg, "error_message", None) or "model error")
                 if self._record_content
                 else "model error"
             )
@@ -907,6 +907,7 @@ class Recorder:
                 event.tool_call_id,
                 span,
                 provider=self._tracer._provider,
+                record_content=self._record_content,
             )
             run.tool_span_tokens[event.tool_call_id] = cv_token
         except ImportError:  # pragma: no cover — mcp module always present
@@ -1170,9 +1171,10 @@ class Recorder:
                     "ci": ci,
                     "chars": len(delta),
                     "accumulated": run.stream_tool_accumulated[ci],
-                    "preview": delta[:60],
                 }
             )
+            if self._record_content:
+                rec["preview"] = delta[:60]
 
         elif event.type == "toolcall_end":
             id_, name, args_str = "", "", ""
@@ -1188,15 +1190,20 @@ class Recorder:
                     "id": id_,
                     "name": name,
                     "args_chars": total,
-                    "args_preview": args_str[:80],
                 }
             )
+            if self._record_content:
+                rec["args_preview"] = args_str[:80]
 
         elif event.type in ("text_delta", "thinking_delta"):
             rec["chars"] = len(event.delta or "")
 
         elif event.type == "error":
-            rec["error_message"] = event.error_message or ""
+            rec["error_message"] = (
+                (event.error_message or "provider error")
+                if self._record_content
+                else "provider error"
+            )
 
         try:
             run.stream_file.write(json.dumps(rec) + "\n")  # type: ignore[union-attr]

--- a/cubepi/tracing/schema.py
+++ b/cubepi/tracing/schema.py
@@ -104,6 +104,7 @@ CUBEPI_AGENT_TOOLS = "cubepi.agent.tools"
 CUBEPI_AGENT_SYSTEM_PROMPT_SHA256 = "cubepi.agent.system_prompt.sha256"
 CUBEPI_INPUT_MESSAGES_COUNT = "cubepi.input.messages.count"
 CUBEPI_OUTPUT_MESSAGES_COUNT = "cubepi.output.messages.count"
+CUBEPI_RUN_OUTCOME = "cubepi.run.outcome"
 CUBEPI_ABORTED = "cubepi.aborted"
 
 # Turn span attributes (cubepi.turn span — no gen_ai.operation.name)

--- a/cubepi/tracing/tracer.py
+++ b/cubepi/tracing/tracer.py
@@ -289,7 +289,10 @@ class Tracer:
             from cubepi.mcp import _tracing as mcp_tracing
 
             assert mcp_tracing is not None
-            mcp_token = mcp_tracing.register_provider(self._provider)
+            mcp_token = mcp_tracing.register_provider(
+                self._provider,
+                record_content=self._record_content,
+            )
         except ImportError:  # pragma: no cover — mcp module always present
             pass
         except BaseException:
@@ -612,9 +615,18 @@ class Tracer:
                     root_span.set_attribute(CUBEPI_ABORTED, True)
                     root_span.set_attribute(ERROR_TYPE, "cubepi.aborted")
                 else:
-                    root_span.set_status(Status(StatusCode.ERROR, str(_exc)[:256]))
+                    description = str(_exc)[:256] if do_record else "oneshot error"
+                    root_span.set_status(Status(StatusCode.ERROR, description))
                     root_span.set_attribute(ERROR_TYPE, type(_exc).__name__)
-                root_span.record_exception(_exc)
+                    if do_record:
+                        root_span.record_exception(_exc)
+                    else:
+                        root_span.add_event(
+                            "exception",
+                            attributes={
+                                "exception.type": type(_exc).__name__,
+                            },
+                        )
             except Exception:  # pragma: no cover — defensive
                 pass
             raise

--- a/dev/plans/2026-08-04-tracing-hitl-suspension.md
+++ b/dev/plans/2026-08-04-tracing-hitl-suspension.md
@@ -50,6 +50,8 @@ OpenTelemetry SDK, pytest, Ruff, mypy, uv.
 - Move assistant output accumulation to `MessageEndEvent` so suspension before
   `TurnEndEvent` still records the partial output.
 - Do not change `_close_open_spans()` cancellation semantics.
+- When `record_content=False`, preserve typed ERROR classification while using
+  generic status descriptions and omitting exception messages/stack traces.
 
 ## Task 4: Document the lifecycle contract
 

--- a/dev/plans/2026-08-04-tracing-hitl-suspension.md
+++ b/dev/plans/2026-08-04-tracing-hitl-suspension.md
@@ -1,0 +1,74 @@
+# HITL Suspension Trace Semantics Implementation Plan
+
+**Goal:** Export durable HITL pauses as committed `suspended` activations,
+never as aborted, while preserving cancellation behavior and tracing cleanup.
+
+**Architecture:** Snapshot the pending request in `Agent.detach()`, commit the
+`HitlDetached` channel transition, and publish `AgentSuspendedEvent` from the
+owning run task after outcome dispatch and active-run cleanup. The recorder then
+finalizes the activation with explicit suspended attributes.
+
+**Tech stack:** Python 3.13, asyncio, FauxProvider, CheckpointedChannel,
+OpenTelemetry SDK, pytest, Ruff, mypy, uv.
+
+## Task 1: Pin the production-shaped regression
+
+- Add `tests/tracing/test_hitl_suspension.py` using a real Agent, HITL channel,
+  ask-user tool, Tracer, and in-memory exporter.
+- Record RED for the original false-abort behavior.
+- Add adversarial RED assertions for:
+  - event observers seeing pre-commit runtime state;
+  - cross-task `_active_run` retention;
+  - assistant output count incorrectly remaining zero;
+  - an earlier regular/cancelled listener hiding suspension from tracing;
+  - detach followed by immediate owner-task cancellation retaining the pending
+    payload and emitting an unhandled-future warning;
+  - same-tick `reset()` deleting a committed suspension snapshot before the
+    owner task can publish it.
+
+## Task 2: Commit suspension at the owning task boundary
+
+- Snapshot the pending request in `Agent.detach()` before the channel clears its
+  in-memory slot.
+- Set `HitlDetached` without publishing the terminal event from the host task.
+- After `prompt()`, `resume()`, or `respond()` records `outcome=suspended`,
+  performs outcome dispatch, and clears `active_run_id`, publish the event from
+  that same owning task.
+- Fan out agent events across regular exceptions and `CancelledError`; after
+  fan-out, give cancellation priority or re-raise the first regular exception.
+- Clear the pending snapshot on every failed owning activation; do not let
+  `reset()` clear a snapshot before that activation publishes its terminal.
+- Mark the detach control exception retrieved via a future done callback without
+  changing what channel awaiters receive.
+
+## Task 3: Add explicit trace semantics
+
+- Add the recorder-owned schema attribute `cubepi.run.outcome`.
+- Handle committed `AgentSuspendedEvent` in `Recorder`.
+- End open tool/chat/turn/root spans with outcome `suspended`.
+- Sweep tool-span registrations, close stream state, and clear the active run.
+- Move assistant output accumulation to `MessageEndEvent` so suspension before
+  `TurnEndEvent` still records the partial output.
+- Do not change `_close_open_spans()` cancellation semantics.
+
+## Task 4: Document the lifecycle contract
+
+- Update tracing guidance to distinguish cancellation from durable suspension.
+- Update HITL reference/durable examples to describe post-commit event timing.
+- State that resume creates a new activation trace.
+
+## Task 5: Verify
+
+Run:
+
+```bash
+uv run pytest tests/tracing/test_hitl_suspension.py -q
+uv run pytest tests/tracing tests/hitl -q
+uv run pytest tests/
+uv run ruff check cubepi/ tests/
+uv run ruff format --check cubepi/ tests/
+uv run mypy cubepi
+```
+
+Inspect `git diff --check` and confirm the branch contains only the spec, plan,
+focused tests, lifecycle fix, recorder/schema fix, and user-facing docs.

--- a/dev/plans/2026-08-04-tracing-hitl-suspension.md
+++ b/dev/plans/2026-08-04-tracing-hitl-suspension.md
@@ -49,9 +49,12 @@ OpenTelemetry SDK, pytest, Ruff, mypy, uv.
 - Sweep tool-span registrations, close stream state, and clear the active run.
 - Move assistant output accumulation to `MessageEndEvent` so suspension before
   `TurnEndEvent` still records the partial output.
-- Do not change `_close_open_spans()` cancellation semantics.
+- Do not change `_close_open_spans()` cancellation semantics; make one-shot
+  cancellation match the same aborted-without-exception-event contract.
 - When `record_content=False`, preserve typed ERROR classification while using
-  generic status descriptions and omitting exception messages/stack traces.
+  generic status descriptions and omitting exception messages/stack traces from
+  provider, turn, one-shot, and MCP spans; keep stream telemetry structural by
+  omitting raw argument/error previews.
 
 ## Task 4: Document the lifecycle contract
 

--- a/dev/specs/2026-08-04-tracing-hitl-suspension.md
+++ b/dev/specs/2026-08-04-tracing-hitl-suspension.md
@@ -37,6 +37,8 @@ left the old `_RunState` retained in that task's context.
 - Remove tool-span and MCP-provider registrations during normal tracing detach.
 - Count the assistant tool-call message as partial activation output.
 - Keep tracing observational: recorder failures must not affect the agent.
+- Keep raw provider error messages and stack traces behind `record_content=True`;
+  privacy-default traces retain only typed error classification.
 
 ## Non-goals
 

--- a/dev/specs/2026-08-04-tracing-hitl-suspension.md
+++ b/dev/specs/2026-08-04-tracing-hitl-suspension.md
@@ -1,0 +1,120 @@
+# HITL Suspension Trace Semantics
+
+- Date: 2026-08-04
+- Status: Accepted
+- Companion plan: `dev/plans/2026-08-04-tracing-hitl-suspension.md`
+
+## Problem
+
+A durable HITL pause is a successful activation outcome, not a cancellation.
+The agent loop records `RunOutcome="suspended"`, but the tracing recorder did
+not have a committed suspension terminal. It therefore kept the root, turn,
+and active tool spans open until tracing detach, whose cancellation cleanup
+marked them `cubepi.aborted=true`.
+
+A first implementation consumed the existing `AgentSuspendedEvent` directly,
+but adversarial review found that event was emitted before `Agent.detach()` set
+`HitlDetached` on the channel future. A later listener could raise, prevent the
+future transition, and leave the prompt running while tracing had already
+exported a false suspended terminal. The handler also ran from the host detach
+task, so resetting a `ContextVar` token created by the prompt task failed and
+left the old `_RunState` retained in that task's context.
+
+## Goals
+
+- Finalize every open span only after suspension is committed.
+- Mark the activation with `cubepi.run.outcome="suspended"`.
+- Never add `cubepi.aborted=true` or `error.type=cubepi.aborted` to a suspended
+  activation.
+- Emit the terminal event from the owning prompt/resume task so recorder
+  context cleanup occurs in the token's original context.
+- Ensure one failing or cancelled observer cannot hide a committed event from
+  later observers; preserve exception propagation after fan-out and give
+  cancellation priority.
+- Clear the pending-request snapshot on every owning activation failure/exit and
+  avoid unhandled `HitlDetached` future warnings.
+- Preserve the existing run cancellation cleanup and classification.
+- Remove tool-span and MCP-provider registrations during normal tracing detach.
+- Count the assistant tool-call message as partial activation output.
+- Keep tracing observational: recorder failures must not affect the agent.
+
+## Non-goals
+
+- Changing HITL persistence, answer, or resume behavior.
+- Continuing one OTel trace across pause and resume. A resumed activation gets a
+  new `invoke_agent` root and can be correlated by host-supplied metadata.
+- Recording pending questions, answers, tool arguments, or other content.
+- Reclassifying provider errors or explicit cancellation.
+
+## Design
+
+### Commit suspension before publishing it
+
+`Agent.detach()` snapshots the real pending request, then sets
+`HitlDetached` on the channel future. It does not publish the terminal event.
+The owning `prompt()`, `resume()`, or `respond()` task lets the loop record
+`RunOutcome="suspended"`, performs outcome dispatch, clears `active_run_id`, and
+only then emits `AgentSuspendedEvent` using the snapshot.
+
+Because the event now runs in the task that received `AgentStartEvent`, the
+recorder can reset its `_active_run` token in the owning context. If an event
+listener raises, the committed runtime state remains suspended rather than
+pending.
+
+Agent event fan-out invokes every registered listener before propagating
+listener failures. If any listener raises `asyncio.CancelledError`, cancellation
+wins after fan-out; otherwise the first regular exception is re-raised. A user
+listener registered before tracing can no longer hide the committed suspension
+from the recorder.
+
+The pending snapshot is cleared from every `prompt()`, `resume()`, and
+`respond()` failure path. `reset()` deliberately does not touch a snapshot owned
+by an activation that has not yet published its committed terminal. The detach future registers a
+done callback that marks its control exception retrieved without changing what
+awaiters receive, preventing an immediate owner-task cancellation from leaving
+an unhandled-future warning.
+
+### Finalize the trace as suspended
+
+On the committed `AgentSuspendedEvent`, the recorder:
+
+1. ends open tool, chat, and turn spans with
+   `cubepi.run.outcome="suspended"`;
+2. ends the root span with the same outcome and the partial output-message count;
+3. sweeps any open tool-span registrations;
+4. closes an active stream file;
+5. releases recorder state so tracing detach is idempotent.
+
+No span receives error status or aborted attributes. The existing generic
+`_close_open_spans()` path remains cancellation-only.
+
+Assistant messages are added to `run.output_messages` at `MessageEndEvent`, not
+at `TurnEndEvent`. That keeps normal output unchanged while making the assistant
+tool-call visible when HITL suspension prevents `TurnEndEvent`.
+
+This aligns trace semantics with Cubepi's existing runtime outcome model.
+Durable agent runtimes similarly treat an interrupt/pause as resumable control
+flow rather than an execution error; Cubepi preserves that distinction without
+adopting a graph runtime or changing its public event payload.
+
+## Acceptance
+
+A real `Agent` using `FauxProvider`, `CheckpointedChannel`, `ask_user_tool`, and
+`Tracer` must demonstrate:
+
+- one exported `invoke_agent` root;
+- `cubepi.run.outcome="suspended"` on the root and open child spans;
+- `cubepi.output.messages.count=1` for the assistant tool-call;
+- zero exported spans with `cubepi.aborted=true`;
+- no leaked MCP provider or active tool-span registrations after tracing detach;
+- `_active_run.get()` is clear when the owning prompt task returns;
+- a listener sees `last_outcome="suspended"` and `active_run_id=None`, never the
+  pre-commit state;
+- tracing still receives the event when an earlier listener raises a regular
+  exception or `CancelledError`;
+- listener cancellation remains the propagated outcome after terminal fan-out;
+- detach followed by immediate owner-task cancellation clears the request
+  snapshot, exports a real aborted trace, and emits no unhandled-future warning;
+- `reset()` in the same tick after detach cannot steal the owning activation's
+  snapshot; the persisted pending remains and the trace is suspended;
+- unchanged passing cancellation, tracing, and HITL suites.

--- a/dev/specs/2026-08-04-tracing-hitl-suspension.md
+++ b/dev/specs/2026-08-04-tracing-hitl-suspension.md
@@ -33,12 +33,15 @@ left the old `_RunState` retained in that task's context.
   cancellation priority.
 - Clear the pending-request snapshot on every owning activation failure/exit and
   avoid unhandled `HitlDetached` future warnings.
-- Preserve the existing run cancellation cleanup and classification.
+- Preserve run cancellation cleanup and classification; align one-shot
+  cancellation with Agent/MCP semantics by recording aborted control flow
+  without an exception event.
 - Remove tool-span and MCP-provider registrations during normal tracing detach.
 - Count the assistant tool-call message as partial activation output.
 - Keep tracing observational: recorder failures must not affect the agent.
-- Keep raw provider error messages and stack traces behind `record_content=True`;
-  privacy-default traces retain only typed error classification.
+- Keep raw provider, turn, one-shot, MCP, and stream-log diagnostics behind
+  `record_content=True`; privacy-default traces retain only typed error
+  classification and structural stream timing/size evidence.
 
 ## Non-goals
 

--- a/tests/tracing/test_attach_atomicity.py
+++ b/tests/tracing/test_attach_atomicity.py
@@ -73,7 +73,7 @@ async def test_tracer_attach_unwinds_recorder_on_mcp_register_failure(monkeypatc
     try:
         import cubepi.mcp._tracing as mcp_tracing
 
-        def _boom(_provider):  # noqa: ANN001, ANN202
+        def _boom(_provider, **_kwargs):  # noqa: ANN001, ANN202
             raise RuntimeError("register_provider failed")
 
         monkeypatch.setattr(mcp_tracing, "register_provider", _boom)
@@ -129,7 +129,7 @@ async def test_tracer_attach_cleanup_swallows_recorder_detach_error(monkeypatch)
 
         import cubepi.mcp._tracing as mcp_tracing
 
-        def _boom(_provider):  # noqa: ANN001, ANN202
+        def _boom(_provider, **_kwargs):  # noqa: ANN001, ANN202
             raise RuntimeError("register_provider failed")
 
         monkeypatch.setattr(mcp_tracing, "register_provider", _boom)

--- a/tests/tracing/test_content_recording.py
+++ b/tests/tracing/test_content_recording.py
@@ -102,6 +102,26 @@ class TestContentDisabled:
                     f"{span.name} should not carry {forbidden} with record_content=False"
                 )
 
+    async def test_error_details_are_private_when_record_content_false(self):
+        secret = "Authorization: Bearer TOPSECRET"
+        agent, provider, exporter, tracer = await _build(record_content=False)
+
+        def explode(*_args):
+            raise RuntimeError(secret)
+
+        provider.append_responses([explode])
+
+        await agent.prompt("private prompt")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        assert any(span.status.status_code.name == "ERROR" for span in exporter.spans)
+        for span in exporter.spans:
+            assert secret not in (span.status.description or "")
+            assert secret not in repr(dict(span.attributes or {}))
+            for event in span.events:
+                assert secret not in repr(dict(event.attributes or {}))
+
 
 class TestRootContent:
     async def test_invoke_agent_records_input_output_system(self):

--- a/tests/tracing/test_content_recording.py
+++ b/tests/tracing/test_content_recording.py
@@ -122,6 +122,30 @@ class TestContentDisabled:
             for event in span.events:
                 assert secret not in repr(dict(event.attributes or {}))
 
+    async def test_turn_error_message_is_private_when_record_content_false(self):
+        secret = "Authorization: Bearer TURNSECRET"
+        agent, provider, exporter, tracer = await _build(record_content=False)
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    "oops",
+                    stop_reason="error",
+                    error_message=secret,
+                )
+            ]
+        )
+
+        await agent.prompt("private prompt")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        turn = next(span for span in exporter.spans if span.name == "cubepi.turn")
+        assert turn.status.status_code.name == "ERROR"
+        assert turn.status.description == "model error"
+        assert secret not in repr(dict(turn.attributes or {}))
+        for event in turn.events:
+            assert secret not in repr(dict(event.attributes or {}))
+
 
 class TestRootContent:
     async def test_invoke_agent_records_input_output_system(self):

--- a/tests/tracing/test_content_recording.py
+++ b/tests/tracing/test_content_recording.py
@@ -197,6 +197,31 @@ class TestChatContent:
         assert resp["id"] == "faux-1"
         assert resp["role"] == "assistant"
 
+    async def test_provider_exception_details_require_content_opt_in(self):
+        secret = "Authorization: Bearer OPTED-IN-ERROR"
+        agent, provider, exporter, tracer = await _build(record_content=True)
+
+        def explode(*_args):
+            raise RuntimeError(secret)
+
+        provider.append_responses([explode])
+
+        await agent.prompt("private prompt")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        chat = next(span for span in exporter.spans if span.name.startswith("chat "))
+        exception = next(
+            event
+            for event in chat.events
+            if event.name == "gen_ai.client.operation.exception"
+        )
+        attrs = dict(exception.attributes or {})
+        assert attrs["exception.type"] == "RuntimeError"
+        assert attrs["exception.message"] == secret
+        assert secret in attrs["exception.stacktrace"]
+        assert chat.status.description == secret
+
 
 class TestToolContent:
     async def test_execute_tool_carries_arguments_and_result(self):

--- a/tests/tracing/test_hitl_suspension.py
+++ b/tests/tracing/test_hitl_suspension.py
@@ -91,6 +91,34 @@ async def _detach_tracing(detach: Any, tracer: Tracer) -> None:
     await tracer.shutdown()
 
 
+async def test_suspended_outcome_without_snapshot_emits_no_event() -> None:
+    agent, _channel, _exporter, tracer = _build_suspending_agent("thread-no-snapshot")
+    observed: list[str] = []
+
+    async def observe(event, signal=None):  # noqa: ANN001, ANN202
+        del signal
+        observed.append(event.type)
+
+    unsubscribe = agent.subscribe(observe)
+    await agent._emit_suspended_event("suspended")
+    unsubscribe()
+    await tracer.shutdown()
+
+    assert observed == []
+
+
+async def test_recorder_suspension_without_active_run_is_noop() -> None:
+    from cubepi.tracing.recorder import Recorder
+
+    tracer = Tracer(service_name="test", exporters=[])
+    recorder = Recorder(tracer)
+
+    recorder._on_agent_suspended()
+    await tracer.shutdown()
+
+    assert recorder._run is None
+
+
 async def test_suspended_run_exports_suspended_trace_without_abort_or_leaks() -> None:
     agent, channel, exporter, tracer = _build_suspending_agent("thread-1")
     provider_stack_baseline = len(mcp_tracing._provider_stack)
@@ -128,6 +156,105 @@ async def test_suspended_run_exports_suspended_trace_without_abort_or_leaks() ->
     ]
     assert len(mcp_tracing._provider_stack) == provider_stack_baseline
     assert len(mcp_tracing._active_entries) == active_entries_baseline
+
+
+async def test_recorder_suspension_finalizes_all_open_resources() -> None:
+    from cubepi.tracing.recorder import Recorder, _RunState
+
+    class _Span:
+        def __init__(self) -> None:
+            self.attributes: dict[str, Any] = {}
+            self.ended = False
+
+        def set_attribute(self, key: str, value: Any) -> None:
+            self.attributes[key] = value
+
+        def end(self) -> None:
+            self.ended = True
+
+    class _Stream:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    tracer = Tracer(service_name="test", exporters=[])
+    recorder = Recorder(tracer)
+    agent_span = _Span()
+    turn_span = _Span()
+    chat_span = _Span()
+    tool_span = _Span()
+    stream = _Stream()
+    run = _RunState(
+        run_id="run-open-resources",
+        agent_span=agent_span,
+        turn_span=turn_span,
+        chat_span=chat_span,
+        tool_spans={"tool-1": tool_span},
+        stream_file=stream,
+    )
+    recorder._run = run
+
+    recorder._on_agent_suspended()
+    await tracer.shutdown()
+
+    for span in (agent_span, turn_span, chat_span, tool_span):
+        assert span.attributes["cubepi.run.outcome"] == "suspended"
+        assert span.ended is True
+    assert stream.closed is True
+    assert run.tool_spans == {}
+    assert run.chat_span is None
+    assert run.turn_span is None
+    assert run.stream_file is None
+    assert recorder._run is None
+
+
+async def test_recorder_suspension_cleanup_continues_after_resource_errors() -> None:
+    from cubepi.tracing.recorder import Recorder, _RunState
+
+    class _Span:
+        def __init__(self) -> None:
+            self.attributes: dict[str, Any] = {}
+            self.ended = False
+
+        def set_attribute(self, key: str, value: Any) -> None:
+            self.attributes[key] = value
+
+        def end(self) -> None:
+            self.ended = True
+
+    class _BoomSpan(_Span):
+        def end(self) -> None:
+            raise RuntimeError("span end failed")
+
+    class _BoomStream:
+        def close(self) -> None:
+            raise OSError("stream close failed")
+
+    tracer = Tracer(service_name="test", exporters=[])
+    recorder = Recorder(tracer)
+    agent_span = _Span()
+    run = _RunState(
+        run_id="run-resource-errors",
+        agent_span=agent_span,
+        turn_span=_BoomSpan(),
+        chat_span=_BoomSpan(),
+        tool_spans={"tool-1": _BoomSpan()},
+        stream_file=_BoomStream(),
+    )
+    recorder._run = run
+
+    recorder._on_agent_suspended()
+    await tracer.shutdown()
+
+    assert agent_span.attributes["cubepi.run.outcome"] == "suspended"
+    assert agent_span.ended is True
+    assert run.tool_spans == {}
+    assert run.chat_span is None
+    assert run.turn_span is None
+    assert run.stream_file is None
+    assert recorder._run is None
 
 
 async def test_suspension_event_observes_committed_runtime_state() -> None:

--- a/tests/tracing/test_hitl_suspension.py
+++ b/tests/tracing/test_hitl_suspension.py
@@ -1,0 +1,340 @@
+"""Tracing coverage for durable HITL suspension."""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+from contextlib import suppress
+from typing import Any
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from cubepi.agent.agent import Agent
+from cubepi.checkpointer.memory import MemoryCheckpointer
+from cubepi.hitl.ask_user import ask_user_tool
+from cubepi.hitl.channel import CheckpointedChannel
+from cubepi.mcp import _tracing as mcp_tracing
+from cubepi.providers.base import AssistantMessage, TextContent, ToolCall
+from cubepi.providers.faux import FauxProvider
+from cubepi.tracing import Tracer
+from cubepi.tracing import recorder as recorder_module
+
+
+class InMemoryExporter(SpanExporter):
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def export(self, spans):  # noqa: ANN001
+        self.spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
+
+
+def _build_suspending_agent(
+    thread_id: str,
+) -> tuple[Agent, CheckpointedChannel, InMemoryExporter, Tracer]:
+    cp = MemoryCheckpointer()
+    channel = CheckpointedChannel(
+        checkpointer=cp,
+        thread_id=thread_id,
+        run_id="R1",
+    )
+    provider = FauxProvider(provider_id="faux")
+    provider.set_responses(
+        [
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="ask-1",
+                        name="ask_user",
+                        arguments={"questions": [{"key": "answer", "prompt": "?"}]},
+                    )
+                ],
+                stop_reason="tool_use",
+            ),
+            AssistantMessage(
+                content=[TextContent(text="done")],
+                stop_reason="end_turn",
+            ),
+        ]
+    )
+    agent = Agent(
+        model=provider.model("faux-model"),
+        tools=[ask_user_tool(channel)],
+        checkpointer=cp,
+        thread_id=thread_id,
+        channel=channel,
+    )
+    exporter = InMemoryExporter()
+    tracer = Tracer(service_name="test", agent_name="test-agent", exporters=[exporter])
+    return agent, channel, exporter, tracer
+
+
+async def _wait_for_pending(channel: CheckpointedChannel) -> None:
+    for _ in range(200):
+        if channel.pending is not None:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("agent did not suspend on HITL")
+
+
+async def _detach_tracing(detach: Any, tracer: Tracer) -> None:
+    flush_task = detach()
+    if flush_task is not None:
+        await flush_task
+    await tracer.shutdown()
+
+
+async def test_suspended_run_exports_suspended_trace_without_abort_or_leaks() -> None:
+    agent, channel, exporter, tracer = _build_suspending_agent("thread-1")
+    provider_stack_baseline = len(mcp_tracing._provider_stack)
+    active_entries_baseline = len(mcp_tracing._active_entries)
+    detach_tracing = tracer.attach(agent)
+
+    prompt_task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
+    await _wait_for_pending(channel)
+    await agent.detach()
+    await prompt_task
+    await _detach_tracing(detach_tracing, tracer)
+
+    roots = [span for span in exporter.spans if span.name == "invoke_agent"]
+    assert len(roots) == 1
+    assert roots[0].attributes.get("cubepi.output.messages.count") == 1
+    suspended_spans = [
+        span
+        for span in exporter.spans
+        if span.name in {"invoke_agent", "cubepi.turn"}
+        or span.name.startswith("execute_tool ")
+    ]
+    assert {span.name for span in suspended_spans} == {
+        "invoke_agent",
+        "cubepi.turn",
+        "execute_tool ask_user",
+    }
+    assert all(
+        span.attributes.get("cubepi.run.outcome") == "suspended"
+        for span in suspended_spans
+    )
+    assert not [
+        span.name
+        for span in exporter.spans
+        if span.attributes.get("cubepi.aborted") is True
+    ]
+    assert len(mcp_tracing._provider_stack) == provider_stack_baseline
+    assert len(mcp_tracing._active_entries) == active_entries_baseline
+
+
+async def test_suspension_event_observes_committed_runtime_state() -> None:
+    agent, channel, _exporter, tracer = _build_suspending_agent("thread-2")
+    detach_tracing = tracer.attach(agent)
+    observed: list[tuple[str | None, str | None]] = []
+
+    async def fail_after_observing(event, signal=None):  # noqa: ANN001, ANN202
+        del signal
+        if event.type == "agent_suspended":
+            observed.append((agent.state.last_outcome, agent.state.active_run_id))
+            raise RuntimeError("listener failed after observing suspension")
+
+    unsubscribe = agent.subscribe(fail_after_observing)
+    prompt_task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
+    await _wait_for_pending(channel)
+
+    with suppress(RuntimeError):
+        await agent.detach()
+    timed_out = False
+    try:
+        await asyncio.wait_for(asyncio.shield(prompt_task), timeout=0.5)
+    except RuntimeError:
+        pass
+    except TimeoutError:
+        timed_out = True
+
+    unsubscribe()
+    if not prompt_task.done():
+        await agent.detach()
+        await prompt_task
+    await _detach_tracing(detach_tracing, tracer)
+
+    assert timed_out is False
+    assert observed == [("suspended", None)]
+
+
+async def test_earlier_listener_failure_cannot_hide_suspension_from_tracer() -> None:
+    agent, channel, exporter, tracer = _build_suspending_agent("thread-early-error")
+
+    async def fail_on_suspension(event, signal=None):  # noqa: ANN001, ANN202
+        del signal
+        if event.type == "agent_suspended":
+            raise RuntimeError("earlier listener failed")
+
+    unsubscribe = agent.subscribe(fail_on_suspension)
+    detach_tracing = tracer.attach(agent)
+    prompt_task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
+    await _wait_for_pending(channel)
+    await agent.detach()
+    with suppress(RuntimeError):
+        await prompt_task
+    unsubscribe()
+    await _detach_tracing(detach_tracing, tracer)
+
+    roots = [span for span in exporter.spans if span.name == "invoke_agent"]
+    assert len(roots) == 1
+    assert roots[0].attributes.get("cubepi.run.outcome") == "suspended"
+    assert roots[0].attributes.get("cubepi.aborted") is not True
+
+
+async def test_cancelled_listener_cannot_hide_suspension_from_tracer() -> None:
+    agent, channel, exporter, tracer = _build_suspending_agent(
+        "thread-cancelled-listener"
+    )
+
+    async def cancel_on_suspension(event, signal=None):  # noqa: ANN001, ANN202
+        del signal
+        if event.type == "agent_suspended":
+            raise asyncio.CancelledError
+
+    unsubscribe = agent.subscribe(cancel_on_suspension)
+    detach_tracing = tracer.attach(agent)
+    prompt_task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
+    await _wait_for_pending(channel)
+    await agent.detach()
+    with suppress(asyncio.CancelledError):
+        await prompt_task
+    unsubscribe()
+    await _detach_tracing(detach_tracing, tracer)
+
+    assert agent.state.last_outcome == "suspended"
+    assert agent.state.active_run_id is None
+    roots = [span for span in exporter.spans if span.name == "invoke_agent"]
+    assert len(roots) == 1
+    assert roots[0].attributes.get("cubepi.run.outcome") == "suspended"
+    assert roots[0].attributes.get("cubepi.aborted") is not True
+
+
+async def test_listener_cancellation_takes_priority_after_terminal_fanout() -> None:
+    agent, channel, exporter, tracer = _build_suspending_agent(
+        "thread-listener-priority"
+    )
+
+    async def fail_on_suspension(event, signal=None):  # noqa: ANN001, ANN202
+        del signal
+        if event.type == "agent_suspended":
+            raise RuntimeError("regular listener failure")
+
+    async def cancel_on_suspension(event, signal=None):  # noqa: ANN001, ANN202
+        del signal
+        if event.type == "agent_suspended":
+            raise asyncio.CancelledError
+
+    unsubscribe_fail = agent.subscribe(fail_on_suspension)
+    unsubscribe_cancel = agent.subscribe(cancel_on_suspension)
+    detach_tracing = tracer.attach(agent)
+    prompt_task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
+    await _wait_for_pending(channel)
+    await agent.detach()
+    raised: BaseException | None = None
+    try:
+        await prompt_task
+    except BaseException as exc:
+        raised = exc
+    unsubscribe_fail()
+    unsubscribe_cancel()
+    await _detach_tracing(detach_tracing, tracer)
+
+    assert isinstance(raised, asyncio.CancelledError)
+    roots = [span for span in exporter.spans if span.name == "invoke_agent"]
+    assert len(roots) == 1
+    assert roots[0].attributes.get("cubepi.run.outcome") == "suspended"
+
+
+async def test_detach_then_owner_cancel_clears_suspension_snapshot() -> None:
+    agent, channel, exporter, tracer = _build_suspending_agent("thread-owner-cancel")
+    detach_tracing = tracer.attach(agent)
+    prompt_task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
+    await _wait_for_pending(channel)
+    loop = asyncio.get_running_loop()
+    old_exception_handler = loop.get_exception_handler()
+    unhandled: list[dict[str, Any]] = []
+    loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+
+    try:
+        await agent.detach()
+        prompt_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await prompt_task
+        await _detach_tracing(detach_tracing, tracer)
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(old_exception_handler)
+
+    assert agent._pending_suspension_event is None
+    assert unhandled == []
+    roots = [span for span in exporter.spans if span.name == "invoke_agent"]
+    assert len(roots) == 1
+    assert roots[0].attributes.get("cubepi.run.outcome") is None
+    assert roots[0].attributes.get("cubepi.aborted") is True
+
+
+async def test_reset_before_owner_resumes_does_not_drop_suspension_snapshot() -> None:
+    agent, channel, exporter, tracer = _build_suspending_agent("thread-reset-race")
+    detach_tracing = tracer.attach(agent)
+    prompt_task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
+    await _wait_for_pending(channel)
+
+    await agent.detach()
+    agent.reset()
+    await prompt_task
+    persisted_pending = await agent.load_pending_hitl_request()
+    await _detach_tracing(detach_tracing, tracer)
+
+    assert agent.state.last_outcome == "suspended"
+    assert persisted_pending is not None
+    roots = [span for span in exporter.spans if span.name == "invoke_agent"]
+    assert len(roots) == 1
+    assert roots[0].attributes.get("cubepi.run.outcome") == "suspended"
+    assert roots[0].attributes.get("cubepi.aborted") is not True
+
+
+async def test_respond_after_suspension_opens_a_new_activation_trace() -> None:
+    agent, channel, exporter, tracer = _build_suspending_agent("thread-respond")
+    detach_tracing = tracer.attach(agent)
+
+    prompt_task = asyncio.create_task(agent.prompt("hi", run_id="R1"))
+    await _wait_for_pending(channel)
+    await agent.detach()
+    await prompt_task
+    pending = await agent.load_pending_hitl_request()
+    assert pending is not None
+    await agent.respond(question_id=pending.question_id, answer="yes")
+    await _detach_tracing(detach_tracing, tracer)
+
+    roots = [span for span in exporter.spans if span.name == "invoke_agent"]
+    assert len(roots) == 2
+    assert roots[0].attributes.get("cubepi.run.outcome") == "suspended"
+    assert roots[1].attributes.get("cubepi.run.outcome") is None
+    assert roots[1].attributes.get("cubepi.aborted") is not True
+    assert roots[0].context.trace_id != roots[1].context.trace_id
+
+
+async def test_suspension_clears_active_run_in_owning_prompt_task() -> None:
+    agent, channel, _exporter, tracer = _build_suspending_agent("thread-3")
+    detach_tracing = tracer.attach(agent)
+
+    async def prompt_and_read_active_run():
+        await agent.prompt("hi", run_id="R1")
+        return recorder_module._active_run.get()
+
+    prompt_task = asyncio.create_task(prompt_and_read_active_run())
+    await _wait_for_pending(channel)
+    await agent.detach()
+    active_run_after_prompt = await prompt_task
+    await _detach_tracing(detach_tracing, tracer)
+
+    assert active_run_after_prompt is None

--- a/tests/tracing/test_mcp_spans.py
+++ b/tests/tracing/test_mcp_spans.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import pytest
 from opentelemetry import trace as _trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
@@ -245,6 +246,26 @@ class TestMCPIsErrorResponse:
         attrs = _attrs(span)
         assert attrs["error.type"] == "mcp.is_error"
 
+    async def test_protocol_error_message_is_private_by_default(self, monkeypatch):
+        from cubepi.mcp._tracing import mark_span_mcp_error, mcp_client_span
+
+        provider, exporter = _make_provider()
+        _patch_mcp_trace(monkeypatch, provider)
+        secret = "Authorization: Bearer MCPPROTOCOLSECRET"
+
+        async with mcp_client_span(
+            method="tools/call",
+            tool_name="search",
+        ) as span:
+            mark_span_mcp_error(span, secret)
+
+        captured = next(s for s in exporter.spans if s.name.startswith("tools/call "))
+        assert captured.status.status_code == StatusCode.ERROR
+        assert captured.status.description == "mcp protocol error"
+        assert secret not in repr(dict(captured.attributes or {}))
+        for event in captured.events:
+            assert secret not in repr(dict(event.attributes or {}))
+
     async def test_iserror_false_keeps_span_unset(self, monkeypatch):
         provider, exporter = _make_provider()
         _patch_mcp_trace(monkeypatch, provider)
@@ -436,6 +457,160 @@ class TestTracerProviderRouting:
         assert client_ctx.trace_id == tool_ctx.trace_id
         assert client_span.parent is not None
         assert client_span.parent.span_id == tool_ctx.span_id
+
+    async def test_mcp_exception_is_private_without_content_opt_in(self):
+        from cubepi.agent.agent import Agent
+        from cubepi.providers.base import ToolCall
+        from cubepi.providers.faux import FauxProvider, faux_assistant_message
+        from cubepi.tracing import Tracer
+
+        secret = "Authorization: Bearer MCPSECRET"
+        exporter = _CaptureExporter()
+
+        async def call_remote(name, args):
+            raise RuntimeError(secret)
+
+        mcp_tool = make_mcp_agent_tool(
+            name="search",
+            description="search",
+            input_schema={
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+            },
+            call_remote=call_remote,
+        )
+        provider = FauxProvider(provider_id="faux")
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    [ToolCall(id="tc1", name="search", arguments={"q": "x"})],
+                    stop_reason="tool_use",
+                ),
+                faux_assistant_message("done"),
+            ]
+        )
+        agent = Agent(
+            model=provider.model("faux-1"),
+            system_prompt="s",
+            tools=[mcp_tool],
+        )
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[exporter],
+            record_content=False,
+        )
+        detach = tracer.attach(agent)
+        try:
+            await agent.prompt("go")
+            await agent.wait_for_idle()
+        finally:
+            detach()
+            await tracer.shutdown()
+
+        span = next(s for s in exporter.spans if s.name.startswith("tools/call "))
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.status.description == "mcp client error"
+        assert secret not in repr(dict(span.attributes or {}))
+        exception_event = next(
+            event for event in span.events if event.name == "exception"
+        )
+        assert exception_event.attributes["exception.type"] == "RuntimeError"
+        for event in span.events:
+            assert secret not in repr(dict(event.attributes or {}))
+
+    async def test_mcp_exception_details_remain_available_with_content_opt_in(self):
+        from cubepi.agent.agent import Agent
+        from cubepi.providers.base import ToolCall
+        from cubepi.providers.faux import FauxProvider, faux_assistant_message
+        from cubepi.tracing import Tracer
+
+        secret = "diagnostic mcp failure"
+        exporter = _CaptureExporter()
+
+        async def call_remote(name, args):
+            raise RuntimeError(secret)
+
+        mcp_tool = make_mcp_agent_tool(
+            name="search",
+            description="search",
+            input_schema={
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+            },
+            call_remote=call_remote,
+        )
+        provider = FauxProvider(provider_id="faux")
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    [ToolCall(id="tc1", name="search", arguments={"q": "x"})],
+                    stop_reason="tool_use",
+                ),
+                faux_assistant_message("done"),
+            ]
+        )
+        agent = Agent(
+            model=provider.model("faux-1"),
+            system_prompt="s",
+            tools=[mcp_tool],
+        )
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[exporter],
+            record_content=True,
+        )
+        detach = tracer.attach(agent)
+        try:
+            await agent.prompt("go")
+            await agent.wait_for_idle()
+        finally:
+            detach()
+            await tracer.shutdown()
+
+        span = next(s for s in exporter.spans if s.name.startswith("tools/call "))
+        assert secret in (span.status.description or "")
+        assert any(
+            secret in repr(dict(event.attributes or {})) for event in span.events
+        )
+
+    async def test_unparented_mcp_exception_fails_closed_with_opted_in_tracer(self):
+        """Without a tool-span owner, the global provider stack cannot prove
+        which concurrent Tracer owns the call, so content must stay disabled."""
+        from cubepi.agent.agent import Agent
+        from cubepi.mcp._tracing import mcp_client_span
+        from cubepi.providers.faux import FauxProvider
+        from cubepi.tracing import Tracer
+
+        secret = "Authorization: Bearer UNPARENTEDMCPSECRET"
+        exporter = _CaptureExporter()
+        provider = FauxProvider(provider_id="faux")
+        agent = Agent(model=provider.model("faux-1"), system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[exporter],
+            record_content=True,
+        )
+        detach = tracer.attach(agent)
+        try:
+            with pytest.raises(RuntimeError, match="UNPARENTEDMCPSECRET"):
+                async with mcp_client_span(
+                    method="connect",
+                    server_address="example.com",
+                ):
+                    raise RuntimeError(secret)
+        finally:
+            detach()
+            await tracer.shutdown()
+
+        span = next(s for s in exporter.spans if s.name == "connect")
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.status.description == "mcp client error"
+        event = next(event for event in span.events if event.name == "exception")
+        assert dict(event.attributes or {}) == {"exception.type": "RuntimeError"}
+        assert secret not in repr(dict(span.attributes or {}))
 
     async def test_two_attaches_detach_one_keeps_other_routing(self):
         """When a Tracer is attached to two agents and one is detached,
@@ -1004,7 +1179,11 @@ class TestMCPSpanParentage:
         )
         try:
             # Innermost lookup is the inner tool while it is live.
-            assert mcp_tracing._get_tool_span_entry() == ("span-inner", "prov-inner")
+            assert mcp_tracing._get_tool_span_entry() == (
+                "span-inner",
+                "prov-inner",
+                False,
+            )
 
             async def _end_inner() -> None:
                 mcp_tracing.unregister_tool_span(tok_inner)
@@ -1013,7 +1192,11 @@ class TestMCPSpanParentage:
             await _asyncio.create_task(_end_inner())
 
             # Must fall back to the OUTER tool, not None.
-            assert mcp_tracing._get_tool_span_entry() == ("span-outer", "prov-outer")
+            assert mcp_tracing._get_tool_span_entry() == (
+                "span-outer",
+                "prov-outer",
+                False,
+            )
         finally:
             mcp_tracing.unregister_tool_span(tok_outer)
 

--- a/tests/tracing/test_oneshot.py
+++ b/tests/tracing/test_oneshot.py
@@ -264,14 +264,15 @@ async def test_oneshot_generate_error_event_raises_and_marks_root() -> None:
 
     provider = FauxProvider(provider_id="faux")
     tracer, exporter = _make_tracer()
+    secret = "Authorization: Bearer ONESHOTSECRET"
 
     error_stream = MessageStream()
-    error_stream.push(StreamEvent(type="error", error_message="boom"))
+    error_stream.push(StreamEvent(type="error", error_message=secret))
     error_stream.set_result(
-        AssistantMessage(content=[], stop_reason="error", error_message="boom")
+        AssistantMessage(content=[], stop_reason="error", error_message=secret)
     )
     with patch.object(provider, "stream", new=AsyncMock(return_value=error_stream)):
-        with pytest.raises(RuntimeError, match="boom"):
+        with pytest.raises(RuntimeError, match="ONESHOTSECRET"):
             async with tracer.oneshot(model=provider.model(MODEL.id)) as session:
                 await session.generate(
                     system="sys",
@@ -286,8 +287,46 @@ async def test_oneshot_generate_error_event_raises_and_marks_root() -> None:
     assert len(roots) == 1
     root = roots[0]
     assert root.status.status_code == StatusCode.ERROR
+    assert root.status.description == "oneshot error"
     attrs = dict(root.attributes or {})
     assert attrs.get("error.type") == "RuntimeError"
+    assert secret not in repr(attrs)
+    for event in root.events:
+        assert secret not in repr(dict(event.attributes or {}))
+
+
+@pytest.mark.asyncio
+async def test_oneshot_error_details_remain_available_with_content_opt_in() -> None:
+    from opentelemetry.trace import StatusCode
+    from unittest.mock import AsyncMock, patch
+
+    provider = FauxProvider(provider_id="faux")
+    tracer, exporter = _make_tracer(record_content=True)
+    diagnostic = "diagnostic oneshot failure"
+
+    error_stream = MessageStream()
+    error_stream.push(StreamEvent(type="error", error_message=diagnostic))
+    error_stream.set_result(
+        AssistantMessage(content=[], stop_reason="error", error_message=diagnostic)
+    )
+    with patch.object(provider, "stream", new=AsyncMock(return_value=error_stream)):
+        with pytest.raises(RuntimeError, match="diagnostic oneshot failure"):
+            async with tracer.oneshot(model=provider.model(MODEL.id)) as session:
+                await session.generate(
+                    system="sys",
+                    messages=[UserMessage(content=[TextContent(text="q")])],
+                    max_output_tokens=10,
+                )
+
+    await tracer.force_flush()
+    await tracer.shutdown()
+
+    root = next(s for s in exporter.spans if s.name == "invoke_agent")
+    assert root.status.status_code == StatusCode.ERROR
+    assert diagnostic in (root.status.description or "")
+    assert any(
+        diagnostic in repr(dict(event.attributes or {})) for event in root.events
+    )
 
 
 @pytest.mark.asyncio
@@ -598,9 +637,11 @@ async def test_oneshot_cancelled_generate_closes_chat_span() -> None:
     # matching the agent path's contract.
     roots = [s for s in exporter.spans if s.name == "invoke_agent"]
     assert len(roots) == 1
-    attrs = dict(roots[0].attributes or {})
+    root = roots[0]
+    attrs = dict(root.attributes or {})
     assert attrs.get("cubepi.aborted") is True
     assert attrs.get("error.type") == "cubepi.aborted"
+    assert not any(event.name == "exception" for event in root.events)
 
 
 @pytest.mark.asyncio

--- a/tests/tracing/test_recorder_coverage.py
+++ b/tests/tracing/test_recorder_coverage.py
@@ -483,12 +483,16 @@ class TestStreamRecording:
         assert len(files) == 1
         files[0].read_text()  # raises if file handle leaked
 
-    async def test_stream_toolcall_events_recorded(self, tmp_path):
-        """toolcall_start / toolcall_delta / toolcall_end events reach the stream file."""
+    async def test_stream_toolcall_events_hide_arguments_without_content_opt_in(
+        self, tmp_path
+    ):
+        """Stream timing stays available without persisting tool arguments."""
         from pydantic import BaseModel
 
+        secret = "Bearer STREAMSECRET"
+
         class P(BaseModel):
-            pass
+            authorization: str
 
         async def noop(tool_call_id: str, params: P, *, signal=None, on_update=None):
             return AgentToolResult(content=[TextContent(text="done")])
@@ -498,7 +502,13 @@ class TestStreamRecording:
         provider.append_responses(
             [
                 faux_assistant_message(
-                    [ToolCall(id="tc1", name="noop", arguments={"x": 1})],
+                    [
+                        ToolCall(
+                            id="tc1",
+                            name="noop",
+                            arguments={"authorization": secret},
+                        )
+                    ],
                     stop_reason="tool_use",
                 ),
                 faux_assistant_message("all done"),
@@ -520,17 +530,22 @@ class TestStreamRecording:
 
         files = list(tmp_path.glob("*.stream.jsonl"))
         assert len(files) == 1
-        events = [
-            json.loads(line) for line in files[0].read_text().splitlines() if line
-        ]
+        raw_stream = files[0].read_text()
+        assert secret not in raw_stream
+        events = [json.loads(line) for line in raw_stream.splitlines() if line]
         types = [e["type"] for e in events]
         assert "toolcall_start" in types
         assert "toolcall_delta" in types
         assert "toolcall_end" in types
-        # toolcall_end should carry accumulated arg char count
+        # Structural telemetry remains, but argument deltas/previews are content.
+        delta_ev = next(e for e in events if e["type"] == "toolcall_delta")
+        assert "chars" in delta_ev
+        assert "accumulated" in delta_ev
+        assert "preview" not in delta_ev
         end_ev = next(e for e in events if e["type"] == "toolcall_end")
         assert "args_chars" in end_ev
         assert end_ev["args_chars"] > 0
+        assert "args_preview" not in end_ev
 
     async def test_no_stream_file_without_record_stream(self, tmp_path):
         """Default (record_stream=False) must not create any stream file."""
@@ -585,6 +600,7 @@ class TestStreamRecording:
             service_name="t",
             agent_name="a",
             exporters=[],
+            record_content=True,
             record_stream=True,
             stream_dir=tmp_path,
         )
@@ -602,7 +618,40 @@ class TestStreamRecording:
         types = [e["type"] for e in events]
         assert "error" in types
         err_ev = next(e for e in events if e["type"] == "error")
-        assert "error_message" in err_ev
+        assert err_ev["error_message"] == "boom"
+
+    async def test_stream_error_hides_message_without_content_opt_in(self, tmp_path):
+        secret = "Authorization: Bearer STREAMSECRET"
+        provider = FauxProvider(provider_id="faux")
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    "oops",
+                    stop_reason="error",
+                    error_message=secret,
+                )
+            ]
+        )
+        agent = Agent(model=provider.model(MODEL.id), system_prompt="s")
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        await agent.prompt("x")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        stream_file = next(tmp_path.glob("*.stream.jsonl"))
+        raw_stream = stream_file.read_text()
+        assert secret not in raw_stream
+        events = [json.loads(line) for line in raw_stream.splitlines() if line]
+        err_ev = next(e for e in events if e["type"] == "error")
+        assert err_ev["error_message"] == "provider error"
 
     async def test_stream_write_exception_swallowed(self, tmp_path):
         """If the stream file write raises, _write_stream_event swallows it silently."""

--- a/tests/tracing/test_recorder_coverage.py
+++ b/tests/tracing/test_recorder_coverage.py
@@ -547,6 +547,60 @@ class TestStreamRecording:
         assert end_ev["args_chars"] > 0
         assert "args_preview" not in end_ev
 
+    async def test_stream_toolcall_previews_require_content_opt_in(self, tmp_path):
+        from pydantic import BaseModel
+
+        secret = "Bearer OPTED-IN-STREAM"
+
+        class P(BaseModel):
+            authorization: str
+
+        async def noop(tool_call_id: str, params: P, *, signal=None, on_update=None):
+            return AgentToolResult(content=[TextContent(text="done")])
+
+        tool = AgentTool(name="noop", description="d", parameters=P, execute=noop)
+        provider = FauxProvider(provider_id="faux")
+        provider.append_responses(
+            [
+                faux_assistant_message(
+                    [
+                        ToolCall(
+                            id="tc1",
+                            name="noop",
+                            arguments={"authorization": secret},
+                        )
+                    ],
+                    stop_reason="tool_use",
+                ),
+                faux_assistant_message("all done"),
+            ]
+        )
+        agent = Agent(model=provider.model(MODEL.id), system_prompt="s", tools=[tool])
+        tracer = Tracer(
+            service_name="t",
+            agent_name="a",
+            exporters=[],
+            record_content=True,
+            record_stream=True,
+            stream_dir=tmp_path,
+        )
+        tracer.attach(agent)
+
+        await agent.prompt("go")
+        await agent.wait_for_idle()
+        await tracer.shutdown()
+
+        stream_file = next(tmp_path.glob("*.stream.jsonl"))
+        events = [
+            json.loads(line) for line in stream_file.read_text().splitlines() if line
+        ]
+        delta_previews = "".join(
+            event["preview"] for event in events if event["type"] == "toolcall_delta"
+        )
+        end_ev = next(event for event in events if event["type"] == "toolcall_end")
+        assert "OPTED-IN-STREAM" in delta_previews
+        assert "OPTED-IN-STREAM" in end_ev["args_preview"]
+
     async def test_no_stream_file_without_record_stream(self, tmp_path):
         """Default (record_stream=False) must not create any stream file."""
         provider = FauxProvider(provider_id="faux")

--- a/website/docs/guides/hitl/durable.md
+++ b/website/docs/guides/hitl/durable.md
@@ -51,10 +51,12 @@ async with PostgresCheckpointer("postgresql://...") as cp:
     # tool_name="bash", args={"cmd":"rm /tmp/foo"}, ...)
 
     # Graceful suspend — persist the assistant message + unresolved
-    # tool_calls, keep pending_request in DB, emit AgentSuspendedEvent.
+    # tool_calls and keep pending_request in DB. detach() commits the
+    # HitlDetached transition; prompt() then emits AgentSuspendedEvent
+    # after recording outcome=suspended.
     # The HTTP handler returns 200 { status: "awaiting_approval" }.
     await agent.detach()
-    await task  # prompt() unwinds with HitlDetached
+    await task
 
 
 # ---------- Process 2: HTTP POST /respond ----------

--- a/website/docs/guides/hitl/reference.md
+++ b/website/docs/guides/hitl/reference.md
@@ -34,7 +34,7 @@ agent listeners. A `_run_lock` (`asyncio.Lock`) serialises `prompt`,
 | Method | Signature | Description |
 |---|---|---|
 | `load_pending_hitl_request()` | `async → HitlRequest \| None` | Reads the pending from the checkpointer (even post-detach). |
-| `detach()` | `async → None` | Emits `AgentSuspendedEvent(pending_request=...)` then triggers `HitlDetached` on the channel future. The loop exits silently; assistant message retains unresolved tool calls; `pending_request` stays persisted. |
+| `detach()` | `async → None` | Snapshots the pending request and triggers `HitlDetached` on the channel future. After the owning run task records `outcome=suspended` and clears its active run, it emits `AgentSuspendedEvent(pending_request=...)`. The assistant message retains unresolved tool calls and `pending_request` stays persisted. |
 | `respond(*, question_id=, answer=)` | `async → None` | Resumes a suspended run. Validates qid matches persistent pending, attaches answer to channel, re-enters the loop via `run_agent_loop_resume`. |
 | `abort_pending(reason=)` | `async → None` | Closes the conversation. Two-phase: Phase 1 signals in-flight await (no lock). Phase 2 appends synthetic deny tool_results + terminal `stop_reason="aborted"` assistant (under lock). |
 
@@ -50,14 +50,15 @@ Four new events are emitted on the agent's event stream:
 |---|---|---|
 | `HitlRequestEvent` | Channel receives a new `confirm/approve/ask`. | `request: HitlRequest` |
 | `HitlAnswerEvent` | `channel.answer()` or `channel.cancel()` fires. | `question_id: str`, `answer: Any`, `cancelled: bool`, `timed_out: bool` |
-| `AgentSuspendedEvent` | `agent.detach()` called while HITL was pending. | `pending_request: HitlRequest` |
+| `AgentSuspendedEvent` | A detach-triggered run has committed `outcome=suspended`. | `pending_request: HitlRequest` |
 | `AgentAbortedEvent` | `agent.abort_pending()` closes the conversation. | `reason: str` |
 
 These are all included in the `AgentEvent` union, so typed listeners
 automatically cover them. `HitlRequestEvent` and `HitlAnswerEvent` are
 emitted by the channel through the agent's emit binding. `AgentSuspendedEvent`
-and `AgentAbortedEvent` are emitted by the Agent layer (not the loop — the
-Agent has the channel handle to populate the real `pending_request` payload).
+and `AgentAbortedEvent` are emitted by the Agent layer. Suspension payload is
+snapshotted by `detach()`, then published by the owning run task only after the
+suspended transition is committed.
 
 ## Trace spans
 

--- a/website/docs/guides/tracing/content-recording.md
+++ b/website/docs/guides/tracing/content-recording.md
@@ -7,10 +7,11 @@ sidebar_position: 4
 # Recording Prompts, Responses, and Tool Payloads
 
 By default CubePi's tracing emits structural attributes only — operation
-names, models, token counts, finish reasons, durations. **No prompt content,
-no model output, no tool arguments or results leave the process.** This is
-deliberate: many agent setups handle PII, customer data, or trade-secret
-prompts that don't belong in a third-party observability backend.
+names, models, token counts, finish reasons, durations, and typed error classes.
+**No prompt content, model output, tool arguments/results, raw exception text,
+or exception stack traces leave the process.** This is deliberate: many agent
+setups handle PII, customer data, or trade-secret prompts that don't belong in
+a third-party observability backend.
 
 When you _do_ want content captured — for offline evaluation, debugging a
 flaky tool call, or building a labelled dataset — opt in explicitly with
@@ -37,6 +38,10 @@ attributes per the OTel GenAI semconv:
 | `cubepi.turn` | `gen_ai.input.messages` (per-turn slice), `gen_ai.output.messages` (per-turn slice) |
 | `chat <model>` | `gen_ai.system_instructions`, `gen_ai.input.messages`, `gen_ai.tool.definitions`, `cubepi.llm.raw_request`, `cubepi.llm.raw_response` |
 | `execute_tool <tool_name>` | `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` |
+
+Developer-authored agent and tool descriptions are treated as operational
+metadata and are exported regardless of `record_content`; do not place secrets
+or per-request user data in description strings.
 
 The `chat` span's `gen_ai.input.messages` contains the **full chronological
 context** the provider request actually carried — including prior assistant
@@ -131,8 +136,10 @@ tracer = Tracer(
 
 `record_stream` writes `<stream_dir>/<run_id>.stream.jsonl` (one JSON line per
 `StreamEvent`). Every line carries `t` (elapsed seconds from run start) and
-`type`. Tool-call lines also include `ci` (content index), `id`, `name`, delta
-sizes, and argument previews:
+`type`. Tool-call lines also include structural fields such as `ci` (content
+index), `id`, `name`, delta sizes, and accumulated argument length. When
+`record_content=True`, they additionally include argument previews, and error
+events include the raw provider error message:
 
 ```json
 {"t": 5.873, "type": "toolcall_start", "ci": 1, "id": "toolu_...", "name": "show_widget"}
@@ -144,8 +151,11 @@ This makes it straightforward to confirm whether argument chunks ever arrived, o
 whether the same event fired twice (e.g. a provider that sends `finish_reason`
 twice produces two `toolcall_end` lines for the same `ci`).
 
-`record_stream` is independent of `record_content` — turn it on only in debugging
-sessions. Files can grow large for long-running, tool-heavy agents.
+`record_stream` is independent of `record_content`: it can retain structural
+chunk timing and size evidence without content recording. Raw tool-argument
+previews and raw error messages still require `record_content=True`. Turn stream
+recording on only in debugging sessions; files can grow large for long-running,
+tool-heavy agents.
 
 ## Auditing what's recorded
 

--- a/website/docs/guides/tracing/getting-started.md
+++ b/website/docs/guides/tracing/getting-started.md
@@ -140,15 +140,19 @@ The recorder treats cancellation as a control signal, not a failure:
 - `agent.abort()` mid-stream → spans close with `cubepi.aborted=true` and
   `error.type=cubepi.aborted`, **status UNSET** (per OTel guidance — cancellation
   isn't an error).
+- `agent.detach()` at a durable HITL prompt → open spans close with
+  `cubepi.run.outcome=suspended` and no aborted/error classification. A later
+  `respond()` is a new activation trace; correlate the two with metadata such as
+  a host run or conversation ID.
 - A provider raising → chat/turn/root close with **status ERROR**, an
   `exception` event on the chat span, and `error.type` derived from the
   exception class (`timeout`, `connection_error`, fully-qualified class name, …).
 - An MCP `tools/call` returning `isError=true` → CLIENT span closes
   ERROR + `error.type=mcp.is_error`.
 
-Either way, `detach()` and `tracer.shutdown()` always close any span the run
-left open, so cancelled runs are still visible in your backend rather than
-silently disappearing.
+In every case, `detach()` and `tracer.shutdown()` close any span the activation
+left open, so cancelled and suspended runs remain visible in your backend rather
+than silently disappearing.
 
 ## What's on each span
 

--- a/website/docs/guides/tracing/getting-started.md
+++ b/website/docs/guides/tracing/getting-started.md
@@ -137,21 +137,23 @@ instrumented MCP server can continue the trace.
 
 The recorder treats cancellation as a control signal, not a failure:
 
-- `agent.abort()` mid-stream → spans close with `cubepi.aborted=true` and
-  `error.type=cubepi.aborted`, **status UNSET** (per OTel guidance — cancellation
-  isn't an error).
+- `agent.abort()` or a cancelled one-shot call → affected spans close with
+  `cubepi.aborted=true` and `error.type=cubepi.aborted`, **status UNSET**, and no
+  exception event (per OTel guidance — cancellation isn't an error).
 - `agent.detach()` at a durable HITL prompt → open spans close with
   `cubepi.run.outcome=suspended` and no aborted/error classification. A later
   `respond()` is a new activation trace; correlate the two with metadata such as
   a host run or conversation ID.
-- A provider raising → chat/turn/root close with **status ERROR**, an
-  `exception` event on the chat span, and `error.type` derived from the
-  exception class (`timeout`, `connection_error`, fully-qualified class name, …).
-  With the default `record_content=False`, the status description is generic and
-  the event contains only `exception.type`; raw exception messages and stack
-  traces are included only when content recording is explicitly enabled.
-- An MCP `tools/call` returning `isError=true` → CLIENT span closes
-  ERROR + `error.type=mcp.is_error`.
+- A provider or one-shot call raising → affected spans close with **status
+  ERROR** and `error.type` derived from the exception class (`timeout`,
+  `connection_error`, fully-qualified class name, …). With the default
+  `record_content=False`, status descriptions are generic and exception events
+  contain only `exception.type`; raw exception messages and stack traces are
+  included only when content recording is explicitly enabled.
+- An MCP transport raising follows the same privacy rule on its CLIENT span. An
+  MCP `tools/call` returning `isError=true` closes the CLIENT span with ERROR +
+  `error.type=mcp.is_error`; its status description is also generic unless
+  content recording is enabled.
 
 In every case, `detach()` and `tracer.shutdown()` close any span the activation
 left open, so cancelled and suspended runs remain visible in your backend rather
@@ -185,8 +187,9 @@ Optional, opt-in via `Tracer(record_content=True)`:
 `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`,
 `gen_ai.tool.definitions`, `gen_ai.tool.call.arguments`,
 `gen_ai.tool.call.result`, `cubepi.llm.raw_request`,
-`cubepi.llm.raw_response`, provider exception messages, and provider exception
-stack traces. See [Content & Redaction](./content-recording).
+`cubepi.llm.raw_response`, provider/MCP/one-shot exception messages and stack
+traces, and stream-log tool-argument/error previews. See
+[Content & Redaction](./content-recording).
 
 ## Multiple agents, one process
 

--- a/website/docs/guides/tracing/getting-started.md
+++ b/website/docs/guides/tracing/getting-started.md
@@ -147,6 +147,9 @@ The recorder treats cancellation as a control signal, not a failure:
 - A provider raising → chat/turn/root close with **status ERROR**, an
   `exception` event on the chat span, and `error.type` derived from the
   exception class (`timeout`, `connection_error`, fully-qualified class name, …).
+  With the default `record_content=False`, the status description is generic and
+  the event contains only `exception.type`; raw exception messages and stack
+  traces are included only when content recording is explicitly enabled.
 - An MCP `tools/call` returning `isError=true` → CLIENT span closes
   ERROR + `error.type=mcp.is_error`.
 
@@ -182,7 +185,8 @@ Optional, opt-in via `Tracer(record_content=True)`:
 `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`,
 `gen_ai.tool.definitions`, `gen_ai.tool.call.arguments`,
 `gen_ai.tool.call.result`, `cubepi.llm.raw_request`,
-`cubepi.llm.raw_response`. See [Content & Redaction](./content-recording).
+`cubepi.llm.raw_response`, provider exception messages, and provider exception
+stack traces. See [Content & Redaction](./content-recording).
 
 ## Multiple agents, one process
 


### PR DESCRIPTION
## Summary

- close durable HITL activations as `suspended` instead of treating a valid pause as an aborted run
- keep provider, turn, MCP, one-shot, and stream raw diagnostic content behind `record_content=True`
- preserve typed error classes and lifecycle/status metadata when content recording is disabled
- make MCP provider registration and one-shot cancellation cleanup fail-safe and deterministic
- document the suspended tracing lifecycle and privacy contract

## Why

A durable HITL activation ends with `AgentSuspendedEvent`, not `AgentEndEvent`. The recorder previously ignored that event, so the required detach cleanup closed the still-open spans as `cubepi.aborted=true`. A valid pause was therefore indistinguishable from cancellation.

Separately, several error paths could retain raw provider/tool diagnostics even when the tracer was constructed with `record_content=False`. That made the privacy switch incomplete.

## Behavior

- completed activations remain completed
- cancelled activations remain explicitly aborted
- durable HITL pauses now end with `cubepi.run.outcome=suspended` and are not marked aborted
- `record_content=False` retains operational IDs, enums, model/tool names, counts, timings, token usage, and typed error classes, but excludes raw messages, arguments/results, provider descriptions, exception messages, and stack traces
- `record_stream=False` continues to disable raw stream files

## Validation

- `tests/tracing`: 224 passed
- full suite: 1780 passed, 90 skipped
- Ruff check/format: passed
- mypy: passed across 98 source files
- independent adversarial review: 0 BLOCKER / 0 IMPORTANT
- targeted mutations confirmed coverage for suspended-vs-aborted lifecycle, MCP registration cleanup, stream privacy, one-shot cancellation, and typed exception retention

## Commits

- `5e51086` — durable HITL pauses are suspended, not aborted
- `550f56f` — provider/turn raw errors follow content opt-in
- `019a261` — MCP/one-shot/stream diagnostics follow content opt-in
