### PR TITLE
docs(website): clarify LangGraph multi-agent comparison

### DIFF
--- a/website/docs/migration/from-langgraph.md
+++ b/website/docs/migration/from-langgraph.md
@@ -215,11 +215,14 @@ checkpoints. `fork` creates a persistent branch you can continue;
 `fork_once` runs a single probe and discards everything. See
 [Conversation Forking](../guides/agents/forking).
 
-## What langgraph does that CubePi doesn't (yet)
+## What LangGraph still offers beyond CubePi
 
-- **Multi-agent supervisor patterns.** No first-class "agents
-  spawning agents" abstraction. You can build it by running multiple
-  `Agent` instances with shared tools.
+- **Graph-native multi-agent orchestration.** CubePi includes
+  `SubagentMiddleware` for tool-driven delegation: a parent agent can dispatch
+  self-contained tasks to typed child agents with dedicated prompts, models,
+  tools, and middleware. What CubePi does not yet provide is LangGraph's
+  explicit, durable graph model for supervisor routing, conditional branches,
+  parallel fan-out/fan-in, and graph-level state management.
 - **Visual graph rendering.** No `app.get_graph().draw_mermaid()`
   equivalent. CubePi's flow is linear so the picture would be a single
   line anyway.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/migration/from-langgraph.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/migration/from-langgraph.md
@@ -210,10 +210,12 @@ CubePi 在已完成的 run 边界处分叉，而非任意 mid-run 检查点。`f
 创建可继续对话的持久化分支；`fork_once` 运行单次探针并丢弃所有内容。
 参见[会话分叉](../guides/agents/forking)。
 
-## langgraph 有而 CubePi 暂无的功能
+## LangGraph 仍优于 CubePi 的能力
 
-- **多 agent 监管模式。** 没有"agent 派生 agent"的原生抽象。
-  你可以通过运行多个共享工具的 `Agent` 实例来实现。
+- **图原生的多智能体编排。** CubePi 提供 `SubagentMiddleware`，支持工具驱动的委派：
+  父 Agent 可以将自包含任务分派给具有专属 prompt、model、tools 和 middleware 的
+  类型化子 Agent。CubePi 目前尚未提供 LangGraph 那种显式、可持久化的图模型，
+  用于 supervisor 路由、条件分支、并行 fan-out/fan-in 以及图级状态管理。
 - **可视化图渲染。** 没有 `app.get_graph().draw_mermaid()` 的等价物。
   CubePi 的流程是线性的，画出来也只是一条直线。
 - **原生 trace 可视化 UI。** CubePi 不像 LangSmith / Langfuse 那样

--- a/website/src/pages/compare/langgraph.tsx
+++ b/website/src/pages/compare/langgraph.tsx
@@ -95,7 +95,7 @@ await agent.prompt("Weather in Tokyo?")
     {
       h2: 'When LangGraph is the better fit',
       body: [
-        'LangGraph is the better choice if you genuinely need arbitrary multi-agent supervisor graphs or visual graph rendering — CubePi keeps its flow linear by design and emits vendor-neutral OpenTelemetry rather than shipping its own trace UI. CubePi has `Agent.fork()` and `Agent.fork_once()` for branching at completed-run boundaries; LangGraph supports finer-grained mid-run checkpoint forks if you need that granularity. If your agent is fundamentally a loop, CubePi removes the graph machinery you were not really using.',
+        'LangGraph is the better choice if you need explicit, durable multi-agent graphs for supervisor routing, conditional branches, or parallel fan-out/fan-in, or if you need visual graph rendering. CubePi supports tool-driven delegation through `SubagentMiddleware`: a parent agent can dispatch self-contained work to typed child agents with dedicated prompts, models, tools, and middleware. CubePi keeps its core flow linear by design and emits vendor-neutral OpenTelemetry rather than shipping its own trace UI. CubePi has `Agent.fork()` and `Agent.fork_once()` for branching at completed-run boundaries; LangGraph supports finer-grained mid-run checkpoint forks if you need that granularity. If your agent is fundamentally a loop, CubePi removes the graph machinery you were not really using.',
       ],
     },
   ],
@@ -198,7 +198,7 @@ await agent.prompt("Weather in Tokyo?")
     {
       h2: '什么时候 LangGraph 更合适',
       body: [
-        '如果你确实需要任意的多 agent supervisor 图或可视化图渲染,LangGraph 更合适 —— CubePi 在设计上保持流程线性,并输出厂商中立的 OpenTelemetry,而不是自带一套 trace UI。CubePi 已有 `Agent.fork()` 和 `Agent.fork_once()` 在已完成的 run 边界处分叉;如果你需要 mid-run 粒度的任意检查点分叉,LangGraph 粒度更细。但如果你的 agent 本质上就是一个循环,CubePi 帮你去掉了那些你其实没真正用上的图机制。',
+        '如果你需要用于 supervisor 路由、条件分支或并行 fan-out/fan-in 的显式、可持久化多智能体图，或需要可视化图渲染，LangGraph 更合适。CubePi 通过 `SubagentMiddleware` 支持工具驱动的委派：父 Agent 可以将自包含任务分派给具有专属 prompt、model、tools 和 middleware 的类型化子 Agent。CubePi 在设计上保持核心流程线性，并输出厂商中立的 OpenTelemetry，而不是自带一套 trace UI。CubePi 已有 `Agent.fork()` 和 `Agent.fork_once()` 在已完成的 run 边界处分叉；如果你需要 mid-run 粒度的任意检查点分叉，LangGraph 粒度更细。但如果你的 agent 本质上就是一个循环，CubePi 帮你去掉了那些你其实没真正用上的图机制。',
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- describe CubePi\u2019s built-in `SubagentMiddleware` delegation
- distinguish it from LangGraph\u2019s explicit, durable graph-native orchestration
- align the English and Simplified Chinese migration docs and comparison page

## Validation
- `git diff --check`
- `pnpm typecheck` *(blocked by pre-existing `src/pages/faq.tsx:20` error: `el.props` is `unknown`)*
- `pnpm exec docusaurus build` *(blocked by pre-existing missing generated API docs referenced from `sidebars.ts`)*