### PR TITLE
chore(release): prepare 0.14.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-09-10
+
 ### Breaking
 
 - **Renamed CubePi / `cubepi` to CubeLoop / `cubeloop`.** The import path,
@@ -809,7 +811,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[0.2.0]** - 2026-05-10 — see the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.2.0).
 - **[0.1.0]** - 2026-05-09 — initial release. See the [release notes](https://github.com/cubeplexai/cubepi/releases/tag/v0.1.0).
 
-[Unreleased]: https://github.com/cubeplexai/cubeloop/compare/v0.13.6...HEAD
+[Unreleased]: https://github.com/cubeplexai/cubeloop/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/cubeplexai/cubeloop/compare/v0.13.6...v0.14.0
 [0.13.6]: https://github.com/cubeplexai/cubeloop/compare/v0.13.5...v0.13.6
 [0.13.5]: https://github.com/cubeplexai/cubeloop/compare/v0.13.4...v0.13.5
 [0.13.4]: https://github.com/cubeplexai/cubeloop/compare/v0.13.3...v0.13.4


### PR DESCRIPTION
## Summary

Move CHANGELOG `[Unreleased]` to `[0.14.0] - 2026-09-10` before tagging.

## Test plan

- [ ] Changelog heading and compare URLs match Keep a Changelog