### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cubeplexai/cubepi/security/code-scanning/1](https://github.com/cubeplexai/cubepi/security/code-scanning/1)

Add a root-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access.  
Best minimal fix without changing functionality is:

- Add:
  - `permissions:`
  - `contents: read`

Place it near the top of the workflow (after `on:` block and before `jobs:`), so both `test` and `lint` get this default.  
No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
