### PR TITLE
feat(providers): harden FallbackBoundModel error policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`FallbackBoundModel` retries the active model before hopping**, then
+  sticks to the first successful leg for the rest of the agent run
+  (`#211`). Transient `RateLimited` / `ProviderUnavailable` retry up to
+  `max_retries_per_model=3` (4 attempts) and honour a capped
+  `retry_after`. Residual `ProviderBadRequest` and `ModelNotFound` hop
+  without same-model retry; `ProviderAuthFailed` and `ContentFiltered`
+  stay fail-closed. Stream first-event errors now carry typed fields so
+  the same predicate applies to exceptions and error events. Exhaustion
+  raises `ProviderUnavailable` with `.errors` listing every leg. New
+  subclasses `ModelNotFound` and `ContentFiltered` inherit
+  `ProviderBadRequest`. `ProviderError.error_code` is extracted from
+  vendor bodies when present.
+
 ## [0.13.4] - 2026-08-10
 
 ### Changed

--- a/cubepi/__init__.py
+++ b/cubepi/__init__.py
@@ -43,7 +43,9 @@ from cubepi.providers import (
     synthetic_user_message,
 )
 from cubepi.errors import (
+    ContentFiltered,
     ContextLengthExceeded,
+    ModelNotFound,
     ProviderAuthFailed,
     ProviderBadRequest,
     ProviderError,
@@ -86,6 +88,7 @@ __all__ = [
     "BaseProvider",
     "BoundModel",
     "CapabilityDescriptor",
+    "ContentFiltered",
     "ContextLengthExceeded",
     "DEFAULT_TRIGGER_ERRORS",
     "FallbackBoundModel",
@@ -102,6 +105,7 @@ __all__ = [
     "MessageStream",
     "Middleware",
     "Model",
+    "ModelNotFound",
     "Provider",
     "ProviderAuthFailed",
     "ProviderBadRequest",

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -764,6 +764,15 @@ class Agent(Generic[TMessage]):
         )
 
     async def _run_prompt(self, messages: list[Message]) -> None:
+        from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+
+        token = begin_fallback_run()
+        try:
+            await self._run_prompt_body(messages)
+        finally:
+            end_fallback_run(token)
+
+    async def _run_prompt_body(self, messages: list[Message]) -> None:
         sink = self._outcome_sink()
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop(
@@ -789,6 +798,15 @@ class Agent(Generic[TMessage]):
         )
 
     async def _run_continuation(self) -> None:
+        from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+
+        token = begin_fallback_run()
+        try:
+            await self._run_continuation_body()
+        finally:
+            end_fallback_run(token)
+
+    async def _run_continuation_body(self) -> None:
         sink = self._outcome_sink()
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop_continue(
@@ -1083,6 +1101,15 @@ class Agent(Generic[TMessage]):
             await self._process_event(AgentAbortedEvent(reason=reason))
 
     async def _run_hitl_resume(self) -> None:
+        from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+
+        token = begin_fallback_run()
+        try:
+            await self._run_hitl_resume_body()
+        finally:
+            end_fallback_run(token)
+
+    async def _run_hitl_resume_body(self) -> None:
         sink = self._outcome_sink()
         await self._run_with_lifecycle(
             lambda signal: run_agent_loop_resume(

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -1101,12 +1101,19 @@ class Agent(Generic[TMessage]):
             await self._process_event(AgentAbortedEvent(reason=reason))
 
     async def _run_hitl_resume(self) -> None:
-        from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+        from cubepi.providers.fallback import (
+            begin_fallback_run,
+            end_fallback_run,
+            get_active_index,
+            set_active_index,
+        )
 
         token = begin_fallback_run()
+        set_active_index(self._fallback_active_index)
         try:
             await self._run_hitl_resume_body()
         finally:
+            self._fallback_active_index = get_active_index()
             end_fallback_run(token)
 
     async def _run_hitl_resume_body(self) -> None:

--- a/cubepi/agent/agent.py
+++ b/cubepi/agent/agent.py
@@ -311,6 +311,7 @@ class Agent(Generic[TMessage]):
         self._listeners: list[Callable] = []
         self._active_signal: asyncio.Event | None = None
         self._active_done: asyncio.Event | None = None
+        self._fallback_active_index: int = 0
 
     @property
     def state(self) -> AgentState:

--- a/cubepi/errors.py
+++ b/cubepi/errors.py
@@ -171,11 +171,20 @@ _RATE_LIMIT_PATTERNS = (
     re.compile(r"too many requests", re.IGNORECASE),
 )
 
+_MODEL_NOT_FOUND_CODES = frozenset(
+    {
+        "model_not_found",
+        "model_not_available",
+        "invalid_model",
+    }
+)
+
 _MODEL_NOT_FOUND_PATTERNS = (
     re.compile(r"model[_ ]not[_ ]found", re.IGNORECASE),
-    re.compile(r"does not exist", re.IGNORECASE),
     re.compile(r"unknown model", re.IGNORECASE),
     re.compile(r"invalid model", re.IGNORECASE),
+    re.compile(r"model .+ does not exist", re.IGNORECASE),
+    re.compile(r"does not exist.+model", re.IGNORECASE),
 )
 
 _CONTENT_FILTER_PATTERNS = (
@@ -252,16 +261,10 @@ def _first_str(*values: object) -> str | None:
     return None
 
 
-def extract_error_code(exc: BaseException) -> str | None:
-    """Best-effort vendor ``error_code`` from an SDK exception.
-
-    Priority (OpenAI / OpenAI-compatible first, then Anthropic ``type``):
-
-    1. ``error.code`` / nested ``error.error.code`` / ``body.error.code``
-    2. ``error.type`` (Anthropic) / ``type``
-    3. ``param`` only when it identifies the model
-    4. Never the full human message
-    """
+def _vendor_error_parts(
+    exc: BaseException,
+) -> tuple[str | None, str | None, str | None]:
+    """Return ``(code, type, param)`` from a vendor SDK exception."""
 
     body = getattr(exc, "body", None)
     err = getattr(exc, "error", None)
@@ -300,34 +303,57 @@ def extract_error_code(exc: BaseException) -> str | None:
         nested_map.get("param") if nested_map else None,
         body_error.get("param") if body_error else None,
     )
+    return (
+        code.lower() if code else None,
+        typ.lower() if typ else None,
+        param.lower() if param else None,
+    )
 
+
+def extract_error_code(exc: BaseException) -> str | None:
+    """Best-effort vendor ``error_code`` from an SDK exception.
+
+    Priority (OpenAI / OpenAI-compatible first, then Anthropic ``type``):
+
+    1. ``error.code`` / nested ``error.error.code`` / ``body.error.code``
+    2. ``error.type`` (Anthropic) / ``type``
+    3. ``param`` only when it identifies the model
+    4. Never the full human message
+    """
+
+    code, typ, param = _vendor_error_parts(exc)
     if code:
-        return code.lower()
-    if typ and typ.lower() in _SPECIFIC_ERROR_CODES:
-        return typ.lower()
-    if typ in {"not_found_error", "not_found"}:
-        return typ.lower()
+        return code
+    if typ and typ in _SPECIFIC_ERROR_CODES:
+        return typ
     if param == "model" and typ:
-        return typ.lower()
-    if typ and typ.lower() not in {"invalid_request_error", "api_error", "error"}:
-        return typ.lower()
+        return typ
+    if typ and typ not in {
+        "invalid_request_error",
+        "api_error",
+        "error",
+        "not_found_error",
+        "not_found",
+    }:
+        return typ
     return None
 
 
 def _looks_like_model_not_found(
-    *, status: int | None, code: str | None, msg: str
+    *,
+    status: int | None,
+    code: str | None,
+    msg: str,
+    param: str | None = None,
 ) -> bool:
-    if code in {
-        "model_not_found",
-        "model_not_available",
-        "invalid_model",
-        "not_found_error",
-        "not_found",
-    }:
+    if code in _MODEL_NOT_FOUND_CODES:
         return True
-    if status == 404 and any(pat.search(msg) for pat in _MODEL_NOT_FOUND_PATTERNS):
+    if param == "model":
         return True
-    if any(pat.search(msg) for pat in _MODEL_NOT_FOUND_PATTERNS):
+    modelish = any(pat.search(msg) for pat in _MODEL_NOT_FOUND_PATTERNS)
+    if code in {"not_found_error", "not_found"} and modelish:
+        return True
+    if status in {400, 404} and modelish:
         return True
     return False
 
@@ -571,7 +597,9 @@ def classify_and_raise(
     status = _status_of(exc)
     provider = model.provider_id
     model_id = model.id
-    error_code = extract_error_code(exc)
+    error_code, _err_type, err_param = _vendor_error_parts(exc)
+    if error_code is None:
+        error_code = extract_error_code(exc)
 
     tokens_in = _estimate_input_tokens(messages)
     cw_val = getattr(model, "context_window", None)
@@ -633,15 +661,6 @@ def classify_and_raise(
             error_code=error_code,
         ) from exc
 
-    if _looks_like_model_not_found(status=status, code=error_code, msg=msg):
-        raise ModelNotFound(
-            msg,
-            provider=provider,
-            model=model_id,
-            status_code=status,
-            error_code=error_code,
-        ) from exc
-
     if isinstance(exc, (TimeoutError, ConnectionError)):
         raise ProviderUnavailable(
             msg,
@@ -666,6 +685,17 @@ def classify_and_raise(
 
     if status is not None and 500 <= status < 600:
         raise ProviderUnavailable(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            error_code=error_code,
+        ) from exc
+
+    if _looks_like_model_not_found(
+        status=status, code=error_code, msg=msg, param=err_param
+    ):
+        raise ModelNotFound(
             msg,
             provider=provider,
             model=model_id,

--- a/cubepi/errors.py
+++ b/cubepi/errors.py
@@ -44,10 +44,12 @@ class ProviderError(Exception):
         provider: str | None = None,
         model: str | None = None,
         status_code: int | None = None,
+        error_code: str | None = None,
     ) -> None:
         self.provider = provider
         self.model = model
         self.status_code = status_code
+        self.error_code = error_code
         super().__init__(message or self.__class__.__name__)
 
 
@@ -68,11 +70,16 @@ class ContextLengthExceeded(ProviderError):
         status_code: int | None = None,
         tokens_in: int | None = None,
         context_window: int | None = None,
+        error_code: str | None = None,
     ) -> None:
         self.tokens_in = tokens_in
         self.context_window = context_window
         super().__init__(
-            message, provider=provider, model=model, status_code=status_code
+            message,
+            provider=provider,
+            model=model,
+            status_code=status_code,
+            error_code=error_code,
         )
 
 
@@ -91,10 +98,15 @@ class RateLimited(ProviderError):
         model: str | None = None,
         status_code: int | None = None,
         retry_after: float | None = None,
+        error_code: str | None = None,
     ) -> None:
         self.retry_after = retry_after
         super().__init__(
-            message, provider=provider, model=model, status_code=status_code
+            message,
+            provider=provider,
+            model=model,
+            status_code=status_code,
+            error_code=error_code,
         )
 
 
@@ -103,11 +115,42 @@ class ProviderAuthFailed(ProviderError):
 
 
 class ProviderUnavailable(ProviderError):
-    """5xx, timeout, or connection failure."""
+    """5xx, timeout, or connection failure.
+
+    On chain exhaustion ``errors`` holds the per-leg failures (typed when
+    available). ``__cause__`` is the last typed error when one exists.
+    """
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        provider: str | None = None,
+        model: str | None = None,
+        status_code: int | None = None,
+        error_code: str | None = None,
+        errors: list[BaseException] | None = None,
+    ) -> None:
+        self.errors: list[BaseException] = list(errors) if errors else []
+        super().__init__(
+            message,
+            provider=provider,
+            model=model,
+            status_code=status_code,
+            error_code=error_code,
+        )
 
 
 class ProviderBadRequest(ProviderError):
-    """Other 4xx provider error (model_not_found, schema rejection, etc.)."""
+    """Residual 4xx provider error (schema rejection, uncertain vendor 400s)."""
+
+
+class ModelNotFound(ProviderBadRequest):
+    """The requested model id is unknown to this provider (typically 404)."""
+
+
+class ContentFiltered(ProviderBadRequest):
+    """Provider refused the request for safety / content-policy reasons."""
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +169,32 @@ _RATE_LIMIT_PATTERNS = (
     re.compile(r"rate ?limit", re.IGNORECASE),
     re.compile(r"quota (?:exceed|exhaust|limit|reach)", re.IGNORECASE),
     re.compile(r"too many requests", re.IGNORECASE),
+)
+
+_MODEL_NOT_FOUND_PATTERNS = (
+    re.compile(r"model[_ ]not[_ ]found", re.IGNORECASE),
+    re.compile(r"does not exist", re.IGNORECASE),
+    re.compile(r"unknown model", re.IGNORECASE),
+    re.compile(r"invalid model", re.IGNORECASE),
+)
+
+_CONTENT_FILTER_PATTERNS = (
+    re.compile(r"content[_ ]policy", re.IGNORECASE),
+    re.compile(r"content[_ ]filter", re.IGNORECASE),
+    re.compile(r"responsible[_ ]ai", re.IGNORECASE),
+    re.compile(r"safety[_ ]system", re.IGNORECASE),
+    re.compile(r"refused to (?:answer|respond)", re.IGNORECASE),
+)
+
+_SPECIFIC_ERROR_CODES = frozenset(
+    {
+        "model_not_found",
+        "model_not_available",
+        "invalid_model",
+        "content_filter",
+        "content_policy_violation",
+        "responsible_ai_policy_violation",
+    }
 )
 
 
@@ -168,6 +237,291 @@ def _estimate_input_tokens(messages: list[Message] | None) -> int | None:
     if total == 0:
         return None
     return max(1, math.ceil(total / 4))
+
+
+def _as_mapping(value: object) -> dict[str, object] | None:
+    if isinstance(value, dict):
+        return value
+    return None
+
+
+def _first_str(*values: object) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def extract_error_code(exc: BaseException) -> str | None:
+    """Best-effort vendor ``error_code`` from an SDK exception.
+
+    Priority (OpenAI / OpenAI-compatible first, then Anthropic ``type``):
+
+    1. ``error.code`` / nested ``error.error.code`` / ``body.error.code``
+    2. ``error.type`` (Anthropic) / ``type``
+    3. ``param`` only when it identifies the model
+    4. Never the full human message
+    """
+
+    body = getattr(exc, "body", None)
+    err = getattr(exc, "error", None)
+    nested = None
+    if isinstance(err, dict):
+        nested = err.get("error") if isinstance(err.get("error"), dict) else err
+    elif err is not None:
+        nested = {
+            "code": getattr(err, "code", None),
+            "type": getattr(err, "type", None),
+            "param": getattr(err, "param", None),
+        }
+
+    body_map = _as_mapping(body)
+    body_error = _as_mapping(body_map.get("error")) if body_map else None
+    err_map = _as_mapping(err)
+    nested_map = _as_mapping(nested)
+
+    code = _first_str(
+        getattr(exc, "code", None),
+        err_map.get("code") if err_map else None,
+        nested_map.get("code") if nested_map else None,
+        body_error.get("code") if body_error else None,
+        body_map.get("code") if body_map else None,
+    )
+    typ = _first_str(
+        err_map.get("type") if err_map else None,
+        nested_map.get("type") if nested_map else None,
+        body_error.get("type") if body_error else None,
+        getattr(err, "type", None)
+        if err is not None and not isinstance(err, dict)
+        else None,
+    )
+    param = _first_str(
+        err_map.get("param") if err_map else None,
+        nested_map.get("param") if nested_map else None,
+        body_error.get("param") if body_error else None,
+    )
+
+    if code:
+        return code.lower()
+    if typ and typ.lower() in _SPECIFIC_ERROR_CODES:
+        return typ.lower()
+    if typ in {"not_found_error", "not_found"}:
+        return typ.lower()
+    if param == "model" and typ:
+        return typ.lower()
+    if typ and typ.lower() not in {"invalid_request_error", "api_error", "error"}:
+        return typ.lower()
+    return None
+
+
+def _looks_like_model_not_found(
+    *, status: int | None, code: str | None, msg: str
+) -> bool:
+    if code in {
+        "model_not_found",
+        "model_not_available",
+        "invalid_model",
+        "not_found_error",
+        "not_found",
+    }:
+        return True
+    if status == 404 and any(pat.search(msg) for pat in _MODEL_NOT_FOUND_PATTERNS):
+        return True
+    if any(pat.search(msg) for pat in _MODEL_NOT_FOUND_PATTERNS):
+        return True
+    return False
+
+
+def _looks_like_content_filtered(*, code: str | None, msg: str) -> bool:
+    if code in {
+        "content_filter",
+        "content_policy_violation",
+        "responsible_ai_policy_violation",
+    }:
+        return True
+    return any(pat.search(msg) for pat in _CONTENT_FILTER_PATTERNS)
+
+
+def classify_string_error(
+    message: str,
+    *,
+    model: _ClassifyTarget | None = None,
+    status_code: int | None = None,
+    error_code: str | None = None,
+    retry_after: float | None = None,
+    tokens_in: int | None = None,
+    context_window: int | None = None,
+) -> ProviderError:
+    """Classify a string-only stream / generate error into a typed error."""
+
+    provider = getattr(model, "provider_id", None) if model is not None else None
+    model_id = getattr(model, "id", None) if model is not None else None
+    msg = message or "provider error"
+    code = error_code.lower() if isinstance(error_code, str) else None
+    cw = context_window if context_window else getattr(model, "context_window", None)
+
+    for pat in _CONTEXT_LENGTH_PATTERNS:
+        if pat.search(msg):
+            return ContextLengthExceeded(
+                msg,
+                provider=provider,
+                model=model_id,
+                status_code=status_code,
+                tokens_in=tokens_in,
+                context_window=cw if cw else None,
+                error_code=code,
+            )
+
+    if status_code == 429 or any(pat.search(msg) for pat in _RATE_LIMIT_PATTERNS):
+        return RateLimited(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status_code or 429,
+            retry_after=retry_after,
+            error_code=code,
+        )
+
+    if status_code in (401, 403) or (code and "auth" in code):
+        return ProviderAuthFailed(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status_code,
+            error_code=code,
+        )
+
+    if _looks_like_content_filtered(code=code, msg=msg):
+        return ContentFiltered(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status_code,
+            error_code=code,
+        )
+
+    if _looks_like_model_not_found(status=status_code, code=code, msg=msg):
+        return ModelNotFound(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status_code,
+            error_code=code,
+        )
+
+    if status_code is not None and 500 <= status_code < 600:
+        return ProviderUnavailable(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status_code,
+            error_code=code,
+        )
+
+    return ProviderBadRequest(
+        msg,
+        provider=provider,
+        model=model_id,
+        status_code=status_code,
+        error_code=code,
+    )
+
+
+def error_from_stream_fields(
+    *,
+    error_message: str | None,
+    error_type: str | None = None,
+    error_code: str | None = None,
+    status_code: int | None = None,
+    retry_after: float | None = None,
+    provider_id: str | None = None,
+    model_id: str | None = None,
+    tokens_in: int | None = None,
+    context_window: int | None = None,
+) -> ProviderError:
+    """Rebuild a typed error from structured stream / message fields."""
+
+    type_map: dict[str, type[ProviderError]] = {
+        "RateLimited": RateLimited,
+        "ProviderUnavailable": ProviderUnavailable,
+        "ContextLengthExceeded": ContextLengthExceeded,
+        "ProviderAuthFailed": ProviderAuthFailed,
+        "ProviderBadRequest": ProviderBadRequest,
+        "ModelNotFound": ModelNotFound,
+        "ContentFiltered": ContentFiltered,
+    }
+    cls = type_map.get(error_type or "")
+    msg = error_message or (error_type or "provider error")
+    kwargs: dict[str, object] = {
+        "provider": provider_id,
+        "model": model_id,
+        "status_code": status_code,
+        "error_code": error_code,
+    }
+    if cls is RateLimited:
+        return RateLimited(msg, retry_after=retry_after, **kwargs)  # type: ignore[arg-type]
+    if cls is ContextLengthExceeded:
+        return ContextLengthExceeded(
+            msg,
+            tokens_in=tokens_in,
+            context_window=context_window,
+            **kwargs,  # type: ignore[arg-type]
+        )
+    if cls is not None:
+        return cls(msg, **kwargs)  # type: ignore[arg-type]
+    target = None
+    if provider_id or model_id:
+        target = type(
+            "_T",
+            (),
+            {
+                "id": model_id or "",
+                "provider_id": provider_id or "",
+                "context_window": context_window,
+            },
+        )()
+    return classify_string_error(
+        msg,
+        model=target,
+        status_code=status_code,
+        error_code=error_code,
+        retry_after=retry_after,
+        tokens_in=tokens_in,
+        context_window=context_window,
+    )
+
+
+def annotate_error_event(
+    exc: BaseException,
+    *,
+    fallback_message: str | None = None,
+) -> dict[str, object]:
+    """Fields to stamp on ``StreamEvent`` / ``AssistantMessage`` for a failure."""
+
+    if isinstance(exc, ProviderError):
+        fields: dict[str, object] = {
+            "error_message": fallback_message or str(exc),
+            "error_type": type(exc).__name__,
+            "error_code": exc.error_code,
+            "status_code": exc.status_code,
+            "provider_id": exc.provider or "",
+            "model_id": exc.model or "",
+        }
+        if isinstance(exc, RateLimited):
+            fields["retry_after"] = exc.retry_after
+        if isinstance(exc, ContextLengthExceeded):
+            fields["tokens_in"] = exc.tokens_in
+            fields["context_window"] = exc.context_window
+        return fields
+    return {
+        "error_message": fallback_message or str(exc),
+        "error_type": None,
+        "error_code": extract_error_code(exc),
+        "status_code": _status_of(exc),
+        "retry_after": _retry_after_from(exc),
+        "provider_id": "",
+        "model_id": "",
+    }
 
 
 def _retry_after_from(exc: BaseException) -> float | None:
@@ -217,6 +571,7 @@ def classify_and_raise(
     status = _status_of(exc)
     provider = model.provider_id
     model_id = model.id
+    error_code = extract_error_code(exc)
 
     tokens_in = _estimate_input_tokens(messages)
     cw_val = getattr(model, "context_window", None)
@@ -231,6 +586,7 @@ def classify_and_raise(
                 status_code=status,
                 tokens_in=tokens_in,
                 context_window=context_window,
+                error_code=error_code,
             ) from exc
 
     if (
@@ -246,6 +602,7 @@ def classify_and_raise(
             status_code=status,
             tokens_in=tokens_in,
             context_window=context_window,
+            error_code=error_code,
         ) from exc
 
     if status == 429 or any(pat.search(msg) for pat in _RATE_LIMIT_PATTERNS):
@@ -255,16 +612,43 @@ def classify_and_raise(
             model=model_id,
             status_code=status,
             retry_after=_retry_after_from(exc),
+            error_code=error_code,
         ) from exc
 
     if status in (401, 403):
         raise ProviderAuthFailed(
-            msg, provider=provider, model=model_id, status_code=status
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            error_code=error_code,
+        ) from exc
+
+    if _looks_like_content_filtered(code=error_code, msg=msg):
+        raise ContentFiltered(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            error_code=error_code,
+        ) from exc
+
+    if _looks_like_model_not_found(status=status, code=error_code, msg=msg):
+        raise ModelNotFound(
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            error_code=error_code,
         ) from exc
 
     if isinstance(exc, (TimeoutError, ConnectionError)):
         raise ProviderUnavailable(
-            msg, provider=provider, model=model_id, status_code=status
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            error_code=error_code,
         ) from exc
 
     # SDK-specific connection/timeout errors (openai.APIConnectionError,
@@ -273,17 +657,29 @@ def classify_and_raise(
     cls_name = type(exc).__name__
     if "ConnectionError" in cls_name or "Timeout" in cls_name:
         raise ProviderUnavailable(
-            msg, provider=provider, model=model_id, status_code=status
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            error_code=error_code,
         ) from exc
 
     if status is not None and 500 <= status < 600:
         raise ProviderUnavailable(
-            msg, provider=provider, model=model_id, status_code=status
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            error_code=error_code,
         ) from exc
 
     if status is not None and 400 <= status < 500:
         raise ProviderBadRequest(
-            msg, provider=provider, model=model_id, status_code=status
+            msg,
+            provider=provider,
+            model=model_id,
+            status_code=status,
+            error_code=error_code,
         ) from exc
 
     # Unknown → let original propagate. Callers might still need to handle it.
@@ -297,5 +693,11 @@ __all__ = [
     "ProviderAuthFailed",
     "ProviderUnavailable",
     "ProviderBadRequest",
+    "ModelNotFound",
+    "ContentFiltered",
     "classify_and_raise",
+    "classify_string_error",
+    "extract_error_code",
+    "error_from_stream_fields",
+    "annotate_error_event",
 ]

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -278,15 +278,19 @@ class AnthropicProvider(BaseProvider):
             except BaseException as e:
                 exc = e
                 err_text = self._error_message(e, model)
-                ev, err_fields = typed_error_event(
-                    e, model=model, error_message=err_text
-                )
+                ev = typed_error_event(e, model=model, error_message=err_text)
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
+                    error_message=ev.error_message,
+                    error_type=ev.error_type,
+                    error_code=ev.error_code,
+                    status_code=ev.status_code,
+                    retry_after=ev.retry_after,
                     usage=Usage(),
                     timestamp=time.time(),
-                    **err_fields,
+                    provider_id=ev.provider_id or model.provider_id,
+                    model_id=ev.model_id or model.id,
                 )
                 await self._emit(ms, ev, model)
                 ms.set_result(error_msg)

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -287,6 +287,8 @@ class AnthropicProvider(BaseProvider):
                     error_code=ev.error_code,
                     status_code=ev.status_code,
                     retry_after=ev.retry_after,
+                    tokens_in=ev.tokens_in,
+                    context_window=ev.context_window,
                     usage=Usage(),
                     timestamp=time.time(),
                     provider_id=ev.provider_id or model.provider_id,

--- a/cubepi/providers/anthropic.py
+++ b/cubepi/providers/anthropic.py
@@ -28,6 +28,7 @@ from cubepi.providers.base import (
     apply_sender_attribution,
     invoke_on_payload,
     invoke_on_response,
+    typed_error_event,
 )
 from cubepi.providers.capability import (
     CapabilityDescriptor,
@@ -277,18 +278,17 @@ class AnthropicProvider(BaseProvider):
             except BaseException as e:
                 exc = e
                 err_text = self._error_message(e, model)
+                ev, err_fields = typed_error_event(
+                    e, model=model, error_message=err_text
+                )
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
-                    error_message=err_text,
                     usage=Usage(),
                     timestamp=time.time(),
-                    provider_id=model.provider_id,
-                    model_id=model.id,
+                    **err_fields,
                 )
-                await self._emit(
-                    ms, StreamEvent(type="error", error_message=err_text), model
-                )
+                await self._emit(ms, ev, model)
                 ms.set_result(error_msg)
                 if not isinstance(e, Exception):
                     raise

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -105,6 +105,10 @@ class AssistantMessage(BaseModel):
     content: list[Content | ThinkingContent | ToolCall]
     stop_reason: str = "stop"
     error_message: str | None = None
+    error_type: str | None = None
+    error_code: str | None = None
+    status_code: int | None = None
+    retry_after: float | None = None
     usage: Usage | None = None
     timestamp: float | None = None
     provider_id: str = ""
@@ -243,6 +247,61 @@ class StreamEvent(BaseModel):
     delta: str | None = None
     partial: AssistantMessage | None = None
     error_message: str | None = None
+    error_type: str | None = None
+    error_code: str | None = None
+    status_code: int | None = None
+    retry_after: float | None = None
+    provider_id: str | None = None
+    model_id: str | None = None
+    tokens_in: int | None = None
+    context_window: int | None = None
+
+
+def typed_error_event(
+    exc: BaseException,
+    *,
+    model: "Model",
+    error_message: str,
+) -> tuple[StreamEvent, dict[str, object]]:
+    """Build a typed error ``StreamEvent`` plus AssistantMessage kwargs."""
+
+    from cubepi.errors import annotate_error_event
+
+    fields = annotate_error_event(exc, fallback_message=error_message)
+    event = StreamEvent(
+        type="error",
+        error_message=str(fields.get("error_message") or error_message),
+        error_type=fields.get("error_type")
+        if isinstance(fields.get("error_type"), str)
+        else None,
+        error_code=fields.get("error_code")
+        if isinstance(fields.get("error_code"), str)
+        else None,
+        status_code=fields.get("status_code")
+        if isinstance(fields.get("status_code"), int)
+        else None,
+        retry_after=fields.get("retry_after")
+        if isinstance(fields.get("retry_after"), (int, float))
+        else None,
+        provider_id=str(fields.get("provider_id") or model.provider_id),
+        model_id=str(fields.get("model_id") or model.id),
+        tokens_in=fields.get("tokens_in")
+        if isinstance(fields.get("tokens_in"), int)
+        else None,
+        context_window=fields.get("context_window")
+        if isinstance(fields.get("context_window"), int)
+        else None,
+    )
+    msg_kwargs: dict[str, object] = {
+        "error_message": event.error_message,
+        "error_type": event.error_type,
+        "error_code": event.error_code,
+        "status_code": event.status_code,
+        "retry_after": event.retry_after,
+        "provider_id": event.provider_id or model.provider_id,
+        "model_id": event.model_id or model.id,
+    }
+    return event, msg_kwargs
 
 
 def format_provider_error(

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -109,6 +109,8 @@ class AssistantMessage(BaseModel):
     error_code: str | None = None
     status_code: int | None = None
     retry_after: float | None = None
+    tokens_in: int | None = None
+    context_window: int | None = None
     usage: Usage | None = None
     timestamp: float | None = None
     provider_id: str = ""

--- a/cubepi/providers/base.py
+++ b/cubepi/providers/base.py
@@ -262,46 +262,32 @@ def typed_error_event(
     *,
     model: "Model",
     error_message: str,
-) -> tuple[StreamEvent, dict[str, object]]:
-    """Build a typed error ``StreamEvent`` plus AssistantMessage kwargs."""
+) -> StreamEvent:
+    """Build a typed error ``StreamEvent`` from a classified exception."""
 
     from cubepi.errors import annotate_error_event
 
     fields = annotate_error_event(exc, fallback_message=error_message)
-    event = StreamEvent(
+    error_type = fields.get("error_type")
+    error_code = fields.get("error_code")
+    status_code = fields.get("status_code")
+    retry_after = fields.get("retry_after")
+    tokens_in = fields.get("tokens_in")
+    context_window = fields.get("context_window")
+    return StreamEvent(
         type="error",
         error_message=str(fields.get("error_message") or error_message),
-        error_type=fields.get("error_type")
-        if isinstance(fields.get("error_type"), str)
-        else None,
-        error_code=fields.get("error_code")
-        if isinstance(fields.get("error_code"), str)
-        else None,
-        status_code=fields.get("status_code")
-        if isinstance(fields.get("status_code"), int)
-        else None,
-        retry_after=fields.get("retry_after")
-        if isinstance(fields.get("retry_after"), (int, float))
+        error_type=error_type if isinstance(error_type, str) else None,
+        error_code=error_code if isinstance(error_code, str) else None,
+        status_code=status_code if isinstance(status_code, int) else None,
+        retry_after=float(retry_after)
+        if isinstance(retry_after, (int, float))
         else None,
         provider_id=str(fields.get("provider_id") or model.provider_id),
         model_id=str(fields.get("model_id") or model.id),
-        tokens_in=fields.get("tokens_in")
-        if isinstance(fields.get("tokens_in"), int)
-        else None,
-        context_window=fields.get("context_window")
-        if isinstance(fields.get("context_window"), int)
-        else None,
+        tokens_in=tokens_in if isinstance(tokens_in, int) else None,
+        context_window=context_window if isinstance(context_window, int) else None,
     )
-    msg_kwargs: dict[str, object] = {
-        "error_message": event.error_message,
-        "error_type": event.error_type,
-        "error_code": event.error_code,
-        "status_code": event.status_code,
-        "retry_after": event.retry_after,
-        "provider_id": event.provider_id or model.provider_id,
-        "model_id": event.model_id or model.id,
-    }
-    return event, msg_kwargs
 
 
 def format_provider_error(

--- a/cubepi/providers/fallback.py
+++ b/cubepi/providers/fallback.py
@@ -94,6 +94,21 @@ def reset_active() -> None:
         state.active_index = 0
 
 
+def get_active_index() -> int:
+    """Return the current sticky index, or 0 if no run is open."""
+
+    state = _run_state.get()
+    return 0 if state is None else state.active_index
+
+
+def set_active_index(index: int) -> None:
+    """Restore a previously snapshotted sticky index into the current run."""
+
+    state = _run_state.get()
+    if state is not None:
+        state.active_index = max(0, index)
+
+
 def _current_state() -> _FallbackRunState | None:
     return _run_state.get()
 
@@ -143,7 +158,22 @@ def _typed_from_message(msg: AssistantMessage, bound: BoundModel) -> ProviderErr
         retry_after=msg.retry_after,
         provider_id=msg.provider_id or bound.spec.provider_id,
         model_id=msg.model_id or bound.spec.id,
+        tokens_in=msg.tokens_in,
+        context_window=msg.context_window,
     )
+
+
+def _window_cannot_fit(bound: BoundModel, tokens_in: int | None) -> bool:
+    window = bound.spec.context_window or None
+    if tokens_in is None or not window:
+        return False
+    return int(window) < int(tokens_in)
+
+
+def _needed_tokens(err: BaseException | None) -> int | None:
+    if isinstance(err, ContextLengthExceeded):
+        return err.tokens_in
+    return None
 
 
 @dataclass(frozen=True)
@@ -297,9 +327,12 @@ class FallbackBoundModel:
             (f.error for f in reversed(failures) if isinstance(f.error, ProviderError)),
             None,
         )
+        by_leg: dict[tuple[str, str], BaseException] = {}
+        for item in failures:
+            by_leg[(item.provider_id, item.model_id)] = item.error
         exc = ProviderUnavailable(
             f"all providers exhausted; last error: {last!r}",
-            errors=[f.error for f in failures],
+            errors=list(by_leg.values()),
         )
         if last_typed is not None:
             exc.__cause__ = last_typed
@@ -338,11 +371,24 @@ class FallbackBoundModel:
         retry = tuple(self.retry_errors)
         failures: list[FailoverAttempt] = []
         start = self._start_index()
+        needed: int | None = None
 
         for index in range(start, len(self.chain)):
             bound = self.chain[index]
             next_bound = self.chain[index + 1] if index + 1 < len(self.chain) else None
             same_retries = 0
+
+            if _window_cannot_fit(bound, needed):
+                skip = ContextLengthExceeded(
+                    "skipped: context_window cannot fit prior tokens_in",
+                    provider=bound.spec.provider_id,
+                    model=bound.spec.id,
+                    tokens_in=needed,
+                    context_window=bound.spec.context_window,
+                )
+                self._record(failures, bound, skip, 0.0, 0, "failover")
+                await self._notify_failover(bound, next_bound, skip, index + 1)
+                continue
 
             while True:
                 t0 = time.monotonic()
@@ -406,6 +452,7 @@ class FallbackBoundModel:
                             return outer
 
                 assert err is not None
+                needed = _needed_tokens(err) or needed
                 duration_ms = (time.monotonic() - t0) * 1000
                 hop = await self._decide(
                     bound=bound,
@@ -443,11 +490,24 @@ class FallbackBoundModel:
         retry = tuple(self.retry_errors)
         failures: list[FailoverAttempt] = []
         start = self._start_index()
+        needed: int | None = None
 
         for index in range(start, len(self.chain)):
             bound = self.chain[index]
             next_bound = self.chain[index + 1] if index + 1 < len(self.chain) else None
             same_retries = 0
+
+            if _window_cannot_fit(bound, needed):
+                skip = ContextLengthExceeded(
+                    "skipped: context_window cannot fit prior tokens_in",
+                    provider=bound.spec.provider_id,
+                    model=bound.spec.id,
+                    tokens_in=needed,
+                    context_window=bound.spec.context_window,
+                )
+                self._record(failures, bound, skip, 0.0, 0, "failover")
+                await self._notify_failover(bound, next_bound, skip, index + 1)
+                continue
 
             while True:
                 t0 = time.monotonic()
@@ -473,6 +533,7 @@ class FallbackBoundModel:
                         return result
 
                 assert err is not None
+                needed = _needed_tokens(err) or needed
                 duration_ms = (time.monotonic() - t0) * 1000
                 hop = await self._decide(
                     bound=bound,

--- a/cubepi/providers/fallback.py
+++ b/cubepi/providers/fallback.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import inspect
 import logging
 import time
@@ -8,10 +9,13 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 from cubepi.errors import (
+    ContentFiltered,
     ContextLengthExceeded,
+    ProviderBadRequest,
     ProviderError,
     ProviderUnavailable,
     RateLimited,
+    error_from_stream_fields,
 )
 from cubepi.providers.base import (
     AssistantMessage,
@@ -29,51 +33,165 @@ from cubepi.providers.base import (
     chain_providers,  # re-exported for back-compat; canonical home is base.py
 )
 
+
 _log = logging.getLogger("cubepi.providers.fallback")
 
 
-DEFAULT_TRIGGER_ERRORS: frozenset[type[ProviderError]] = frozenset(
-    {RateLimited, ProviderUnavailable, ContextLengthExceeded}
+DEFAULT_RETRY_ERRORS: frozenset[type[ProviderError]] = frozenset(
+    {RateLimited, ProviderUnavailable}
 )
+
+DEFAULT_TRIGGER_ERRORS: frozenset[type[ProviderError]] = frozenset(
+    {
+        RateLimited,
+        ProviderUnavailable,
+        ContextLengthExceeded,
+        ProviderBadRequest,
+    }
+)
+
+# ContentFiltered / ProviderAuthFailed stay fail-closed unless the caller
+# opts in. ModelNotFound inherits ProviderBadRequest so it is included.
+
+
+_FallbackOnFailover = Callable[
+    [BoundModel, BoundModel | None, BaseException | str], Awaitable[None] | None
+]
+_FallbackOnRetry = Callable[
+    [BoundModel, BaseException, int, float], Awaitable[None] | None
+]
+
+
+class _FallbackRunState:
+    """Per-task sticky index. Isolated across concurrent agent runs."""
+
+    __slots__ = ("active_index",)
+
+    def __init__(self) -> None:
+        self.active_index = 0
+
+
+_run_state: contextvars.ContextVar[_FallbackRunState | None] = contextvars.ContextVar(
+    "cubepi_fallback_run_state", default=None
+)
+
+
+def begin_fallback_run() -> contextvars.Token[_FallbackRunState | None]:
+    """Reset sticky state for a new agent run / user turn. Returns a reset token."""
+
+    return _run_state.set(_FallbackRunState())
+
+
+def end_fallback_run(token: contextvars.Token[_FallbackRunState | None]) -> None:
+    _run_state.reset(token)
+
+
+def reset_active() -> None:
+    """Point the current run back at ``chain[0]`` (no-op if no run state)."""
+
+    state = _run_state.get()
+    if state is not None:
+        state.active_index = 0
+
+
+def _current_state() -> _FallbackRunState | None:
+    return _run_state.get()
+
+
+def _is_trigger(err: BaseException, trigger: tuple[type[ProviderError], ...]) -> bool:
+    # ContentFiltered is a ProviderBadRequest subclass but stays fail-closed
+    # unless the caller explicitly lists it in trigger_errors.
+    if isinstance(err, ContentFiltered):
+        return ContentFiltered in trigger
+    return isinstance(err, trigger)
+
+
+def _is_retryable(err: BaseException, retry: tuple[type[ProviderError], ...]) -> bool:
+    return isinstance(err, retry)
+
+
+def _context_too_small(err: BaseException, bound: BoundModel) -> bool:
+    if not isinstance(err, ContextLengthExceeded):
+        return False
+    need = err.tokens_in
+    window = bound.spec.context_window or None
+    if need is None or not window:
+        return False
+    return int(window) < int(need)
+
+
+def _typed_from_event(event: StreamEvent, bound: BoundModel) -> ProviderError:
+    return error_from_stream_fields(
+        error_message=event.error_message,
+        error_type=event.error_type,
+        error_code=event.error_code,
+        status_code=event.status_code,
+        retry_after=event.retry_after,
+        provider_id=event.provider_id or bound.spec.provider_id,
+        model_id=event.model_id or bound.spec.id,
+        tokens_in=event.tokens_in,
+        context_window=event.context_window,
+    )
+
+
+def _typed_from_message(msg: AssistantMessage, bound: BoundModel) -> ProviderError:
+    return error_from_stream_fields(
+        error_message=msg.error_message,
+        error_type=msg.error_type,
+        error_code=msg.error_code,
+        status_code=msg.status_code,
+        retry_after=msg.retry_after,
+        provider_id=msg.provider_id or bound.spec.provider_id,
+        model_id=msg.model_id or bound.spec.id,
+    )
+
+
+@dataclass(frozen=True)
+class FailoverAttempt:
+    model_id: str
+    provider_id: str
+    error: BaseException
+    duration_ms: float
+    attempt: int
+    phase: str  # "retry" | "failover"
 
 
 @dataclass(frozen=True)
 class FallbackBoundModel:
-    """Ordered chain of BoundModels — tries each in turn on retriable errors.
+    """Ordered chain of BoundModels — retry the active leg, then hop.
 
-    chain[0] is the primary model. On a trigger_errors exception or a first-event
-    error from stream(), the next model in the chain is tried transparently.
-    For generate(), an error AssistantMessage (stop_reason="error") also triggers
-    failover. Mid-stream errors (after the first non-error event) are forwarded
-    as-is.
+    chain[0] is the user-selected primary. Transient errors
+    (``DEFAULT_RETRY_ERRORS``) are retried on the same model before the next
+    chain entry is tried. Residual ``ProviderBadRequest`` / ``ModelNotFound``
+    hop without same-model retry. Mid-stream errors (after the first
+    non-error event) are forwarded as-is.
+
+    Sticky active leg: after a successful response from chain[i], later
+    ``stream`` / ``generate`` calls in the same agent run (or same task, when
+    used standalone) start at *i*. A new ``Agent.prompt`` resets to chain[0]
+    via :func:`begin_fallback_run`.
 
     provider and spec proxy chain[0] so tracing/billing code that reads
     agent._model.provider / agent._model.spec continues to work unchanged.
-
-    Tracer / Meter coverage: Recorder.attach() and Meter.attach() detect
-    FallbackBoundModel and subscribe to every unique BaseProvider in the
-    chain (via chain_providers() below), so post-failover chat spans and
-    provider metrics land in the trace / metric stream like primary-leg
-    calls do.
     """
 
     chain: tuple[BoundModel, ...]
     trigger_errors: frozenset[type[ProviderError]] = DEFAULT_TRIGGER_ERRORS
-    on_failover: (
-        Callable[
-            [BoundModel, BoundModel | None, BaseException | str], Awaitable[None] | None
-        ]
-        | None
-    ) = None
+    retry_errors: frozenset[type[ProviderError]] = DEFAULT_RETRY_ERRORS
+    max_retries_per_model: int = 3
+    max_retry_after: float = 5.0
+    retry_backoff: float = 0.0
+    sticky_within_run: bool = True
+    on_failover: _FallbackOnFailover | None = None
+    on_retry: _FallbackOnRetry | None = None
 
     def __post_init__(self) -> None:
-        # An empty chain is a configuration mistake: provider/spec proxy,
-        # stream(), and generate() would all IndexError or silently exhaust
-        # without ever attempting a call. Fail fast at construction time.
         if not self.chain:
             raise ValueError(
                 "FallbackBoundModel.chain must contain at least one BoundModel"
             )
+        if self.max_retries_per_model < 0:
+            raise ValueError("max_retries_per_model must be >= 0")
 
     @property
     def provider(self) -> Provider:
@@ -83,7 +201,12 @@ class FallbackBoundModel:
     def spec(self) -> Model:
         return self.chain[0].spec
 
-    async def _notify(
+    def reset_active(self) -> None:
+        """Reset the current-run sticky pointer to ``chain[0]``."""
+
+        reset_active()
+
+    async def _notify_failover(
         self,
         failed: BoundModel,
         next_model: BoundModel | None,
@@ -116,6 +239,92 @@ class FallbackBoundModel:
                     cb_exc,
                 )
 
+    async def _notify_retry(
+        self,
+        failed: BoundModel,
+        error: BaseException,
+        attempt: int,
+        wait_s: float,
+    ) -> None:
+        _log.info(
+            "cubepi.providers.fallback: same-model retry  model=%s/%s  "
+            "attempt=%s/%s  wait=%.2fs  reason=%s",
+            failed.spec.provider_id,
+            failed.spec.id,
+            attempt,
+            self.max_retries_per_model,
+            wait_s,
+            error,
+        )
+        if self.on_retry is not None:
+            try:
+                result = self.on_retry(failed, error, attempt, wait_s)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as cb_exc:  # noqa: BLE001
+                _log.warning(
+                    "cubepi.providers.fallback: on_retry callback raised; swallowed: %s",
+                    cb_exc,
+                )
+
+    def _wait_s(self, err: BaseException, retry_i: int) -> float:
+        wait = self.retry_backoff * (2 ** max(0, retry_i - 1))
+        if isinstance(err, RateLimited) and err.retry_after is not None:
+            wait = max(wait, float(err.retry_after))
+        return min(wait, self.max_retry_after)
+
+    def _start_index(self) -> int:
+        if not self.sticky_within_run:
+            return 0
+        state = _current_state()
+        if state is None:
+            return 0
+        idx = state.active_index
+        if idx < 0 or idx >= len(self.chain):
+            return 0
+        return idx
+
+    def _stick(self, index: int) -> None:
+        if not self.sticky_within_run:
+            return
+        state = _current_state()
+        if state is not None:
+            state.active_index = index
+
+    def _exhaust(self, failures: list[FailoverAttempt]) -> ProviderUnavailable:
+        last = failures[-1].error if failures else "no providers in chain"
+        last_typed = next(
+            (f.error for f in reversed(failures) if isinstance(f.error, ProviderError)),
+            None,
+        )
+        exc = ProviderUnavailable(
+            f"all providers exhausted; last error: {last!r}",
+            errors=[f.error for f in failures],
+        )
+        if last_typed is not None:
+            exc.__cause__ = last_typed
+        return exc
+
+    def _record(
+        self,
+        failures: list[FailoverAttempt],
+        bound: BoundModel,
+        err: BaseException,
+        duration_ms: float,
+        attempt: int,
+        phase: str,
+    ) -> None:
+        failures.append(
+            FailoverAttempt(
+                model_id=bound.spec.id,
+                provider_id=bound.spec.provider_id,
+                error=err,
+                duration_ms=duration_ms,
+                attempt=attempt,
+                phase=phase,
+            )
+        )
+
     async def stream(
         self,
         messages: list[Message],
@@ -125,72 +334,98 @@ class FallbackBoundModel:
         tool_choice: ToolChoice | None = None,
         options: StreamOptions | None = None,
     ) -> MessageStream:
-        last_error: BaseException | str = "no providers in chain"
         trigger = tuple(self.trigger_errors)
+        retry = tuple(self.retry_errors)
+        failures: list[FailoverAttempt] = []
+        start = self._start_index()
 
-        for attempt, bound in enumerate(self.chain, start=1):
-            next_bound = self.chain[attempt] if attempt < len(self.chain) else None
+        for index in range(start, len(self.chain)):
+            bound = self.chain[index]
+            next_bound = self.chain[index + 1] if index + 1 < len(self.chain) else None
+            same_retries = 0
 
-            try:
-                inner = await bound.stream(
-                    messages,
-                    system_prompt=system_prompt,
-                    tools=tools,
-                    tool_choice=tool_choice,
-                    options=options,
-                )
-            except trigger as exc:
-                last_error = exc
-                await self._notify(bound, next_bound, exc, attempt)
-                continue
-            except Exception:
-                raise
-
-            iterator = inner.__aiter__()
-            try:
-                first = await iterator.__anext__()
-            except StopAsyncIteration:
-                last_error = "stream ended before producing any events"
-                await self._notify(bound, next_bound, last_error, attempt)
-                continue
-
-            if first.type == "error":
-                last_error = first.error_message or "stream error"
-                await self._notify(bound, next_bound, last_error, attempt)
-                continue
-
-            outer = MessageStream()
-
-            async def _forward(
-                first_ev: StreamEvent = first,
-                src: Any = iterator,
-                src_stream: MessageStream = inner,
-                out: MessageStream = outer,
-            ) -> None:
+            while True:
+                t0 = time.monotonic()
+                err: BaseException | None = None
+                first: StreamEvent | None = None
                 try:
-                    out.push(first_ev)
-                    async for ev in src:
-                        out.push(ev)
-                    out.set_result(await src_stream.result())
-                except BaseException as exc:  # noqa: BLE001
-                    err_msg = AssistantMessage(
-                        content=[],
-                        stop_reason="error",
-                        error_message=str(exc),
-                        usage=Usage(),
-                        timestamp=time.time(),
+                    inner = await bound.stream(
+                        messages,
+                        system_prompt=system_prompt,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        options=options,
                     )
-                    out.push(StreamEvent(type="error", error_message=str(exc)))
-                    out.set_result(err_msg)
-                    if not isinstance(exc, Exception):
-                        raise
+                except Exception as exc:
+                    err = exc
+                else:
+                    iterator = inner.__aiter__()
+                    try:
+                        first = await iterator.__anext__()
+                    except StopAsyncIteration:
+                        err = ProviderUnavailable(
+                            "stream ended before producing any events"
+                        )
+                    else:
+                        if first.type == "error":
+                            err = _typed_from_event(first, bound)
+                        else:
+                            self._stick(index)
+                            outer = MessageStream()
 
-            outer.attach_task(asyncio.create_task(_forward()))
-            return outer
+                            async def _forward(
+                                first_ev: StreamEvent = first,
+                                src: Any = iterator,
+                                src_stream: MessageStream = inner,
+                                out: MessageStream = outer,
+                            ) -> None:
+                                try:
+                                    out.push(first_ev)
+                                    async for ev in src:
+                                        out.push(ev)
+                                    out.set_result(await src_stream.result())
+                                except BaseException as fwd_exc:  # noqa: BLE001
+                                    err_msg = AssistantMessage(
+                                        content=[],
+                                        stop_reason="error",
+                                        error_message=str(fwd_exc),
+                                        usage=Usage(),
+                                        timestamp=time.time(),
+                                    )
+                                    out.push(
+                                        StreamEvent(
+                                            type="error",
+                                            error_message=str(fwd_exc),
+                                        )
+                                    )
+                                    out.set_result(err_msg)
+                                    if not isinstance(fwd_exc, Exception):
+                                        raise
 
-        raise ProviderUnavailable(
-            f"all providers exhausted; last error: {last_error!r}"
-        )
+                            outer.attach_task(asyncio.create_task(_forward()))
+                            return outer
+
+                assert err is not None
+                duration_ms = (time.monotonic() - t0) * 1000
+                hop = await self._decide(
+                    bound=bound,
+                    next_bound=next_bound,
+                    err=err,
+                    duration_ms=duration_ms,
+                    same_retries=same_retries,
+                    failures=failures,
+                    trigger=trigger,
+                    retry=retry,
+                    chain_pos=index + 1,
+                )
+                if hop == "retry":
+                    same_retries += 1
+                    continue
+                if hop == "failover":
+                    break
+                raise err
+
+        raise self._exhaust(failures)
 
     async def generate(
         self,
@@ -204,40 +439,93 @@ class FallbackBoundModel:
         temperature: float | None = None,
         reasoning: ReasoningControl | None = None,
     ) -> AssistantMessage:
-        last_error: BaseException | str = "no providers in chain"
         trigger = tuple(self.trigger_errors)
+        retry = tuple(self.retry_errors)
+        failures: list[FailoverAttempt] = []
+        start = self._start_index()
 
-        for attempt, bound in enumerate(self.chain, start=1):
-            next_bound = self.chain[attempt] if attempt < len(self.chain) else None
+        for index in range(start, len(self.chain)):
+            bound = self.chain[index]
+            next_bound = self.chain[index + 1] if index + 1 < len(self.chain) else None
+            same_retries = 0
 
-            try:
-                result = await bound.generate(
-                    messages,
-                    system_prompt=system_prompt,
-                    tools=tools,
-                    tool_choice=tool_choice,
-                    options=options,
-                    max_output_tokens=max_output_tokens,
-                    temperature=temperature,
-                    reasoning=reasoning,
+            while True:
+                t0 = time.monotonic()
+                err: BaseException | None = None
+                try:
+                    result = await bound.generate(
+                        messages,
+                        system_prompt=system_prompt,
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        options=options,
+                        max_output_tokens=max_output_tokens,
+                        temperature=temperature,
+                        reasoning=reasoning,
+                    )
+                except Exception as exc:
+                    err = exc
+                else:
+                    if result.stop_reason == "error":
+                        err = _typed_from_message(result, bound)
+                    else:
+                        self._stick(index)
+                        return result
+
+                assert err is not None
+                duration_ms = (time.monotonic() - t0) * 1000
+                hop = await self._decide(
+                    bound=bound,
+                    next_bound=next_bound,
+                    err=err,
+                    duration_ms=duration_ms,
+                    same_retries=same_retries,
+                    failures=failures,
+                    trigger=trigger,
+                    retry=retry,
+                    chain_pos=index + 1,
                 )
-            except trigger as exc:
-                last_error = exc
-                await self._notify(bound, next_bound, exc, attempt)
-                continue
-            except Exception:
-                raise
+                if hop == "retry":
+                    same_retries += 1
+                    continue
+                if hop == "failover":
+                    break
+                raise err
 
-            if result.stop_reason == "error":
-                last_error = result.error_message or "generate error"
-                await self._notify(bound, next_bound, last_error, attempt)
-                continue
+        raise self._exhaust(failures)
 
-            return result
+    async def _decide(
+        self,
+        *,
+        bound: BoundModel,
+        next_bound: BoundModel | None,
+        err: BaseException,
+        duration_ms: float,
+        same_retries: int,
+        failures: list[FailoverAttempt],
+        trigger: tuple[type[ProviderError], ...],
+        retry: tuple[type[ProviderError], ...],
+        chain_pos: int,
+    ) -> str:
+        if _context_too_small(err, bound):
+            self._record(failures, bound, err, duration_ms, same_retries, "failover")
+            await self._notify_failover(bound, next_bound, err, chain_pos)
+            return "failover"
 
-        raise ProviderUnavailable(
-            f"all providers exhausted; last error: {last_error!r}"
-        )
+        if _is_retryable(err, retry) and same_retries < self.max_retries_per_model:
+            wait_s = self._wait_s(err, same_retries + 1)
+            self._record(failures, bound, err, duration_ms, same_retries + 1, "retry")
+            await self._notify_retry(bound, err, same_retries + 1, wait_s)
+            if wait_s > 0:
+                await asyncio.sleep(wait_s)
+            return "retry"
+
+        if _is_trigger(err, trigger):
+            self._record(failures, bound, err, duration_ms, same_retries, "failover")
+            await self._notify_failover(bound, next_bound, err, chain_pos)
+            return "failover"
+
+        return "raise"
 
 
 # ``chain_providers`` lives in :mod:`cubepi.providers.base` so the tracing /
@@ -245,7 +533,12 @@ class FallbackBoundModel:
 # import above re-exports it under ``cubepi.providers.fallback.chain_providers``
 # for back-compat with existing call sites.
 __all__ = [
+    "DEFAULT_RETRY_ERRORS",
     "DEFAULT_TRIGGER_ERRORS",
+    "FailoverAttempt",
     "FallbackBoundModel",
+    "begin_fallback_run",
+    "end_fallback_run",
+    "reset_active",
     "chain_providers",
 ]

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -35,6 +35,7 @@ from cubepi.providers.base import (
     apply_sender_attribution,
     invoke_on_payload,
     invoke_on_response,
+    typed_error_event,
 )
 from cubepi.providers.reasoning_profiles import get_capability_profile
 
@@ -532,18 +533,17 @@ class OpenAIProvider(BaseProvider):
                     except Exception as _classified:
                         exc = _classified
                 err_text = self._error_message(exc, model)
+                ev, err_fields = typed_error_event(
+                    exc, model=model, error_message=err_text
+                )
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
-                    error_message=err_text,
                     usage=Usage(),
                     timestamp=time.time(),
-                    provider_id=model.provider_id,
-                    model_id=model.id,
+                    **err_fields,
                 )
-                await self._emit(
-                    ms, StreamEvent(type="error", error_message=err_text), model
-                )
+                await self._emit(ms, ev, model)
                 ms.set_result(error_msg)
                 if not isinstance(e, Exception):
                     raise

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -533,15 +533,19 @@ class OpenAIProvider(BaseProvider):
                     except Exception as _classified:
                         exc = _classified
                 err_text = self._error_message(exc, model)
-                ev, err_fields = typed_error_event(
-                    exc, model=model, error_message=err_text
-                )
+                ev = typed_error_event(exc, model=model, error_message=err_text)
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
+                    error_message=ev.error_message,
+                    error_type=ev.error_type,
+                    error_code=ev.error_code,
+                    status_code=ev.status_code,
+                    retry_after=ev.retry_after,
                     usage=Usage(),
                     timestamp=time.time(),
-                    **err_fields,
+                    provider_id=ev.provider_id or model.provider_id,
+                    model_id=ev.model_id or model.id,
                 )
                 await self._emit(ms, ev, model)
                 ms.set_result(error_msg)

--- a/cubepi/providers/openai.py
+++ b/cubepi/providers/openai.py
@@ -542,6 +542,8 @@ class OpenAIProvider(BaseProvider):
                     error_code=ev.error_code,
                     status_code=ev.status_code,
                     retry_after=ev.retry_after,
+                    tokens_in=ev.tokens_in,
+                    context_window=ev.context_window,
                     usage=Usage(),
                     timestamp=time.time(),
                     provider_id=ev.provider_id or model.provider_id,

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -579,6 +579,8 @@ class OpenAIResponsesProvider(BaseProvider):
                     error_code=ev.error_code,
                     status_code=ev.status_code,
                     retry_after=ev.retry_after,
+                    tokens_in=ev.tokens_in,
+                    context_window=ev.context_window,
                     usage=Usage(),
                     timestamp=time.time(),
                     provider_id=ev.provider_id or model.provider_id,

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -570,15 +570,19 @@ class OpenAIResponsesProvider(BaseProvider):
                     except Exception as _classified:
                         exc = _classified
                 err_text = self._error_message(exc, model)
-                ev, err_fields = typed_error_event(
-                    exc, model=model, error_message=err_text
-                )
+                ev = typed_error_event(exc, model=model, error_message=err_text)
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
+                    error_message=ev.error_message,
+                    error_type=ev.error_type,
+                    error_code=ev.error_code,
+                    status_code=ev.status_code,
+                    retry_after=ev.retry_after,
                     usage=Usage(),
                     timestamp=time.time(),
-                    **err_fields,
+                    provider_id=ev.provider_id or model.provider_id,
+                    model_id=ev.model_id or model.id,
                 )
                 await self._emit(ms, ev, model)
                 ms.set_result(error_msg)

--- a/cubepi/providers/openai_responses.py
+++ b/cubepi/providers/openai_responses.py
@@ -28,6 +28,7 @@ from cubepi.providers.base import (
     apply_sender_attribution,
     invoke_on_payload,
     invoke_on_response,
+    typed_error_event,
 )
 from cubepi.providers.capability import (
     CapabilityDescriptor,
@@ -569,18 +570,17 @@ class OpenAIResponsesProvider(BaseProvider):
                     except Exception as _classified:
                         exc = _classified
                 err_text = self._error_message(exc, model)
+                ev, err_fields = typed_error_event(
+                    exc, model=model, error_message=err_text
+                )
                 error_msg = AssistantMessage(
                     content=[],
                     stop_reason="error",
-                    error_message=err_text,
                     usage=Usage(),
                     timestamp=time.time(),
-                    provider_id=model.provider_id,
-                    model_id=model.id,
+                    **err_fields,
                 )
-                await self._emit(
-                    ms, StreamEvent(type="error", error_message=err_text), model
-                )
+                await self._emit(ms, ev, model)
                 ms.set_result(error_msg)
                 if not isinstance(e, Exception):
                     raise

--- a/examples/multi_provider_failover.py
+++ b/examples/multi_provider_failover.py
@@ -1,8 +1,8 @@
 """Multi-provider failover — recipe example.
 
 Demonstrates FallbackBoundModel: the primary provider is given a bad key so its
-first stream event is an auth error, which triggers transparent failover to the
-real provider.
+first stream event is an auth error. Auth is fail-closed by default, so this
+example opts in via ``trigger_errors`` to show a hop to the real provider.
 
     uv run python examples/multi_provider_failover.py
 
@@ -16,6 +16,13 @@ import asyncio
 import os
 
 from cubepi import Agent, FallbackBoundModel
+from cubepi.errors import (
+    ContextLengthExceeded,
+    ProviderAuthFailed,
+    ProviderBadRequest,
+    ProviderUnavailable,
+    RateLimited,
+)
 from cubepi.providers.anthropic import AnthropicProvider
 from cubepi.providers.base import BoundModel
 from cubepi.providers.openai import OpenAIProvider
@@ -41,9 +48,21 @@ async def main() -> None:
             _bad_key_primary(),
             provider.model(MODEL_ID),
         ),
+        # Demo only: auth is fail-closed by default. Real apps should not hop
+        # on a bad key unless they want a second provider to take over.
+        trigger_errors=frozenset(
+            {
+                RateLimited,
+                ProviderUnavailable,
+                ContextLengthExceeded,
+                ProviderBadRequest,
+                ProviderAuthFailed,
+            }
+        ),
         on_failover=lambda failed, nxt, err: print(
             f"[failover] {failed.spec.provider_id}/{failed.spec.id}"
-            f" → {nxt.spec.provider_id}/{nxt.spec.id if nxt else '—'}: {err}"
+            f" → {nxt.spec.provider_id if nxt else 'none'}"
+            f"/{nxt.spec.id if nxt else '—'}: {err}"
         ),
     )
 

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -715,6 +715,12 @@ async def test_context_length_skips_too_small_fallback() -> None:
         await fbm.stream(_messages())
     assert ei.value.errors
     assert all(isinstance(e, ContextLengthExceeded) for e in ei.value.errors)
+    assert getattr(b.provider, "_error", None) is small_err
+    # 16k window cannot fit 200k — must not be invoked.
+    assert not hasattr(b.provider, "calls") or getattr(b.provider, "calls", 0) == 0
+    # _RaisingProvider has no counter; wrap via call_count if present
+    if hasattr(b.provider, "call_count"):
+        assert b.provider.call_count == 0  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio
@@ -790,8 +796,29 @@ async def test_sticky_after_successful_failover() -> None:
         s2 = await fbm.stream(_messages())
         r2 = await s2.result()
         assert r2.provider_id == "fallback"
-        # second call must not probe primary again
-        assert primary.provider  # constructed
+    finally:
+        end_fallback_run(token)
+
+
+@pytest.mark.asyncio
+async def test_sticky_second_call_skips_primary() -> None:
+    from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+
+    err = ProviderUnavailable("down", provider="primary", model="m")
+    primary_p = _CountingRaiseProvider(err, fail_times=99, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+    fb = FauxProvider(provider_id="fallback")
+    fb.set_responses([faux_assistant_message("ok"), faux_assistant_message("ok2")])
+    fallback = fb.model("model-1")
+    fbm = FallbackBoundModel(
+        chain=(primary, fallback), max_retries_per_model=0, retry_backoff=0.0
+    )
+    token = begin_fallback_run()
+    try:
+        await (await fbm.stream(_messages())).result()
+        after_first = primary_p.calls
+        await (await fbm.stream(_messages())).result()
+        assert primary_p.calls == after_first
     finally:
         end_fallback_run(token)
 
@@ -823,6 +850,36 @@ async def test_new_run_resets_sticky_to_primary() -> None:
 
 
 @pytest.mark.asyncio
+async def test_new_run_after_failover_probes_primary_again() -> None:
+    from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+
+    err = ProviderUnavailable("down", provider="primary", model="m")
+    primary_p = _CountingRaiseProvider(err, fail_times=99, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+    fb = FauxProvider(provider_id="fallback")
+    fb.set_responses([faux_assistant_message("ok"), faux_assistant_message("ok2")])
+    fbm = FallbackBoundModel(
+        chain=(primary, fb.model("model-1")),
+        max_retries_per_model=0,
+        retry_backoff=0.0,
+    )
+    token = begin_fallback_run()
+    try:
+        r1 = await (await fbm.stream(_messages())).result()
+        assert r1.provider_id == "fallback"
+    finally:
+        end_fallback_run(token)
+    after_run1 = primary_p.calls
+    token = begin_fallback_run()
+    try:
+        r2 = await (await fbm.stream(_messages())).result()
+        assert r2.provider_id == "fallback"
+        assert primary_p.calls > after_run1
+    finally:
+        end_fallback_run(token)
+
+
+@pytest.mark.asyncio
 async def test_generate_exhaustion_preserves_errors() -> None:
     e1 = RateLimited("a", provider="p", model="m1")
     e2 = RateLimited("b", provider="p", model="m2")
@@ -834,3 +891,17 @@ async def test_generate_exhaustion_preserves_errors() -> None:
         await fbm.generate(_messages())
     assert len(ei.value.errors) == 2
     assert isinstance(ei.value.__cause__, RateLimited)
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_errors_are_one_per_leg() -> None:
+    e1 = RateLimited("a", provider="p", model="m1")
+    e2 = RateLimited("b", provider="p", model="m2")
+    fbm = FallbackBoundModel(
+        chain=(_raising(e1, "m1"), _raising(e2, "m2")),
+        max_retries_per_model=3,
+        retry_backoff=0.0,
+    )
+    with pytest.raises(ProviderUnavailable) as ei:
+        await fbm.generate(_messages())
+    assert len(ei.value.errors) == 2

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -905,3 +905,213 @@ async def test_exhaustion_errors_are_one_per_leg() -> None:
     with pytest.raises(ProviderUnavailable) as ei:
         await fbm.generate(_messages())
     assert len(ei.value.errors) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_skips_too_small_middle_leg() -> None:
+    err = ContextLengthExceeded(
+        "too long", provider="p", model="a", tokens_in=200_000, context_window=8_000
+    )
+    a = BoundModel(
+        provider=_RaisingProvider(err),
+        spec=Model(id="a", provider_id="p", context_window=8_000),
+    )
+    mid_p = _CountingRaiseProvider(
+        ContextLengthExceeded("mid", tokens_in=200_000, context_window=16_000),
+        fail_times=99,
+        provider_id="mid",
+    )
+    b = BoundModel(
+        provider=mid_p, spec=Model(id="b", provider_id="p", context_window=16_000)
+    )
+    big = _faux("big", "ok")
+    big = BoundModel(
+        provider=big.provider,
+        spec=Model(id="c", provider_id="big", context_window=400_000),
+    )
+    fbm = FallbackBoundModel(chain=(a, b, big), retry_backoff=0.0)
+    result = await fbm.generate(_messages())
+    assert mid_p.calls == 0
+    assert result.provider_id == "big"
+
+
+@pytest.mark.asyncio
+async def test_content_filtered_does_not_hop_unless_listed() -> None:
+    from cubepi.errors import ContentFiltered
+
+    err = ContentFiltered("blocked", provider="primary", model="m")
+    primary = _raising(err)
+    fallback = _faux("fallback", "ok")
+    fbm = FallbackBoundModel(chain=(primary, fallback))
+    with pytest.raises(ContentFiltered):
+        await fbm.stream(_messages())
+    assert fallback.provider.call_count == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_content_filtered_hops_when_opted_in() -> None:
+    from cubepi.errors import ContentFiltered
+
+    err = ContentFiltered("blocked", provider="primary", model="m")
+    primary = _raising(err)
+    fallback = _faux("fallback", "ok")
+    fbm = FallbackBoundModel(
+        chain=(primary, fallback),
+        trigger_errors=frozenset({ContentFiltered}),
+    )
+    stream = await fbm.stream(_messages())
+    result = await stream.result()
+    assert result.provider_id == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_reset_active_and_index_helpers() -> None:
+    from cubepi.providers.fallback import (
+        begin_fallback_run,
+        end_fallback_run,
+        get_active_index,
+        reset_active,
+        set_active_index,
+    )
+
+    assert get_active_index() == 0
+    token = begin_fallback_run()
+    try:
+        set_active_index(2)
+        assert get_active_index() == 2
+        reset_active()
+        assert get_active_index() == 0
+        fbm = FallbackBoundModel(chain=(_faux("p", "hi"),))
+        fbm.reset_active()
+        assert get_active_index() == 0
+    finally:
+        end_fallback_run(token)
+
+
+def test_negative_retries_rejected() -> None:
+    with pytest.raises(ValueError, match="max_retries_per_model"):
+        FallbackBoundModel(chain=(_faux("p", "hi"),), max_retries_per_model=-1)
+
+
+@pytest.mark.asyncio
+async def test_on_retry_callback_exception_is_swallowed() -> None:
+    err = ProviderUnavailable("blip", provider="primary", model="m")
+    primary_p = _CountingRaiseProvider(err, fail_times=1, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+
+    def _bad(failed, error, attempt, wait_s):  # noqa: ANN001
+        raise RuntimeError("retry hook broken")
+
+    fbm = FallbackBoundModel(
+        chain=(primary,), on_retry=_bad, retry_backoff=0.0, max_retries_per_model=2
+    )
+    stream = await fbm.stream(_messages())
+    result = await stream.result()
+    assert result.content
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_honors_retry_after_cap() -> None:
+    err = RateLimited("429", provider="primary", model="m", retry_after=30.0)
+    primary_p = _CountingRaiseProvider(err, fail_times=1, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+    waits: list[float] = []
+
+    def _on_retry(failed, error, attempt, wait_s):  # noqa: ANN001
+        waits.append(wait_s)
+
+    fbm = FallbackBoundModel(
+        chain=(primary,),
+        on_retry=_on_retry,
+        retry_backoff=0.0,
+        max_retry_after=0.0,
+        max_retries_per_model=1,
+    )
+    stream = await fbm.stream(_messages())
+    await stream.result()
+    assert waits == [0.0]
+
+
+def test_sticky_disabled_always_starts_at_zero() -> None:
+    fbm = FallbackBoundModel(chain=(_faux("p", "hi"),), sticky_within_run=False)
+    assert fbm._start_index() == 0
+
+
+@pytest.mark.asyncio
+async def test_async_on_retry_is_awaited() -> None:
+    seen: list[int] = []
+    err = ProviderUnavailable("blip", provider="primary", model="m")
+    primary_p = _CountingRaiseProvider(err, fail_times=1, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+
+    async def _cb(failed, error, attempt, wait_s):  # noqa: ANN001
+        seen.append(attempt)
+
+    fbm = FallbackBoundModel(
+        chain=(primary,), on_retry=_cb, retry_backoff=0.0, max_retries_per_model=2
+    )
+    await (await fbm.stream(_messages())).result()
+    assert seen == [1]
+
+
+def test_context_too_small_without_need_or_window() -> None:
+    from cubepi.providers.fallback import _context_too_small
+
+    bound = BoundModel(
+        provider=_RaisingProvider(ProviderUnavailable("x")),
+        spec=Model(id="m", provider_id="p", context_window=0),
+    )
+    assert (
+        _context_too_small(ContextLengthExceeded("long", tokens_in=10), bound) is False
+    )
+    bound2 = BoundModel(
+        provider=bound.provider,
+        spec=Model(id="m", provider_id="p", context_window=8_000),
+    )
+    assert (
+        _context_too_small(ContextLengthExceeded("long", tokens_in=None), bound2)
+        is False
+    )
+
+
+def test_start_index_clamps_out_of_range() -> None:
+    from cubepi.providers.fallback import (
+        begin_fallback_run,
+        end_fallback_run,
+        set_active_index,
+    )
+
+    fbm = FallbackBoundModel(chain=(_faux("p", "hi"),))
+    token = begin_fallback_run()
+    try:
+        set_active_index(99)
+        assert fbm._start_index() == 0
+    finally:
+        end_fallback_run(token)
+
+
+def test_stick_noop_when_disabled() -> None:
+    from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+
+    fbm = FallbackBoundModel(chain=(_faux("p", "hi"),), sticky_within_run=False)
+    token = begin_fallback_run()
+    try:
+        fbm._stick(1)
+        assert fbm._start_index() == 0
+    finally:
+        end_fallback_run(token)
+
+
+@pytest.mark.asyncio
+async def test_retry_sleeps_when_wait_positive() -> None:
+    err = RateLimited("429", provider="primary", model="m", retry_after=0.01)
+    primary_p = _CountingRaiseProvider(err, fail_times=1, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+    fbm = FallbackBoundModel(
+        chain=(primary,),
+        retry_backoff=0.0,
+        max_retry_after=0.01,
+        max_retries_per_model=1,
+    )
+    await (await fbm.stream(_messages())).result()
+    assert primary_p.calls == 2

--- a/tests/providers/test_fallback.py
+++ b/tests/providers/test_fallback.py
@@ -87,12 +87,15 @@ def _messages() -> list[Message]:
 
 
 def test_default_trigger_errors_composition() -> None:
-    """DEFAULT_TRIGGER_ERRORS contains the right three error types."""
+    """DEFAULT_TRIGGER_ERRORS includes residual bad-request; auth stays out."""
     assert RateLimited in DEFAULT_TRIGGER_ERRORS
     assert ProviderUnavailable in DEFAULT_TRIGGER_ERRORS
     assert ContextLengthExceeded in DEFAULT_TRIGGER_ERRORS
+    assert ProviderBadRequest in DEFAULT_TRIGGER_ERRORS
     assert ProviderAuthFailed not in DEFAULT_TRIGGER_ERRORS
-    assert ProviderBadRequest not in DEFAULT_TRIGGER_ERRORS
+    from cubepi.errors import ContentFiltered
+
+    assert ContentFiltered not in DEFAULT_TRIGGER_ERRORS
 
 
 def test_empty_chain_raises_value_error() -> None:
@@ -149,14 +152,14 @@ async def test_stream_primary_raises_trigger_error_fallback_succeeds() -> None:
 
 @pytest.mark.asyncio
 async def test_stream_primary_raises_non_trigger_error_reraises() -> None:
-    """Primary raises ProviderBadRequest (not in trigger_errors) → re-raised, fallback not tried."""
-    bad_req = ProviderBadRequest("400", provider="primary", model="model-1")
-    primary = _raising(bad_req)
+    """Primary raises ProviderAuthFailed (not in trigger_errors) → re-raised."""
+    auth = ProviderAuthFailed("401", provider="primary", model="model-1")
+    primary = _raising(auth)
     fallback = _faux("fallback", "ok")
 
     fbm = FallbackBoundModel(chain=(primary, fallback))
 
-    with pytest.raises(ProviderBadRequest):
+    with pytest.raises(ProviderAuthFailed):
         await fbm.stream(_messages())
 
     assert fallback.provider.call_count == 0  # type: ignore[attr-defined]
@@ -345,14 +348,14 @@ async def test_stream_mid_stream_error_is_forwarded() -> None:
 
 @pytest.mark.asyncio
 async def test_generate_non_trigger_error_reraises() -> None:
-    """generate() — ProviderBadRequest (not in trigger_errors) re-raised immediately."""
-    bad_req = ProviderBadRequest("400", provider="primary", model="model-1")
-    primary = _raising(bad_req)
+    """generate() — ProviderAuthFailed (not in trigger_errors) re-raised immediately."""
+    auth = ProviderAuthFailed("401", provider="primary", model="model-1")
+    primary = _raising(auth)
     fallback = _faux("fallback", "ok")
 
     fbm = FallbackBoundModel(chain=(primary, fallback))
 
-    with pytest.raises(ProviderBadRequest):
+    with pytest.raises(ProviderAuthFailed):
         await fbm.generate(_messages())
 
 
@@ -533,3 +536,301 @@ async def test_generate_forwards_tool_choice() -> None:
     result = await fbm.generate(_messages(), tool_choice="required")
 
     assert result.provider_id == "primary"
+
+
+# ---------------------------------------------------------------------------
+# retry / sticky / typed first-event (issue #211)
+# ---------------------------------------------------------------------------
+
+
+class _CountingRaiseProvider(BaseProvider):
+    """Raise ``error`` the first ``fail_times`` stream/generate calls, then succeed."""
+
+    def __init__(
+        self, error: ProviderError, fail_times: int, provider_id: str = "count"
+    ) -> None:
+        super().__init__(provider_id=provider_id)
+        self._error = error
+        self._fail_times = fail_times
+        self.calls = 0
+
+    async def stream(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: Any = None,
+        options: StreamOptions | None = None,
+    ) -> MessageStream:
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise self._error
+        inner = FauxProvider(provider_id=self.provider_id)
+        inner.set_responses([faux_assistant_message("recovered")])
+        return await inner.stream(model, messages)
+
+    async def generate(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: Any = None,
+        options: StreamOptions | None = None,
+        max_output_tokens: int | None = None,
+        temperature: float | None = None,
+        reasoning: ReasoningControl | None = None,
+    ) -> AssistantMessage:
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise self._error
+        return faux_assistant_message("recovered")
+
+
+class _FirstEventTypedProvider(BaseProvider):
+    def __init__(self, event: StreamEvent, provider_id: str = "typed-ev") -> None:
+        super().__init__(provider_id=provider_id)
+        self._event = event
+
+    async def stream(
+        self,
+        model: Model,
+        messages: list[Message],
+        *,
+        system_prompt: str = "",
+        tools: list[ToolDefinition] | None = None,
+        tool_choice: Any = None,
+        options: StreamOptions | None = None,
+    ) -> MessageStream:
+        ms = MessageStream()
+
+        async def _produce() -> None:
+            ms.push(self._event)
+            if self._event.type == "error":
+                ms.set_result(
+                    AssistantMessage(
+                        content=[],
+                        stop_reason="error",
+                        error_message=self._event.error_message,
+                        error_type=self._event.error_type,
+                    )
+                )
+
+        ms.attach_task(__import__("asyncio").create_task(_produce()))
+        return ms
+
+
+@pytest.mark.asyncio
+async def test_same_model_retry_recovers_without_secondary() -> None:
+    err = ProviderUnavailable("blip", provider="primary", model="m")
+    primary_p = _CountingRaiseProvider(err, fail_times=2, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+    fallback = _faux("fallback", "nope")
+    retries: list[int] = []
+
+    def _on_retry(failed, error, attempt, wait_s):  # noqa: ANN001
+        retries.append(attempt)
+
+    fbm = FallbackBoundModel(
+        chain=(primary, fallback),
+        on_retry=_on_retry,
+        retry_backoff=0.0,
+    )
+    stream = await fbm.stream(_messages())
+    result = await stream.result()
+    assert result.content
+    assert fallback.provider.call_count == 0  # type: ignore[attr-defined]
+    assert primary_p.calls == 3
+    assert retries == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_retries_then_failover() -> None:
+    err = RateLimited("429", provider="primary", model="m")
+    primary_p = _CountingRaiseProvider(err, fail_times=99, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+    fallback = _faux("fallback", "ok")
+    hops: list[Any] = []
+
+    def _on_fail(failed, nxt, error):  # noqa: ANN001
+        hops.append(error)
+
+    fbm = FallbackBoundModel(
+        chain=(primary, fallback),
+        max_retries_per_model=3,
+        on_failover=_on_fail,
+        retry_backoff=0.0,
+    )
+    stream = await fbm.stream(_messages())
+    result = await stream.result()
+    assert result.provider_id == "fallback"
+    assert primary_p.calls == 4  # first try + 3 retries
+    assert len(hops) == 1
+
+
+@pytest.mark.asyncio
+async def test_context_length_skips_same_model_retry() -> None:
+    err = ContextLengthExceeded(
+        "too long", provider="p", model="small", tokens_in=200_000, context_window=8_000
+    )
+    primary_p = _CountingRaiseProvider(err, fail_times=99, provider_id="small")
+    primary = BoundModel(
+        provider=primary_p,
+        spec=Model(id="small", provider_id="small", context_window=8_000),
+    )
+    fallback = _faux("fallback", "ok")
+    fbm = FallbackBoundModel(chain=(primary, fallback), retry_backoff=0.0)
+    stream = await fbm.stream(_messages())
+    await stream.result()
+    assert primary_p.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_context_length_skips_too_small_fallback() -> None:
+    err = ContextLengthExceeded(
+        "too long", provider="p", model="a", tokens_in=200_000, context_window=8_000
+    )
+    a = _raising(err, "a")
+    # rewrite spec window
+    a = BoundModel(
+        provider=a.provider,
+        spec=Model(id="a", provider_id="p", context_window=8_000),
+    )
+    small_err = ContextLengthExceeded(
+        "still too long",
+        provider="p",
+        model="b",
+        tokens_in=200_000,
+        context_window=16_000,
+    )
+    b = BoundModel(
+        provider=_RaisingProvider(small_err),
+        spec=Model(id="b", provider_id="p", context_window=16_000),
+    )
+    fbm = FallbackBoundModel(chain=(a, b), retry_backoff=0.0)
+    with pytest.raises(ProviderUnavailable) as ei:
+        await fbm.stream(_messages())
+    assert ei.value.errors
+    assert all(isinstance(e, ContextLengthExceeded) for e in ei.value.errors)
+
+
+@pytest.mark.asyncio
+async def test_residual_bad_request_failovers_without_retry() -> None:
+    err = ProviderBadRequest("InvalidParameter", provider="primary", model="m")
+    primary_p = _CountingRaiseProvider(err, fail_times=99, provider_id="primary")
+    primary = BoundModel(provider=primary_p, spec=Model(id="m", provider_id="primary"))
+    fallback = _faux("fallback", "ok")
+    fbm = FallbackBoundModel(chain=(primary, fallback), retry_backoff=0.0)
+    stream = await fbm.stream(_messages())
+    result = await stream.result()
+    assert result.provider_id == "fallback"
+    assert primary_p.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_first_event_typed_auth_does_not_failover() -> None:
+    ev = StreamEvent(
+        type="error",
+        error_message="bad key",
+        error_type="ProviderAuthFailed",
+        status_code=401,
+    )
+    primary = BoundModel(
+        provider=_FirstEventTypedProvider(ev, "primary"),
+        spec=Model(id="m", provider_id="primary"),
+    )
+    fallback = _faux("fallback", "ok")
+    fbm = FallbackBoundModel(chain=(primary, fallback))
+    with pytest.raises(ProviderAuthFailed):
+        await fbm.stream(_messages())
+    assert fallback.provider.call_count == 0  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_first_event_typed_rate_limited_retries_then_failovers() -> None:
+    ev = StreamEvent(
+        type="error",
+        error_message="slow down",
+        error_type="RateLimited",
+        status_code=429,
+    )
+    primary = BoundModel(
+        provider=_FirstEventTypedProvider(ev, "primary"),
+        spec=Model(id="m", provider_id="primary"),
+    )
+    fallback = _faux("fallback", "ok")
+    fbm = FallbackBoundModel(
+        chain=(primary, fallback), max_retries_per_model=1, retry_backoff=0.0
+    )
+    stream = await fbm.stream(_messages())
+    result = await stream.result()
+    assert result.provider_id == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_sticky_after_successful_failover() -> None:
+    from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+
+    err = ProviderUnavailable("down", provider="primary", model="m")
+    primary = _raising(err)
+    fb = FauxProvider(provider_id="fallback")
+    fb.set_responses([faux_assistant_message("ok"), faux_assistant_message("ok2")])
+    fallback = fb.model("model-1")
+    fbm = FallbackBoundModel(
+        chain=(primary, fallback), max_retries_per_model=0, retry_backoff=0.0
+    )
+    token = begin_fallback_run()
+    try:
+        s1 = await fbm.stream(_messages())
+        r1 = await s1.result()
+        assert r1.provider_id == "fallback"
+        s2 = await fbm.stream(_messages())
+        r2 = await s2.result()
+        assert r2.provider_id == "fallback"
+        # second call must not probe primary again
+        assert primary.provider  # constructed
+    finally:
+        end_fallback_run(token)
+
+
+@pytest.mark.asyncio
+async def test_new_run_resets_sticky_to_primary() -> None:
+    from cubepi.providers.fallback import begin_fallback_run, end_fallback_run
+
+    prim = FauxProvider(provider_id="primary")
+    prim.set_responses(
+        [faux_assistant_message("hello"), faux_assistant_message("hello2")]
+    )
+    ok_primary = prim.model("model-1")
+    fallback = _faux("fallback", "world")
+    fbm = FallbackBoundModel(chain=(ok_primary, fallback))
+    token = begin_fallback_run()
+    try:
+        s = await fbm.stream(_messages())
+        await s.result()
+    finally:
+        end_fallback_run(token)
+    token = begin_fallback_run()
+    try:
+        s = await fbm.stream(_messages())
+        r = await s.result()
+        assert r.provider_id == "primary"
+    finally:
+        end_fallback_run(token)
+
+
+@pytest.mark.asyncio
+async def test_generate_exhaustion_preserves_errors() -> None:
+    e1 = RateLimited("a", provider="p", model="m1")
+    e2 = RateLimited("b", provider="p", model="m2")
+    fbm = FallbackBoundModel(
+        chain=(_raising(e1, "m1"), _raising(e2, "m2")),
+        max_retries_per_model=0,
+    )
+    with pytest.raises(ProviderUnavailable) as ei:
+        await fbm.generate(_messages())
+    assert len(ei.value.errors) == 2
+    assert isinstance(ei.value.__cause__, RateLimited)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -382,3 +382,15 @@ class TestErrorCodeExtraction:
         exc = _FakeExc("content policy violation", status_code=400)
         with pytest.raises(ContentFiltered):
             classify_and_raise(exc, model=_model())
+
+    def test_503_does_not_exist_is_unavailable_not_model_not_found(self) -> None:
+        exc = _FakeExc("replica does not exist", status_code=503)
+        with pytest.raises(ProviderUnavailable):
+            classify_and_raise(exc, model=_model())
+
+    def test_generic_not_found_code_without_model_hint_is_bad_request(self) -> None:
+        exc = _FakeExc("missing resource", status_code=404)
+        exc.body = {"error": {"code": "not_found_error"}}
+        with pytest.raises(ProviderBadRequest) as ei:
+            classify_and_raise(exc, model=_model())
+        assert not isinstance(ei.value, ModelNotFound)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -394,3 +394,105 @@ class TestErrorCodeExtraction:
         with pytest.raises(ProviderBadRequest) as ei:
             classify_and_raise(exc, model=_model())
         assert not isinstance(ei.value, ModelNotFound)
+
+    def test_nested_error_object_and_attr_error(self) -> None:
+        from cubepi.errors import extract_error_code
+
+        nested = _FakeExc("x", status_code=400)
+        nested.error = {"error": {"code": "model_not_available"}}
+        assert extract_error_code(nested) == "model_not_available"
+
+        class _Obj:
+            code = None
+            type = "content_filter"
+            param = None
+
+        attr = _FakeExc("filtered", status_code=400)
+        attr.error = _Obj()
+        assert extract_error_code(attr) == "content_filter"
+
+    def test_type_fallback_and_param_model(self) -> None:
+        from cubepi.errors import extract_error_code
+
+        typ = _FakeExc("x", status_code=400)
+        typ.error = {"type": "invalid_model"}
+        assert extract_error_code(typ) == "invalid_model"
+
+        param = _FakeExc("x", status_code=400)
+        param.error = {"type": "invalid_request_error", "param": "model"}
+        assert extract_error_code(param) == "invalid_request_error"
+
+        other = _FakeExc("x", status_code=400)
+        other.error = {"type": "overloaded_error"}
+        assert extract_error_code(other) == "overloaded_error"
+
+    def test_looks_like_model_not_found_gates(self) -> None:
+        from cubepi.errors import _looks_like_model_not_found
+
+        assert _looks_like_model_not_found(status=500, code="model_not_found", msg="x")
+        assert _looks_like_model_not_found(
+            status=400, code=None, msg="x", param="model"
+        )
+        assert _looks_like_model_not_found(
+            status=404, code="not_found_error", msg="unknown model id"
+        )
+        assert _looks_like_model_not_found(
+            status=400, code=None, msg="invalid model xyz"
+        )
+
+    def test_content_filtered_by_code(self) -> None:
+        from cubepi.errors import _looks_like_content_filtered
+
+        assert _looks_like_content_filtered(code="content_filter", msg="nope")
+
+    def test_classify_string_error_branches(self) -> None:
+        from cubepi.errors import classify_string_error
+
+        assert isinstance(
+            classify_string_error("maximum context length exceeded"),
+            ContextLengthExceeded,
+        )
+        assert isinstance(
+            classify_string_error("slow down", status_code=429), RateLimited
+        )
+        assert isinstance(
+            classify_string_error("nope", status_code=401), ProviderAuthFailed
+        )
+        assert isinstance(
+            classify_string_error("blocked by content_policy"), ContentFiltered
+        )
+        assert isinstance(
+            classify_string_error("unknown model foo", status_code=404), ModelNotFound
+        )
+        assert isinstance(
+            classify_string_error("boom", status_code=503), ProviderUnavailable
+        )
+
+    def test_error_from_stream_fields_context_length(self) -> None:
+        from cubepi.errors import error_from_stream_fields
+
+        err = error_from_stream_fields(
+            error_message="too long",
+            error_type="ContextLengthExceeded",
+            tokens_in=99,
+            context_window=10,
+        )
+        assert isinstance(err, ContextLengthExceeded)
+        assert err.tokens_in == 99
+
+    def test_annotate_error_event_typed_and_raw(self) -> None:
+        from cubepi.errors import annotate_error_event
+
+        rl = RateLimited("wait", retry_after=1.5, provider="p", model="m")
+        fields = annotate_error_event(rl)
+        assert fields["error_type"] == "RateLimited"
+        assert fields["retry_after"] == 1.5
+
+        cle = ContextLengthExceeded("long", tokens_in=10, context_window=8)
+        fields = annotate_error_event(cle)
+        assert fields["tokens_in"] == 10
+
+        raw = RuntimeError("nope")
+        fields = annotate_error_event(raw, fallback_message="x")
+        assert fields["error_message"] == "x"
+        assert fields["error_type"] is None

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -7,7 +7,9 @@ from types import SimpleNamespace
 import pytest
 
 from cubepi.errors import (
+    ContentFiltered,
     ContextLengthExceeded,
+    ModelNotFound,
     ProviderAuthFailed,
     ProviderBadRequest,
     ProviderError,
@@ -212,10 +214,11 @@ class TestClassifyProviderBadRequest:
             classify_and_raise(exc, model=_model())
         assert ei.value.status_code == 400
 
-    def test_404_raises_provider_bad_request(self) -> None:
+    def test_404_model_not_found(self) -> None:
         exc = _FakeExc("model not found", status_code=404)
-        with pytest.raises(ProviderBadRequest):
+        with pytest.raises(ModelNotFound) as ei:
             classify_and_raise(exc, model=_model())
+        assert isinstance(ei.value, ProviderBadRequest)
 
 
 class TestClassifyUnknown:
@@ -244,6 +247,8 @@ class TestProviderErrorInheritance:
             ProviderAuthFailed,
             ProviderUnavailable,
             ProviderBadRequest,
+            ModelNotFound,
+            ContentFiltered,
         ):
             err = cls("msg", provider="p", model="m")
             assert isinstance(err, ProviderError)
@@ -360,4 +365,20 @@ class TestSDKConnectionErrors:
         """anthropic.APITimeoutError has 'Timeout' in class name."""
         exc = type("APITimeoutError", (Exception,), {})("timed out")
         with pytest.raises(ProviderUnavailable):
+            classify_and_raise(exc, model=_model())
+
+
+class TestErrorCodeExtraction:
+    def test_openai_error_code(self) -> None:
+        from cubepi.errors import extract_error_code
+
+        exc = _FakeExc("nope", status_code=400)
+        exc.body = {
+            "error": {"code": "model_not_found", "type": "invalid_request_error"}
+        }
+        assert extract_error_code(exc) == "model_not_found"
+
+    def test_content_filtered_from_message(self) -> None:
+        exc = _FakeExc("content policy violation", status_code=400)
+        with pytest.raises(ContentFiltered):
             classify_and_raise(exc, model=_model())

--- a/website/docs/recipes/multi-provider-failover.md
+++ b/website/docs/recipes/multi-provider-failover.md
@@ -117,9 +117,12 @@ really responded.
 - **Mid-stream errors aren't retried** — Once a healthy first event arrives,
   `FallbackBoundModel` commits to that provider. Errors during the rest of
   the stream are forwarded to the agent as-is.
-- **`ContextLengthExceeded` is only useful if the fallback is larger** — If
-  both providers have the same context window the failover will fail the same
-  way. Consider pairing a standard-window primary with a large-context fallback.
+- **`ContextLengthExceeded` skips legs that cannot fit** — if `tokens_in` is
+  known and the next model's `context_window` is smaller, that leg is not
+  called. Pair a standard-window primary with a large-context fallback.
+- **Sticky is per run, not a long-term preference** — the next
+  `Agent.prompt` starts at the user-selected primary again. Do not persist
+  the active index unless the product layer opts in.
 
 ## Run the example
 

--- a/website/docs/recipes/multi-provider-failover.md
+++ b/website/docs/recipes/multi-provider-failover.md
@@ -34,24 +34,42 @@ agent = Agent(model=model, system_prompt="You answer concisely.")
 await agent.prompt("Capital of Mongolia?")
 ```
 
-`FallbackBoundModel` peeks at the first stream event from each provider. If it
-is a `type="error"` event, or if `stream()` raises a retriable error, the next
-model in the chain is tried. Once a non-error first event arrives the stream is
-forwarded as-is — mid-stream errors are not retried.
+`FallbackBoundModel` peeks at the first stream event from each provider. Typed
+error fields on that event (`error_type`, `error_code`, `status_code`, …) use
+the **same predicate** as a raised exception. Once a non-error first event
+arrives the stream is forwarded as-is — mid-stream errors are not retried.
+
+Policy in one turn:
+
+1. **Same-model retry** (default 3 retries / 4 attempts) for transient
+   `RateLimited` and `ProviderUnavailable` only. `RateLimited.retry_after` is
+   honoured, capped by `max_retry_after` (default 5s).
+2. **Then hop** to the next chain entry. Residual `ProviderBadRequest` and
+   `ModelNotFound` hop immediately (no same-model retry) — classification
+   misses model-specific 400s more often than a true schema bug that fails
+   every provider.
+3. **Stick** to the first *successful* leg for later `stream` / `generate`
+   calls in the same `Agent.prompt` / run. The next user turn resets to
+   `chain[0]`. Subagents start their own run and do **not** inherit the
+   parent's sticky index.
 
 ## Default trigger conditions
 
-By default failover is triggered on:
+By default **failover** is triggered on:
 
-| Error | Why |
-|---|---|
-| `RateLimited` | Quota hit; another provider can serve |
-| `ProviderUnavailable` | 5xx / timeout / connection failure |
-| `ContextLengthExceeded` | Fallback may have a larger context window |
+| Error | Same-model retry | Hop |
+|---|---|---|
+| `RateLimited` | Yes | After retries |
+| `ProviderUnavailable` | Yes | After retries |
+| `ContextLengthExceeded` | No | Yes, but skip legs whose `context_window` cannot fit `tokens_in` |
+| `ModelNotFound` | No | Yes |
+| `ProviderBadRequest` (residual 4xx) | No | Yes |
+| `ProviderAuthFailed` | No | No (fail-closed) |
+| `ContentFiltered` | No | No (fail-closed; opt in via `trigger_errors`) |
 
-Auth failures (`ProviderAuthFailed`) and bad requests (`ProviderBadRequest`)
-are **not** triggered by default — a bad key or a malformed request will fail
-the same way on every provider in the chain.
+This is an intentional change from earlier releases: residual 4xx used to
+hard-fail the turn. A true schema bug still exhausts the chain quickly; the
+aggregated `ProviderUnavailable.errors` list keeps every leg.
 
 ## Custom trigger conditions
 
@@ -88,14 +106,21 @@ async def record_failover(failed, next_model, error):
 
 model = FallbackBoundModel(
     chain=(primary, fallback),
+    max_retries_per_model=3,   # 3 retries after the first failure (4 attempts)
+    max_retry_after=5.0,
     on_failover=record_failover,
 )
 ```
 
 `on_failover` receives `(failed: BoundModel, next_model: BoundModel | None,
-error: BaseException | str)`. Both sync and async callables are accepted.
-Exceptions raised inside the callback are logged and swallowed — a broken
-callback never aborts the failover.
+error: BaseException | str)` and fires **only on a chain hop**, not on each
+same-model retry. Optional `on_retry(failed, error, attempt, wait_s)` covers
+retries. Both sync and async callables are accepted. Exceptions raised inside
+either callback are logged and swallowed.
+
+When every leg fails, CubePi raises `ProviderUnavailable` whose `.errors`
+list holds the per-leg failures (typed when possible). `__cause__` is the
+last typed error.
 
 ## `provider` and `spec` always reflect the primary
 
@@ -136,8 +161,9 @@ export ANTHROPIC_API_KEY=sk-ant-...   # or OPENAI_API_KEY [+ OPENAI_BASE_URL]
 uv run python examples/multi_provider_failover.py
 ```
 
-The example deliberately uses a bad key for the primary to trigger failover,
-then answers correctly via the real fallback.
+The example deliberately uses a bad key for the primary. Auth is fail-closed
+by default, so the example **opts in** via `trigger_errors` to include
+`ProviderAuthFailed`, then answers correctly via the real fallback.
 
 ## See also
 

--- a/website/docs/recipes/multi-provider-failover.md
+++ b/website/docs/recipes/multi-provider-failover.md
@@ -49,9 +49,11 @@ Policy in one turn:
    misses model-specific 400s more often than a true schema bug that fails
    every provider.
 3. **Stick** to the first *successful* leg for later `stream` / `generate`
-   calls in the same `Agent.prompt` / run. The next user turn resets to
-   `chain[0]`. Subagents start their own run and do **not** inherit the
-   parent's sticky index.
+   calls in the same `Agent.prompt`. HITL `respond()` continues that run and
+   keeps the sticky index. The next user `prompt` resets to `chain[0]`.
+   Subagents start their own run and do **not** inherit the parent's index.
+   Sticky requires `begin_fallback_run()` (Agent does this); standalone
+   `FallbackBoundModel` calls do not stick.
 
 ## Default trigger conditions
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/recipes/multi-provider-failover.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/recipes/multi-provider-failover.md
@@ -45,9 +45,11 @@ await agent.prompt("Capital of Mongolia?")
 2. **再 hop** 到下一条。residual `ProviderBadRequest` 和 `ModelNotFound`
    立刻 hop（不同模型重试）——分类漏报「其实是这个模型/网关的问题」比
    「全链都会炸的真 schema 错误」更常见。
-3. **粘住**本轮第一次**成功**的那条腿：同一 `Agent.prompt` / run 里后续
-   `stream` / `generate` 直接打这条。下一次用户回合重置回 `chain[0]`。
-   Subagent 自己开 run，**不继承**父级 sticky index。
+3. **粘住**本轮第一次**成功**的那条腿：同一 `Agent.prompt` 里后续
+   `stream` / `generate` 直接打这条。HITL `respond()` 继续该 run，保留
+   sticky。下一次用户 `prompt` 重置回 `chain[0]`。Subagent 自己开 run，
+   **不继承**父级 index。Sticky 依赖 `begin_fallback_run()`（Agent 会调）；
+   单独调用 `FallbackBoundModel` 不会粘。
 
 ## 默认触发条件
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/recipes/multi-provider-failover.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/recipes/multi-provider-failover.md
@@ -1,264 +1,144 @@
 ---
 title: 多 Provider 故障转移
-description: "在 CubePi 中配置多 provider 故障转移以提升弹性 —— provider 间自动降级。"
+description: "用内置 FallbackBoundModel 在 LLM provider 之间自动降级。"
 ---
 
 # Recipe：多 Provider 故障转移
 
-当 Anthropic 触发限速或发生故障时，自动切换到 OpenAI 而不让 agent 崩溃。
-我们将把两个 provider 封装在一个单独的 `Provider` 适配器后面，
-由该适配器自行实现重试/故障转移逻辑。
+主 provider 限流、不可用或撞上上下文窗口时，自动切到下一条，不要把 agent 打崩。
+CubePi 内置 `FallbackBoundModel`，不必再手写适配器。
 
-**预计耗时：** 10 分钟。
-**依赖：** `cubepi`、`ANTHROPIC_API_KEY`、`OPENAI_API_KEY`。
+**预计耗时：** 5 分钟。
+**依赖：** `cubepi`，以及至少两套 provider API key。
 
-## 封装 provider
+## 内置：`FallbackBoundModel`
 
-```python title="failover.py"
-import asyncio
-import logging
-import time
-from typing import Sequence
-
-from cubepi.providers.base import (
-    AssistantMessage,
-    BaseProvider,
-    BoundModel,
-    Message,
-    MessageStream,
-    Model,
-    StreamEvent,
-    StreamOptions,
-    ToolDefinition,
-    Usage,
-)
+```python
+import os
+from cubepi import Agent, FallbackBoundModel
 from cubepi.providers.anthropic import AnthropicProvider
 from cubepi.providers.openai import OpenAIProvider
+
+anthropic = AnthropicProvider(api_key=os.environ["ANTHROPIC_API_KEY"])
+openai = OpenAIProvider(api_key=os.environ["OPENAI_API_KEY"])
+
+model = FallbackBoundModel(
+    chain=(
+        anthropic.model("claude-opus-4-8"),   # 主模型
+        openai.model("gpt-5"),                # 备援
+    )
+)
+
+agent = Agent(model=model, system_prompt="You answer concisely.")
+await agent.prompt("Capital of Mongolia?")
+```
+
+`FallbackBoundModel` 会看每条腿的**第一个** stream 事件。该事件上的类型字段
+（`error_type`、`error_code`、`status_code` …）和抛出的异常走**同一套判定**。
+一旦出现非 error 的首包，流原样转发——流中途出错不会再 hop。
+
+一轮里的策略：
+
+1. **先同模型重试**（默认 3 次重试 / 共 4 次尝试），仅针对瞬时的
+   `RateLimited` 和 `ProviderUnavailable`。会遵守
+   `RateLimited.retry_after`，并受 `max_retry_after`（默认 5s）封顶。
+2. **再 hop** 到下一条。residual `ProviderBadRequest` 和 `ModelNotFound`
+   立刻 hop（不同模型重试）——分类漏报「其实是这个模型/网关的问题」比
+   「全链都会炸的真 schema 错误」更常见。
+3. **粘住**本轮第一次**成功**的那条腿：同一 `Agent.prompt` / run 里后续
+   `stream` / `generate` 直接打这条。下一次用户回合重置回 `chain[0]`。
+   Subagent 自己开 run，**不继承**父级 sticky index。
+
+## 默认触发条件
+
+默认会 **failover（hop）** 的错误：
+
+| 错误 | 同模型重试 | Hop |
+|---|---|---|
+| `RateLimited` | 是 | 重试耗尽后 |
+| `ProviderUnavailable` | 是 | 重试耗尽后 |
+| `ContextLengthExceeded` | 否 | 是，但会跳过 `context_window` 装不下 `tokens_in` 的腿 |
+| `ModelNotFound` | 否 | 是 |
+| `ProviderBadRequest`（其余 4xx） | 否 | 是 |
+| `ProviderAuthFailed` | 否 | 否（fail-closed） |
+| `ContentFiltered` | 否 | 否（fail-closed；可用 `trigger_errors` 打开） |
+
+相对早期版本这是有意的行为变化：residual 4xx 以前会直接打死这一轮。
+真 schema 错误仍会很快耗尽整条链；聚合后的
+`ProviderUnavailable.errors` 会留下每一腿。
+
+## 自定义触发条件
+
+用 `trigger_errors` 覆盖默认集合：
+
+```python
+from cubepi import FallbackBoundModel
+from cubepi.errors import ProviderAuthFailed, ProviderUnavailable, RateLimited
+
+model = FallbackBoundModel(
+    chain=(primary, fallback),
+    trigger_errors=frozenset({RateLimited, ProviderUnavailable, ProviderAuthFailed}),
+)
+```
+
+## 监控 failover
+
+用 `on_failover` 接计费或告警：
+
+```python
+import logging
 
 log = logging.getLogger(__name__)
 
-
-class FailoverProvider(BaseProvider):
-    """按顺序尝试各 provider；在构造时或首个事件出错时进行故障转移。
-
-    内置 provider 会吞掉 API/网络错误，并将其作为
-    `StreamEvent(type="error")` 暴露在返回的流上 —— 而不是从
-    `provider.stream()` 抛出异常。因此我们先查看每个内部流的第一个事件，
-    只有当看到非错误事件时才确认切换到该 provider。
-
-    限制：*首个事件之后*发生的错误（如流传输过半时的限速、服务端断连）
-    会原样转发给 agent。对故障 provider 完整重放半条流式响应
-    需要缓冲整轮内容 —— 超出本 recipe 范围。
-    """
-
-    def __init__(self, primary: BoundModel, *fallbacks: BoundModel) -> None:
-        super().__init__(provider_id=primary.spec.provider_id)
-        self._chain: list[BoundModel] = [primary, *fallbacks]
-
-    async def stream(
-        self,
-        model: Model,
-        messages: list[Message],
-        *,
-        system_prompt: str = "",
-        tools: list[ToolDefinition] | None = None,
-        options: StreamOptions | None = None,
-    ) -> MessageStream:
-        last_error: str | None = None
-
-        for bound_model in self._chain:
-            provider = bound_model.provider
-            mapped_model = bound_model.spec
-            # 构造时失败（罕见 —— 大多数错误留在生产者任务内部）。
-            try:
-                inner = await provider.stream(
-                    mapped_model,
-                    messages,
-                    system_prompt=system_prompt,
-                    tools=tools,
-                    options=options,
-                )
-            except Exception as e:
-                log.warning("provider %s failed at construction: %s", mapped_model.provider_id, e)
-                last_error = repr(e)
-                continue
-
-            # 查看第一个事件以判断流是否健康。
-            iterator = inner.__aiter__()
-            try:
-                first = await iterator.__anext__()
-            except StopAsyncIteration:
-                last_error = "stream ended before producing any events"
-                continue
-
-            if first.type == "error":
-                log.warning("provider %s errored on first event: %s",
-                            mapped_model.provider_id, first.error_message)
-                last_error = first.error_message or "stream error"
-                continue
-
-            # 健康 —— 提交到此 provider。通过全新的外层 MessageStream
-            # 转发 `first` 及后续事件，让调用方看到从头开始的完整流。
-            outer = MessageStream()
-
-            async def _forward(first_event=first, src=iterator, src_stream=inner):
-                try:
-                    outer.push(first_event)
-                    async for ev in src:
-                        outer.push(ev)
-                    final = await src_stream.result()
-                    outer.set_result(final)
-                except Exception as exc:
-                    fallback_msg = AssistantMessage(
-                        content=[],
-                        stop_reason="error",
-                        error_message=str(exc),
-                        usage=Usage(),
-                        timestamp=time.time(),
-                    )
-                    outer.push(StreamEvent(type="error", error_message=str(exc)))
-                    outer.set_result(fallback_msg)
-
-            outer.attach_task(asyncio.create_task(_forward()))
-            return outer
-
-        raise RuntimeError(f"all providers exhausted; last error: {last_error!r}")
-```
-
-## 使用方式
-
-```python title="main.py"
-import asyncio
-import os
-
-from cubepi import Agent
-from cubepi.providers.anthropic import AnthropicProvider
-from cubepi.providers.openai import OpenAIProvider
-from failover import FailoverProvider
-
-
-async def main():
-    anthropic = AnthropicProvider(
-        provider_id="anthropic",
-        api_key=os.environ["ANTHROPIC_API_KEY"],
-    )
-    openai = OpenAIProvider(
-        provider_id="openai",
-        api_key=os.environ["OPENAI_API_KEY"],
-    )
-    failover = FailoverProvider(
-        anthropic.model("claude-sonnet-4-6"),
-        openai.model("gpt-5"),
+async def record_failover(failed, next_model, error):
+    log.warning(
+        "provider failover: %s/%s → %s/%s (%s)",
+        failed.spec.provider_id, failed.spec.id,
+        next_model.spec.provider_id if next_model else "none",
+        next_model.spec.id if next_model else "—",
+        error,
     )
 
-    # 此处传入的 model 会被 FailoverProvider 内部覆盖；可传任意占位符。
-    # 我们使用主 provider 的 model，以便用量统计标签与正常路径保持一致。
-    agent = Agent(
-        model=failover.model("claude-sonnet-4-6"),
-        system_prompt="You answer concisely.",
-    )
-    agent.subscribe(lambda e, s=None: None)
-    await agent.prompt("Capital of Mongolia?")
-    last = agent.state.messages[-1]
-    print(last.content[0].text)
-
-
-asyncio.run(main())
+model = FallbackBoundModel(
+    chain=(primary, fallback),
+    max_retries_per_model=3,   # 首次失败后再重试 3 次（共 4 次）
+    max_retry_after=5.0,
+    on_failover=record_failover,
+)
 ```
 
-## 更智能的故障转移策略
+`on_failover` 的参数是 `(failed: BoundModel, next_model: BoundModel | None,
+error: BaseException | str)`，**只在真正 hop 时**触发，同模型重试不会调它。
+同模型重试用可选的 `on_retry(failed, error, attempt, wait_s)`。
+同步 / 异步回调都可以；回调里抛错会被记日志并吞掉。
 
-上面的示例在**任何**错误事件时都会降级。这对于 `RateLimitError`、
-`APIConnectionError` 或 5xx 是合理的 —— 但对于 `BadRequestError`
-则未必正确（代码有误；下一个 provider 也会以同样方式失败）。
+整条链都失败时抛 `ProviderUnavailable`，`.errors` 是每条腿的失败
+（能分类则带类型），`__cause__` 是最后一条 typed error。
 
-首个事件的 `error_message` 来自底层 SDK 异常的 `str(exc)`。
-可以按子字符串过滤，或者 —— 更好的做法 —— 封装每个 provider 的
-`_produce` 方法，为错误打上类别标签：
+## `provider` 和 `spec` 始终指向主模型
 
-```python
-NON_RETRYABLE_HINTS = ("bad request", "invalid_request_error", "401", "403")
-
-if first.type == "error":
-    msg = (first.error_message or "").lower()
-    if any(h in msg for h in NON_RETRYABLE_HINTS):
-        raise RuntimeError(f"non-retryable error from {mapped_model.provider_id}: {msg}")
-    last_error = first.error_message
-    continue
-```
-
-更健壮的方法是 fork 内置 provider 并从 `_produce` 中重新抛出
-特定的 SDK 异常，使其作为真正的 Python 异常到达 `provider.stream()` ——
-但这需要对 CubePi 本身做较大改动。
-
-## 添加熔断器
-
-不要持续重试一个明显已宕机的 provider。一个简单的计数器：
-
-```python
-import time
-
-class CircuitBreaker:
-    def __init__(self, failure_threshold: int = 3, recovery_seconds: float = 60) -> None:
-        self._failures = 0
-        self._opened_at: float | None = None
-        self._threshold = failure_threshold
-        self._recovery = recovery_seconds
-
-    def can_attempt(self) -> bool:
-        if self._opened_at and time.monotonic() - self._opened_at < self._recovery:
-            return False
-        if self._opened_at:
-            self._opened_at = None   # half-open
-        return True
-
-    def record_failure(self) -> None:
-        self._failures += 1
-        if self._failures >= self._threshold:
-            self._opened_at = time.monotonic()
-            self._failures = 0
-
-    def record_success(self) -> None:
-        self._failures = 0
-```
-
-在 `FailoverProvider` 中为每个 provider 持有一个 `CircuitBreaker`，
-若 `can_attempt()` 返回 False 则跳过该 provider。
-
-## 按工具故障转移不适用
-
-本 recipe 处理的是 **provider** 故障。工具故障是另一回事 ——
-参见 [Middleware → 重试](../guides/middleware/examples#retries-with-backoff)
-了解该模式。
+`FallbackBoundModel.provider` / `.spec` 代理 `chain[0]`。读
+`agent._model.provider` 或 `agent._model.spec` 的 tracing / 计费代码看到的
+仍是用户选的主模型。真正应答的那条腿写在返回的
+`AssistantMessage.provider_id` / `model_id` 上。
 
 ## 常见陷阱
 
-- **不同 provider 的工具 schema 不同** —— 两个内置 provider 都接受相同的
-  `ToolDefinition`，但 extra-body 定制（如 OpenAI 的
-  `parallel_tool_calls=False`）不会带到 Anthropic。请将跨 provider 的
-  行为放在 [`transform_context`](../guides/middleware/hooks#transform_context)
-  中，而非 `extra_body`。
-- **成本不同** —— 从 Anthropic 故障转移到 OpenAI 会改变每 token 的费用。
-  跟踪是哪个 provider 响应（通过 `on_response` 或
-  `AssistantMessage.provider_id`）并据此计费。
-- **流一致性** —— 封装器通过全新的 `MessageStream` 转发事件，因此
-  消费者无论哪个 provider 响应都能看到相同的 `StreamEvent` 结构。
-  原始的 `start` 事件由内部 provider 原样传递。
-- **流传输中途的错误无法恢复** —— 一旦看到健康的首个事件，封装器即
-  提交到该 provider。如果在长响应传输途中出错，agent 会看到该错误。
-  完整的中途重放需要缓冲 —— 超出本 recipe 范围。
-
-## 另请参见
-
-- [Providers / Anthropic](../guides/providers/anthropic) 和
-  [OpenAI](../guides/providers/openai) —— provider 专属细节。
-- [编写自定义 Provider](../guides/providers/custom) —— 本封装器使用的同一 Protocol。
+- **不同 provider 的工具 schema** — 两个内置 provider 都吃同一套
+  `ToolDefinition`，但厂商私货（如 OpenAI `parallel_tool_calls=False`）
+  带不到 Anthropic。跨 provider 行为放在 `transform_context` middleware，
+  不要塞 `extra_body`。
+- **成本不同** — hop 会改单价。用 `AssistantMessage.provider_id` 记账；
+  `on_failover` 是记录切换的合适位置。
+- **流中途错误不重试** — 看到健康首包就提交该 provider，后半段错误原样转发。
+- **`ContextLengthExceeded` 会跳过装不下的腿** — 已知 `tokens_in` 且下一腿
+  `context_window` 更小时不会打它。标准窗口主模型请配大窗口备援。
+- **Sticky 只作用于本轮，不是长期偏好** — 下一次 `Agent.prompt` 仍从用户选的
+  主模型开始。除非产品层显式持久化，不要把 active index 存下来。
 
 ## 运行示例
 
-仓库中有一份完整可运行的代码，位于
-[`examples/multi_provider_failover.py`](https://github.com/cubeplexai/cubepi/blob/main/examples/multi_provider_failover.py)。
-示例故意使用错误的主 provider key 触发故障转移，再通过备用 provider 正确返回结果。
+仓库里有可运行版本：
 
 ```bash
 git clone https://github.com/cubeplexai/cubepi && cd cubepi
@@ -267,3 +147,12 @@ uv sync
 export ANTHROPIC_API_KEY=sk-ant-...   # 或 OPENAI_API_KEY [+ OPENAI_BASE_URL]
 uv run python examples/multi_provider_failover.py
 ```
+
+示例故意给主模型一个坏 key。鉴权默认 fail-closed，所以示例通过
+`trigger_errors` **显式加入** `ProviderAuthFailed`，再由真实备援给出答案。
+
+## 另请参见
+
+- [Providers 总览](../guides/providers/overview) — provider 配置与 `CapabilityDescriptor`。
+- [Providers / Anthropic](../guides/providers/anthropic) 和 [OpenAI](../guides/providers/openai) — 厂商细节。
+- [编写自定义 Provider](../guides/providers/custom) — 内置不够用时。


### PR DESCRIPTION
Closes #211.

Hardens the error-classification + failover path without changing the public `FallbackBoundModel(chain=..., trigger_errors=..., on_failover=...)` shape.

## Policy

- Same-model retry first (default `max_retries_per_model=3` → 4 attempts) for `RateLimited` / `ProviderUnavailable`. Honour capped `retry_after`.
- Then hop. Residual `ProviderBadRequest` and `ModelNotFound` hop with **no** same-model retry.
- `ProviderAuthFailed` and `ContentFiltered` stay fail-closed (opt in via `trigger_errors`).
- Sticky active leg after the **first successful** response, scoped to one `Agent.prompt` / run via `contextvars`. Next turn resets to `chain[0]`. Subagents start their own run and do not inherit the parent index.
- `ContextLengthExceeded` skips same-model retry and skips legs whose `context_window` cannot fit `tokens_in`.
- Exhaustion raises `ProviderUnavailable` with `.errors` (per-leg) and `__cause__` = last typed error.

## Typing

- `ProviderError.error_code` extracted from vendor bodies (OpenAI `code` before Anthropic `type`).
- New `ModelNotFound` / `ContentFiltered` subclasses of `ProviderBadRequest`.
- `StreamEvent` / `AssistantMessage` carry `error_type`, `error_code`, `status_code`, `retry_after` so first-event errors use the same predicate as raised exceptions.

## Docs / tests

- Recipe `website/docs/recipes/multi-provider-failover.md` updated.
- Example opts into auth failover (demo-only; default remains fail-closed).
- Fallback + classifier tests cover retry, sticky, typed first-event, residual 4xx hop, context-window skip, exhaustion aggregation.