### PR TITLE
chore(release): prepare 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.4] - 2026-08-10
+
 ### Changed
 
 - **`cubepi.run_id` now follows the agent business run id.** On
@@ -763,7 +765,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.2.0]** - 2026-05-10 — see the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.2.0).
 - **[0.1.0]** - 2026-05-09 — initial release. See the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.3...HEAD
+[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.4...HEAD
+[0.13.4]: https://github.com/cubeplexai/cubepi/compare/v0.13.3...v0.13.4
 [0.13.3]: https://github.com/cubeplexai/cubepi/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/cubeplexai/cubepi/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/cubeplexai/cubepi/compare/v0.13.0...v0.13.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cubepi"
-version = "0.13.3"
+version = "0.13.4"
 description = "Pythonic async-native agent framework"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "cubepi"
-version = "0.13.3"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bump package version `0.13.3` → `0.13.4`
- Promote Unreleased changelog entries into `## [0.13.4] - 2026-08-10`
- Update uv.lock package version

### Included since v0.13.3

- **Changed:** `cubepi.run_id` follows agent business run id (`prompt` / `Message.run_id`)
- **Fixed:** durable HITL suspension trace terminal
- **Fixed:** raw diagnostics gated by content opt-in
- **Fixed:** oneshot cancellation matches agent/MCP abort semantics

Patch-only; no docs version snapshot (X.Y cut not required).

## Test plan

- [x] Version strings consistent in pyproject.toml / CHANGELOG / uv.lock
- [ ] After merge: publish GitHub release `v0.13.4` to trigger PyPI workflow