### PR TITLE
chore(release): prepare 0.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.6] - 2026-09-04
+
+### Fixed
+
+- **Compaction no longer lets trailing synthetic user controls hide
+  current-turn evidence.** Transform middleware can append a synthetic
+  `UserMessage` after this turn's tool results. Compaction previously
+  treated that control as the protected tail and a legal boundary, so
+  the results immediately before it became eligible for size-only
+  pruning (`[tool] N chars`) even though they were still in durable
+  history. Trailing synthetic user messages are now split off before
+  tail, boundary, prune, and summarize decisions; they still count
+  toward the send-size threshold and are reattached unchanged (`#217`).
+- **GitHub Actions workflows now declare least-privilege permissions.**
+  CI and publish workflows explicitly request read-only repository
+  contents access.
+
 ## [0.13.5] - 2026-08-16
 
 ### Changed
@@ -782,7 +799,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.2.0]** - 2026-05-10 — see the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.2.0).
 - **[0.1.0]** - 2026-05-09 — initial release. See the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.5...HEAD
+[Unreleased]: https://github.com/cubeplexai/cubepi/compare/v0.13.6...HEAD
+[0.13.6]: https://github.com/cubeplexai/cubepi/compare/v0.13.5...v0.13.6
 [0.13.5]: https://github.com/cubeplexai/cubepi/compare/v0.13.4...v0.13.5
 [0.13.4]: https://github.com/cubeplexai/cubepi/compare/v0.13.3...v0.13.4
 [0.13.3]: https://github.com/cubeplexai/cubepi/compare/v0.13.2...v0.13.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cubepi"
-version = "0.13.5"
+version = "0.13.6"
 description = "Pythonic async-native agent framework"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -522,7 +522,7 @@ wheels = [
 
 [[package]]
 name = "cubepi"
-version = "0.13.5"
+version = "0.13.6"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- Bump package version `0.13.5` → `0.13.6`
- Promote Unreleased changelog entries into `## [0.13.6] - 2026-09-04`
- Update uv.lock package version

### Included since v0.13.5

- **Fixed:** Compaction no longer lets trailing synthetic user controls hide current-turn evidence (`#217`). Transform middleware can append a synthetic `UserMessage` after this turn's tool results; compaction previously treated that control as the protected tail and a legal boundary, so the results immediately before it were pruned to `[tool] N chars`. Trailing synthetic user messages are now split off before tail/boundary/prune/summarize decisions, still counted toward the send-size threshold, and reattached unchanged. Compaction guide on `current/` already documents this.
- **Fixed:** GitHub Actions CI and publish workflows now declare least-privilege permissions (`contents: read`). Copilot Autofix for code scanning alerts 4 and 5.

Website `pnpm` 11.8.0 → 11.11.0 (`#218`) is included on `main` but is a docs-site tooling bump, not a library changelog item.

Patch-only; no docs version snapshot (X.Y cut not required).

## Test plan

- [x] Version strings consistent in pyproject.toml / CHANGELOG / uv.lock
- [x] Every `## [N.M.P]` heading has a matching reference link
- [x] Release branch rebased onto current `main` (includes #217 / #218)
- [ ] CI green (pytest / ruff / mypy)
- [ ] After merge: publish GitHub release `v0.13.6` to trigger PyPI workflow