### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cubeplexai/cubepi/security/code-scanning/5](https://github.com/cubeplexai/cubepi/security/code-scanning/5)

Add an explicit `permissions` block at the workflow root in `.github/workflows/ci.yml` so all jobs inherit least-privilege permissions unless overridden.  
Best fix here: set:

- `contents: read`

This preserves functionality (checkout and read access) while preventing unintended write scopes.  
Edit region: directly after the `on:` trigger block and before `jobs:`.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
