### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cubeplexai/cubepi/security/code-scanning/4](https://github.com/cubeplexai/cubepi/security/code-scanning/4)

Add explicit `permissions` to the workflow so jobs without their own permissions (here, `build`) do not inherit potentially broad defaults.

Best single fix without changing functionality: add a workflow-level block right after the trigger section:

- `permissions:`
  - `contents: read`

This keeps `build` least-privileged and preserves existing job-level overrides for publish jobs (`id-token: write`), which remain in effect for those jobs.

File to edit:
- `.github/workflows/publish.yml` near the top-level keys, between `on:` and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
