### PR TITLE
chore(release): prepare 0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.5] - 2026-08-16
+
 ### Changed
 
 - **`FallbackBoundModel` retries the active model before hopping**, then
@@ -780,7 +782,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.2.0]** - 2026-05-10 — see the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.2.0).
 - **[0.1.0]** - 2026-05-09 — initial release. See the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.4...HEAD
+[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.5...HEAD
+[0.13.5]: https://github.com/cubeplexai/cubepi/compare/v0.13.4...v0.13.5
 [0.13.4]: https://github.com/cubeplexai/cubepi/compare/v0.13.3...v0.13.4
 [0.13.3]: https://github.com/cubeplexai/cubepi/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/cubeplexai/cubepi/compare/v0.13.1...v0.13.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cubepi"
-version = "0.13.4"
+version = "0.13.5"
 description = "Pythonic async-native agent framework"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "cubepi"
-version = "0.13.4"
+version = "0.13.5"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bump package version `0.13.4` → `0.13.5`
- Promote Unreleased changelog entries into `## [0.13.5] - 2026-08-16`
- Update uv.lock package version

### Included since v0.13.4

- **Changed:** `FallbackBoundModel` retries the active model before hopping, then sticks to the first successful leg for the rest of the agent run (`#211` / `#212`). Transient `RateLimited` / `ProviderUnavailable` retry up to `max_retries_per_model=3`; residual `ProviderBadRequest` / `ModelNotFound` hop without same-model retry; auth and content-filter stay fail-closed. New `ModelNotFound` / `ContentFiltered` subclasses; typed first-event stream errors; exhaustion raises `ProviderUnavailable` with `.errors`.

Patch-only; no docs version snapshot (X.Y cut not required). Failover recipe already landed on `current/` in #212.

## Test plan

- [x] Version strings consistent in pyproject.toml / CHANGELOG / uv.lock
- [x] Every `## [N.M.P]` heading has a matching reference link
- [ ] CI green (pytest / ruff / mypy)
- [ ] After merge: publish GitHub release `v0.13.5` to trigger PyPI workflow