### PR TITLE
Document host Alembic traps when migrating from cubepi

### DIFF
--- a/cubeloop/checkpointer/postgres/README.md
+++ b/cubeloop/checkpointer/postgres/README.md
@@ -121,6 +121,11 @@ CubeLoop bumps `EXPECTED_SCHEMA_VERSION` when the schema changes; the
 checkpointer refuses to connect if the row in `cubeloop_schema_version`
 doesn't match. Each bump is one host migration.
 
+Host Alembic traps when moving a pre-0.14 database (historical
+`create_message_partitions_op()` now emitting cubeloop names,
+autogenerate dropping `cubepi_threads`, reverse-rename vs DROP on
+downgrade) are in `website/docs/migration/from-cubepi.md`.
+
 **v1 → v2** (HITL): adds `pending_request JSONB NULL` to `cubepi_threads`.
 
 ```python

--- a/website/docs/guides/checkpointing/mysql.md
+++ b/website/docs/guides/checkpointing/mysql.md
@@ -279,7 +279,9 @@ def upgrade():
             op.execute(stmt)
 ```
 
-Do not run the v6 `CREATE TABLE` helpers against a v5 database. See the
+Do not run the v6 `CREATE TABLE` helpers against a v5 database.
+Host Alembic traps (autogenerate dropping `cubepi_*` tables, downgrade that
+`DROP`s instead of reverse-renaming) are in the
 [migration guide](../../migration/from-cubepi).
 
 ## Common pitfalls

--- a/website/docs/guides/checkpointing/postgres.md
+++ b/website/docs/guides/checkpointing/postgres.md
@@ -265,7 +265,11 @@ def upgrade():
 
 Do not run the v6 `CREATE TABLE` helpers against a v5 database — they
 would try to create tables that already exist under the old names.
-See the [migration guide](../../migration/from-cubepi).
+
+Host Alembic traps (historical `create_message_partitions_op()` now
+emitting cubeloop names, autogenerate dropping `cubepi_threads`,
+downgrade that `DROP`s instead of reverse-renaming partitions) are
+documented in the [migration guide](../../migration/from-cubepi).
 
 ## Common pitfalls
 

--- a/website/docs/migration/from-cubepi.md
+++ b/website/docs/migration/from-cubepi.md
@@ -41,13 +41,94 @@ If you have data tables but no `*_schema_version` table, do not apply the
 fresh v6 CREATE TABLE. Create `cubepi_schema_version` with version 5 first,
 then run the v5→v6 helper.
 
+Ship the package bump and this revision **together**. A process that imports
+0.14 and then opens the checkpointer against a still-v5 database will refuse
+to start.
+
+### Do not retarget historical helpers blindly
+
+0.14 split the Alembic helpers into two kinds:
+
+| Helper | SQL it emits in 0.14 |
+|---|---|
+| `create_message_partitions_op()`, `create_runs_partitions_op()` | **Current** names: `cubeloop_messages_pXX PARTITION OF cubeloop_messages`, same for runs. Postgres only. |
+| `add_pending_request_column_op()`, `add_run_id_column_op()`, `upgrade_v3_to_v4_op()`, `upgrade_v4_to_v5_op()` | **Historical** names: still `cubepi_*`. Safe to import from `cubeloop.checkpointer.postgres.alembic_helpers`. |
+| `write_schema_version_op()` | Writes `EXPECTED_SCHEMA_VERSION` (now **6**) to `cubeloop_schema_version` if that table exists, else to `cubepi_schema_version`. |
+
+A typical host v1 revision created `cubepi_messages` and then called
+`create_message_partitions_op()`. After you depend on cubeloop 0.14, that
+same call emits `PARTITION OF cubeloop_messages`. A greenfield
+`alembic upgrade head` (empty database replaying v1→v6) dies at v1:
+the cubeloop parent does not exist yet.
+
+**Fix:** stop calling `create_message_partitions_op()` from that historical
+revision. Inline the original SQL against the old parent:
+
+```sql
+CREATE TABLE cubepi_messages_p00
+  PARTITION OF cubepi_messages
+  FOR VALUES WITH (modulus 64, remainder 0);
+-- … p01 … p63
+```
+
+The same trap applies if a historical revision called
+`create_runs_partitions_op()`. CubeLoop's own `upgrade_v3_to_v4_op()`
+already inlines `cubepi_runs_pXX` and is safe.
+
+Do the inline **before** (or in the same change as) removing the `cubepi`
+package. Do not run Alembic against an empty database in between: v1 still
+`import cubepi.checkpointer…` until you retarget the remaining helper
+imports, and after the pin that module is gone.
+
+`write_schema_version_op()` writing 6 from a v1 replay is intentional —
+it has always written the *current* expected version, and `alembic upgrade
+head` runs v1→v6 in one shot. Do not rewrite those calls to insert
+historical 1/2/3/4/5 by hand.
+
+### Autogenerate can drop `cubepi_threads`
+
+`cubeloop_metadata` describes the **new** names. After you point Alembic
+`target_metadata` at it, a database that is still on v5 still has
+`cubepi_*` tables. Autogenerate then proposes `DROP cubepi_*` and
+`CREATE cubeloop_*` (empty). `cubepi_threads` is the usual casualty:
+many hosts let autogen create it in v1 and never put it on an exclusion
+list.
+
+That drop cascades onto messages, runs, and HITL answers.
+
+**Fix, in `env.py`, before generating the v6 revision:** exclude both
+generations from autogenerate:
+
+- Tables: `cubepi_threads`, `cubepi_messages`, `cubepi_runs`,
+  `cubepi_hitl_answers`, `cubepi_schema_version`, and the matching
+  `cubeloop_*` names.
+- Postgres partitions: prefixes `cubepi_messages_p`, `cubepi_runs_p`,
+  `cubeloop_messages_p`, `cubeloop_runs_p`.
+
+Inspect the generated v6 revision: it must not contain
+`DROP TABLE cubepi_threads` or a fresh `CREATE TABLE cubeloop_*`. The
+body should be `upgrade_v5_to_v6_op()` plus `write_schema_version_op()`.
+
+### Downgrade is a reverse rename, not DROP
+
+`upgrade_v5_to_v6_op()` renames parents, **each** of the 64 message and
+64 run partitions (Postgres), the HITL and version tables, and
+`ix_cubepi_*` indexes. PostgreSQL `ALTER TABLE … RENAME TO` on a
+partitioned parent does **not** rename children.
+
+A downgrade copied from an older bump (`DROP TABLE cubeloop_runs
+CASCADE`) deletes every conversation. Reverse-rename instead, including
+every partition, then write version 5 into `cubepi_schema_version`.
+
 ## Tracing
 
 New spans use `cubeloop.*` attributes and `cubeloop.turn` span names.
 `cubeloop trace` still reads 0.13 JSONL that used `cubepi.*`.
 Dashboards you own need their own attribute-name update.
 
-Default JSONL directory is `./cubeloop-traces`.
+Default JSONL directory is `./cubeloop-traces`. There is no automatic
+fallback to `./cubepi-traces`; pass `--dir` (or keep your config path)
+to read leftover files.
 
 ## Environment variables
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/checkpointing/mysql.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/checkpointing/mysql.md
@@ -206,7 +206,8 @@ def upgrade():
             op.execute(stmt)
 ```
 
-不要对 v5 数据库跑 v6 的 `CREATE TABLE` helper。详见
+不要对 v5 数据库跑 v6 的 `CREATE TABLE` helper。Host Alembic 的常见坑
+（autogenerate 可能 DROP `cubepi_*`、downgrade 用 DROP 而不是反向 rename）写在
 [从 cubepi 迁移](../../migration/from-cubepi)。
 
 ## 常见陷阱

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/checkpointing/postgres.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/checkpointing/postgres.md
@@ -218,7 +218,10 @@ def upgrade():
 ```
 
 不要对 v5 数据库跑 v6 的 `CREATE TABLE` helper——旧表已经在，只是名字还是 `cubepi_*`。
-详见 [从 cubepi 迁移](../../migration/from-cubepi)。
+
+Host Alembic 的常见坑（历史 `create_message_partitions_op()` 现在发出 cubeloop
+名字、autogenerate 可能 DROP `cubepi_threads`、downgrade 用 DROP 而不是反向
+rename 分区）写在 [从 cubepi 迁移](../../migration/from-cubepi)。
 
 ## 常见坑
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/migration/from-cubepi.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/migration/from-cubepi.md
@@ -1,19 +1,18 @@
 ---
 title: From cubepi
-description: "CubePi was renamed to CubeLoop in 0.14. How to update installs, imports, checkpointer schema, and traces."
+description: "CubePi 在 0.14 更名为 CubeLoop。如何更新安装、导入、checkpointer schema 和 traces。"
 ---
 
-# Migrating from cubepi
+# 从 cubepi 迁移
 
-0.14 renames the project from CubePi / `cubepi` to CubeLoop / `cubeloop`.
-GitHub keeps the same repository (renamed in place to `cubeplexai/cubeloop`).
-The docs site is https://cubeloop.dev.
+0.14 把项目从 CubePi / `cubepi` 更名为 CubeLoop / `cubeloop`。
+GitHub 仓库原地改名为 `cubeplexai/cubeloop`。文档站是 https://cubeloop.dev。
 
-## Install and imports
+## 安装与导入
 
 ```bash
 pip install cubeloop
-# extras are unchanged: cubeloop[sqlite], cubeloop[postgres], cubeloop[mysql], …
+# extras 不变：cubeloop[sqlite]、cubeloop[postgres]、cubeloop[mysql]、…
 ```
 
 ```python
@@ -21,36 +20,102 @@ from cubeloop import Agent, tool
 from cubeloop.providers.anthropic import AnthropicProvider
 ```
 
-`pip install -U cubepi` still works: 0.14+ is a wrapper that depends on
-`cubeloop==0.14.0`, re-exports the public API, and aliases `cubepi.*` imports.
-It warns on first import. Prefer depending on `cubeloop` directly.
+`pip install -U cubepi` 仍然可用：0.14+ 是一层包装，依赖
+`cubeloop==0.14.0`，再导出公共 API，并把 `cubepi.*` 导入别名到新包。
+第一次 `import cubepi` 会告警。请直接依赖 `cubeloop`。
 
-CLI: `cubeloop trace` (the wrapper still provides `cubepi trace` and warns).
+CLI：`cubeloop trace`（包装层仍提供 `cubepi trace`，并告警）。
 
 ## Checkpointer schema v5 → v6
 
-Postgres and MySQL table names moved from `cubepi_*` to `cubeloop_*`.
-SQLite table names were never prefixed; they stay `messages` / `runs` / ….
+Postgres 和 MySQL 表名从 `cubepi_*` 改成 `cubeloop_*`。
+SQLite 表名从未加前缀，仍是 `messages` / `runs` / …。
 
-Existing databases: add an Alembic revision that runs
-`upgrade_v5_to_v6_op()` then `write_schema_version_op()`. Opening 0.14 against
-an unmigrated v5 database raises `CubeloopSchemaMismatch` pointing at that
-helper — not “tables not found”.
+已有数据库：加一条 Alembic revision，先跑 `upgrade_v5_to_v6_op()`，再跑
+`write_schema_version_op()`。用 0.14 打开未迁移的 v5 库会抛
+`CubeloopSchemaMismatch`，并指向这个 helper — 不是「表不存在」。
 
-If you have data tables but no `*_schema_version` table, do not apply the
-fresh v6 CREATE TABLE. Create `cubepi_schema_version` with version 5 first,
-then run the v5→v6 helper.
+如果有数据表但没有 `*_schema_version` 表，不要跑全新的 v6 CREATE TABLE。
+先创建 `cubepi_schema_version` 并写入 version 5，再跑 v5→v6 helper。
+
+包升级和这条 revision **必须一起上**。进程已经 import 0.14、却对着仍是
+v5 的库打开 checkpointer，会拒绝启动。
+
+### 不要把历史 helper 的 import 一刀切改掉
+
+0.14 把 Alembic helper 分成两类：
+
+| Helper | 0.14 发出的 SQL |
+|---|---|
+| `create_message_partitions_op()`、`create_runs_partitions_op()` | **当前**名字：`cubeloop_messages_pXX PARTITION OF cubeloop_messages`，runs 同理。仅 Postgres。 |
+| `add_pending_request_column_op()`、`add_run_id_column_op()`、`upgrade_v3_to_v4_op()`、`upgrade_v4_to_v5_op()` | **历史**名字：仍是 `cubepi_*`。可以从 `cubeloop.checkpointer.postgres.alembic_helpers` 导入。 |
+| `write_schema_version_op()` | 把 `EXPECTED_SCHEMA_VERSION`（现在是 **6**）写进已存在的 `cubeloop_schema_version`，否则写进 `cubepi_schema_version`。 |
+
+常见的 host v1 revision 会先 `CREATE cubepi_messages`，再调用
+`create_message_partitions_op()`。依赖 cubeloop 0.14 之后，同一次调用会发出
+`PARTITION OF cubeloop_messages`。空库 `alembic upgrade head`（从头 replay
+v1→v6）会在 v1 失败：cubeloop 父表还不存在。
+
+**改法：** 历史 revision 里不要再调用 `create_message_partitions_op()`。
+把原来的 SQL 内联到旧父表上：
+
+```sql
+CREATE TABLE cubepi_messages_p00
+  PARTITION OF cubepi_messages
+  FOR VALUES WITH (modulus 64, remainder 0);
+-- … p01 … p63
+```
+
+如果某条历史 revision 调用过 `create_runs_partitions_op()`，同样会踩坑。
+CubeLoop 自带的 `upgrade_v3_to_v4_op()` 已经内联了 `cubepi_runs_pXX`，可以安全导入。
+
+内联要发生在去掉 `cubepi` 包 **之前**（或与 pin 同一批改动）。中间不要对空库跑
+Alembic：v1 在你改完剩余 helper import 之前仍是 `import cubepi.checkpointer…`，
+pin 之后这个模块就不在了。
+
+`write_schema_version_op()` 在 v1 replay 时写入 6 是故意的 — 它一直写的是
+*当前* expected version，`alembic upgrade head` 会一次跑完 v1→v6。不要改成手写
+1/2/3/4/5。
+
+### Autogenerate 可能 DROP `cubepi_threads`
+
+`cubeloop_metadata` 描述的是 **新** 名字。Alembic `target_metadata` 指过去之后，
+仍停在 v5 的库里却是 `cubepi_*`。Autogenerate 会提议 `DROP cubepi_*` 再
+`CREATE cubeloop_*`（空表）。最常见的受害者是 `cubepi_threads`：很多 host 的 v1
+是 autogen 建出来的，从未放进排除列表。
+
+这次 DROP 会 CASCADE 掉 messages、runs 和 HITL answers。
+
+**改法：生成 v6 revision 之前，先在 `env.py` 里把两代表都排除：**
+
+- 表：`cubepi_threads`、`cubepi_messages`、`cubepi_runs`、
+  `cubepi_hitl_answers`、`cubepi_schema_version`，以及对应的 `cubeloop_*`。
+- Postgres 分区：前缀 `cubepi_messages_p`、`cubepi_runs_p`、
+  `cubeloop_messages_p`、`cubeloop_runs_p`。
+
+检查生成出来的 v6 文件：不能出现 `DROP TABLE cubepi_threads`，也不能出现全新的
+`CREATE TABLE cubeloop_*`。正文应是 `upgrade_v5_to_v6_op()` 加上
+`write_schema_version_op()`。
+
+### Downgrade 是反向 rename，不是 DROP
+
+`upgrade_v5_to_v6_op()` 会 rename 父表、**每一张** 64 张 message 分区和 64 张
+run 分区（Postgres）、HITL 和 version 表，以及 `ix_cubepi_*` 索引。PostgreSQL
+对分区父表做 `ALTER TABLE … RENAME TO` **不会** 改子分区名字。
+
+从更早的 bump 抄 `DROP TABLE cubeloop_runs CASCADE` 会删掉全部会话。应该反向
+rename（含每一张分区），再把 version 5 写回 `cubepi_schema_version`。
 
 ## Tracing
 
-New spans use `cubeloop.*` attributes and `cubeloop.turn` span names.
-`cubeloop trace` still reads 0.13 JSONL that used `cubepi.*`.
-Dashboards you own need their own attribute-name update.
+新 span 使用 `cubeloop.*` 属性和 `cubeloop.turn` span 名。
+`cubeloop trace` 仍能读 0.13 里用 `cubepi.*` 的 JSONL。
+你自己的 dashboard 需要改属性名。
 
-Default JSONL directory is `./cubeloop-traces`.
+默认 JSONL 目录是 `./cubeloop-traces`。不会自动回退到 `./cubepi-traces`；读旧文件请传
+`--dir`（或沿用你原来的配置路径）。
 
-## Environment variables
+## 环境变量
 
-`CUBELOOP_TEST_PG_DSN`, `CUBELOOP_TEST_MYSQL_DSN`, `CUBELOOP_PG_DSN`,
-`CUBELOOP_MYSQL_DSN` replace the `CUBEPI_*` names. The old names are still
-read if the new one is unset, for the rest of 0.x.
+`CUBELOOP_TEST_PG_DSN`、`CUBELOOP_TEST_MYSQL_DSN`、`CUBELOOP_PG_DSN`、
+`CUBELOOP_MYSQL_DSN` 替换原来的 `CUBEPI_*`。新名字未设置时，0.x 剩余周期内仍会读旧名字。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.14/guides/checkpointing/mysql.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.14/guides/checkpointing/mysql.md
@@ -206,7 +206,8 @@ def upgrade():
             op.execute(stmt)
 ```
 
-不要对 v5 数据库跑 v6 的 `CREATE TABLE` helper。详见
+不要对 v5 数据库跑 v6 的 `CREATE TABLE` helper。Host Alembic 的常见坑
+（autogenerate 可能 DROP `cubepi_*`、downgrade 用 DROP 而不是反向 rename）写在
 [从 cubepi 迁移](../../migration/from-cubepi)。
 
 ## 常见陷阱

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.14/guides/checkpointing/postgres.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.14/guides/checkpointing/postgres.md
@@ -218,7 +218,10 @@ def upgrade():
 ```
 
 不要对 v5 数据库跑 v6 的 `CREATE TABLE` helper——旧表已经在，只是名字还是 `cubepi_*`。
-详见 [从 cubepi 迁移](../../migration/from-cubepi)。
+
+Host Alembic 的常见坑（历史 `create_message_partitions_op()` 现在发出 cubeloop
+名字、autogenerate 可能 DROP `cubepi_threads`、downgrade 用 DROP 而不是反向
+rename 分区）写在 [从 cubepi 迁移](../../migration/from-cubepi)。
 
 ## 常见坑
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.14/migration/from-cubepi.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/version-0.14/migration/from-cubepi.md
@@ -1,19 +1,18 @@
 ---
 title: From cubepi
-description: "CubePi was renamed to CubeLoop in 0.14. How to update installs, imports, checkpointer schema, and traces."
+description: "CubePi 在 0.14 更名为 CubeLoop。如何更新安装、导入、checkpointer schema 和 traces。"
 ---
 
-# Migrating from cubepi
+# 从 cubepi 迁移
 
-0.14 renames the project from CubePi / `cubepi` to CubeLoop / `cubeloop`.
-GitHub keeps the same repository (renamed in place to `cubeplexai/cubeloop`).
-The docs site is https://cubeloop.dev.
+0.14 把项目从 CubePi / `cubepi` 更名为 CubeLoop / `cubeloop`。
+GitHub 仓库原地改名为 `cubeplexai/cubeloop`。文档站是 https://cubeloop.dev。
 
-## Install and imports
+## 安装与导入
 
 ```bash
 pip install cubeloop
-# extras are unchanged: cubeloop[sqlite], cubeloop[postgres], cubeloop[mysql], …
+# extras 不变：cubeloop[sqlite]、cubeloop[postgres]、cubeloop[mysql]、…
 ```
 
 ```python
@@ -21,36 +20,102 @@ from cubeloop import Agent, tool
 from cubeloop.providers.anthropic import AnthropicProvider
 ```
 
-`pip install -U cubepi` still works: 0.14+ is a wrapper that depends on
-`cubeloop==0.14.0`, re-exports the public API, and aliases `cubepi.*` imports.
-It warns on first import. Prefer depending on `cubeloop` directly.
+`pip install -U cubepi` 仍然可用：0.14+ 是一层包装，依赖
+`cubeloop==0.14.0`，再导出公共 API，并把 `cubepi.*` 导入别名到新包。
+第一次 `import cubepi` 会告警。请直接依赖 `cubeloop`。
 
-CLI: `cubeloop trace` (the wrapper still provides `cubepi trace` and warns).
+CLI：`cubeloop trace`（包装层仍提供 `cubepi trace`，并告警）。
 
 ## Checkpointer schema v5 → v6
 
-Postgres and MySQL table names moved from `cubepi_*` to `cubeloop_*`.
-SQLite table names were never prefixed; they stay `messages` / `runs` / ….
+Postgres 和 MySQL 表名从 `cubepi_*` 改成 `cubeloop_*`。
+SQLite 表名从未加前缀，仍是 `messages` / `runs` / …。
 
-Existing databases: add an Alembic revision that runs
-`upgrade_v5_to_v6_op()` then `write_schema_version_op()`. Opening 0.14 against
-an unmigrated v5 database raises `CubeloopSchemaMismatch` pointing at that
-helper — not “tables not found”.
+已有数据库：加一条 Alembic revision，先跑 `upgrade_v5_to_v6_op()`，再跑
+`write_schema_version_op()`。用 0.14 打开未迁移的 v5 库会抛
+`CubeloopSchemaMismatch`，并指向这个 helper — 不是「表不存在」。
 
-If you have data tables but no `*_schema_version` table, do not apply the
-fresh v6 CREATE TABLE. Create `cubepi_schema_version` with version 5 first,
-then run the v5→v6 helper.
+如果有数据表但没有 `*_schema_version` 表，不要跑全新的 v6 CREATE TABLE。
+先创建 `cubepi_schema_version` 并写入 version 5，再跑 v5→v6 helper。
+
+包升级和这条 revision **必须一起上**。进程已经 import 0.14、却对着仍是
+v5 的库打开 checkpointer，会拒绝启动。
+
+### 不要把历史 helper 的 import 一刀切改掉
+
+0.14 把 Alembic helper 分成两类：
+
+| Helper | 0.14 发出的 SQL |
+|---|---|
+| `create_message_partitions_op()`、`create_runs_partitions_op()` | **当前**名字：`cubeloop_messages_pXX PARTITION OF cubeloop_messages`，runs 同理。仅 Postgres。 |
+| `add_pending_request_column_op()`、`add_run_id_column_op()`、`upgrade_v3_to_v4_op()`、`upgrade_v4_to_v5_op()` | **历史**名字：仍是 `cubepi_*`。可以从 `cubeloop.checkpointer.postgres.alembic_helpers` 导入。 |
+| `write_schema_version_op()` | 把 `EXPECTED_SCHEMA_VERSION`（现在是 **6**）写进已存在的 `cubeloop_schema_version`，否则写进 `cubepi_schema_version`。 |
+
+常见的 host v1 revision 会先 `CREATE cubepi_messages`，再调用
+`create_message_partitions_op()`。依赖 cubeloop 0.14 之后，同一次调用会发出
+`PARTITION OF cubeloop_messages`。空库 `alembic upgrade head`（从头 replay
+v1→v6）会在 v1 失败：cubeloop 父表还不存在。
+
+**改法：** 历史 revision 里不要再调用 `create_message_partitions_op()`。
+把原来的 SQL 内联到旧父表上：
+
+```sql
+CREATE TABLE cubepi_messages_p00
+  PARTITION OF cubepi_messages
+  FOR VALUES WITH (modulus 64, remainder 0);
+-- … p01 … p63
+```
+
+如果某条历史 revision 调用过 `create_runs_partitions_op()`，同样会踩坑。
+CubeLoop 自带的 `upgrade_v3_to_v4_op()` 已经内联了 `cubepi_runs_pXX`，可以安全导入。
+
+内联要发生在去掉 `cubepi` 包 **之前**（或与 pin 同一批改动）。中间不要对空库跑
+Alembic：v1 在你改完剩余 helper import 之前仍是 `import cubepi.checkpointer…`，
+pin 之后这个模块就不在了。
+
+`write_schema_version_op()` 在 v1 replay 时写入 6 是故意的 — 它一直写的是
+*当前* expected version，`alembic upgrade head` 会一次跑完 v1→v6。不要改成手写
+1/2/3/4/5。
+
+### Autogenerate 可能 DROP `cubepi_threads`
+
+`cubeloop_metadata` 描述的是 **新** 名字。Alembic `target_metadata` 指过去之后，
+仍停在 v5 的库里却是 `cubepi_*`。Autogenerate 会提议 `DROP cubepi_*` 再
+`CREATE cubeloop_*`（空表）。最常见的受害者是 `cubepi_threads`：很多 host 的 v1
+是 autogen 建出来的，从未放进排除列表。
+
+这次 DROP 会 CASCADE 掉 messages、runs 和 HITL answers。
+
+**改法：生成 v6 revision 之前，先在 `env.py` 里把两代表都排除：**
+
+- 表：`cubepi_threads`、`cubepi_messages`、`cubepi_runs`、
+  `cubepi_hitl_answers`、`cubepi_schema_version`，以及对应的 `cubeloop_*`。
+- Postgres 分区：前缀 `cubepi_messages_p`、`cubepi_runs_p`、
+  `cubeloop_messages_p`、`cubeloop_runs_p`。
+
+检查生成出来的 v6 文件：不能出现 `DROP TABLE cubepi_threads`，也不能出现全新的
+`CREATE TABLE cubeloop_*`。正文应是 `upgrade_v5_to_v6_op()` 加上
+`write_schema_version_op()`。
+
+### Downgrade 是反向 rename，不是 DROP
+
+`upgrade_v5_to_v6_op()` 会 rename 父表、**每一张** 64 张 message 分区和 64 张
+run 分区（Postgres）、HITL 和 version 表，以及 `ix_cubepi_*` 索引。PostgreSQL
+对分区父表做 `ALTER TABLE … RENAME TO` **不会** 改子分区名字。
+
+从更早的 bump 抄 `DROP TABLE cubeloop_runs CASCADE` 会删掉全部会话。应该反向
+rename（含每一张分区），再把 version 5 写回 `cubepi_schema_version`。
 
 ## Tracing
 
-New spans use `cubeloop.*` attributes and `cubeloop.turn` span names.
-`cubeloop trace` still reads 0.13 JSONL that used `cubepi.*`.
-Dashboards you own need their own attribute-name update.
+新 span 使用 `cubeloop.*` 属性和 `cubeloop.turn` span 名。
+`cubeloop trace` 仍能读 0.13 里用 `cubepi.*` 的 JSONL。
+你自己的 dashboard 需要改属性名。
 
-Default JSONL directory is `./cubeloop-traces`.
+默认 JSONL 目录是 `./cubeloop-traces`。不会自动回退到 `./cubepi-traces`；读旧文件请传
+`--dir`（或沿用你原来的配置路径）。
 
-## Environment variables
+## 环境变量
 
-`CUBELOOP_TEST_PG_DSN`, `CUBELOOP_TEST_MYSQL_DSN`, `CUBELOOP_PG_DSN`,
-`CUBELOOP_MYSQL_DSN` replace the `CUBEPI_*` names. The old names are still
-read if the new one is unset, for the rest of 0.x.
+`CUBELOOP_TEST_PG_DSN`、`CUBELOOP_TEST_MYSQL_DSN`、`CUBELOOP_PG_DSN`、
+`CUBELOOP_MYSQL_DSN` 替换原来的 `CUBEPI_*`。新名字未设置时，0.x 剩余周期内仍会读旧名字。

--- a/website/versioned_docs/version-0.14/guides/checkpointing/mysql.md
+++ b/website/versioned_docs/version-0.14/guides/checkpointing/mysql.md
@@ -279,7 +279,9 @@ def upgrade():
             op.execute(stmt)
 ```
 
-Do not run the v6 `CREATE TABLE` helpers against a v5 database. See the
+Do not run the v6 `CREATE TABLE` helpers against a v5 database.
+Host Alembic traps (autogenerate dropping `cubepi_*` tables, downgrade that
+`DROP`s instead of reverse-renaming) are in the
 [migration guide](../../migration/from-cubepi).
 
 ## Common pitfalls

--- a/website/versioned_docs/version-0.14/guides/checkpointing/postgres.md
+++ b/website/versioned_docs/version-0.14/guides/checkpointing/postgres.md
@@ -265,7 +265,11 @@ def upgrade():
 
 Do not run the v6 `CREATE TABLE` helpers against a v5 database — they
 would try to create tables that already exist under the old names.
-See the [migration guide](../../migration/from-cubepi).
+
+Host Alembic traps (historical `create_message_partitions_op()` now
+emitting cubeloop names, autogenerate dropping `cubepi_threads`,
+downgrade that `DROP`s instead of reverse-renaming partitions) are
+documented in the [migration guide](../../migration/from-cubepi).
 
 ## Common pitfalls
 

--- a/website/versioned_docs/version-0.14/migration/from-cubepi.md
+++ b/website/versioned_docs/version-0.14/migration/from-cubepi.md
@@ -41,13 +41,94 @@ If you have data tables but no `*_schema_version` table, do not apply the
 fresh v6 CREATE TABLE. Create `cubepi_schema_version` with version 5 first,
 then run the v5→v6 helper.
 
+Ship the package bump and this revision **together**. A process that imports
+0.14 and then opens the checkpointer against a still-v5 database will refuse
+to start.
+
+### Do not retarget historical helpers blindly
+
+0.14 split the Alembic helpers into two kinds:
+
+| Helper | SQL it emits in 0.14 |
+|---|---|
+| `create_message_partitions_op()`, `create_runs_partitions_op()` | **Current** names: `cubeloop_messages_pXX PARTITION OF cubeloop_messages`, same for runs. Postgres only. |
+| `add_pending_request_column_op()`, `add_run_id_column_op()`, `upgrade_v3_to_v4_op()`, `upgrade_v4_to_v5_op()` | **Historical** names: still `cubepi_*`. Safe to import from `cubeloop.checkpointer.postgres.alembic_helpers`. |
+| `write_schema_version_op()` | Writes `EXPECTED_SCHEMA_VERSION` (now **6**) to `cubeloop_schema_version` if that table exists, else to `cubepi_schema_version`. |
+
+A typical host v1 revision created `cubepi_messages` and then called
+`create_message_partitions_op()`. After you depend on cubeloop 0.14, that
+same call emits `PARTITION OF cubeloop_messages`. A greenfield
+`alembic upgrade head` (empty database replaying v1→v6) dies at v1:
+the cubeloop parent does not exist yet.
+
+**Fix:** stop calling `create_message_partitions_op()` from that historical
+revision. Inline the original SQL against the old parent:
+
+```sql
+CREATE TABLE cubepi_messages_p00
+  PARTITION OF cubepi_messages
+  FOR VALUES WITH (modulus 64, remainder 0);
+-- … p01 … p63
+```
+
+The same trap applies if a historical revision called
+`create_runs_partitions_op()`. CubeLoop's own `upgrade_v3_to_v4_op()`
+already inlines `cubepi_runs_pXX` and is safe.
+
+Do the inline **before** (or in the same change as) removing the `cubepi`
+package. Do not run Alembic against an empty database in between: v1 still
+`import cubepi.checkpointer…` until you retarget the remaining helper
+imports, and after the pin that module is gone.
+
+`write_schema_version_op()` writing 6 from a v1 replay is intentional —
+it has always written the *current* expected version, and `alembic upgrade
+head` runs v1→v6 in one shot. Do not rewrite those calls to insert
+historical 1/2/3/4/5 by hand.
+
+### Autogenerate can drop `cubepi_threads`
+
+`cubeloop_metadata` describes the **new** names. After you point Alembic
+`target_metadata` at it, a database that is still on v5 still has
+`cubepi_*` tables. Autogenerate then proposes `DROP cubepi_*` and
+`CREATE cubeloop_*` (empty). `cubepi_threads` is the usual casualty:
+many hosts let autogen create it in v1 and never put it on an exclusion
+list.
+
+That drop cascades onto messages, runs, and HITL answers.
+
+**Fix, in `env.py`, before generating the v6 revision:** exclude both
+generations from autogenerate:
+
+- Tables: `cubepi_threads`, `cubepi_messages`, `cubepi_runs`,
+  `cubepi_hitl_answers`, `cubepi_schema_version`, and the matching
+  `cubeloop_*` names.
+- Postgres partitions: prefixes `cubepi_messages_p`, `cubepi_runs_p`,
+  `cubeloop_messages_p`, `cubeloop_runs_p`.
+
+Inspect the generated v6 revision: it must not contain
+`DROP TABLE cubepi_threads` or a fresh `CREATE TABLE cubeloop_*`. The
+body should be `upgrade_v5_to_v6_op()` plus `write_schema_version_op()`.
+
+### Downgrade is a reverse rename, not DROP
+
+`upgrade_v5_to_v6_op()` renames parents, **each** of the 64 message and
+64 run partitions (Postgres), the HITL and version tables, and
+`ix_cubepi_*` indexes. PostgreSQL `ALTER TABLE … RENAME TO` on a
+partitioned parent does **not** rename children.
+
+A downgrade copied from an older bump (`DROP TABLE cubeloop_runs
+CASCADE`) deletes every conversation. Reverse-rename instead, including
+every partition, then write version 5 into `cubepi_schema_version`.
+
 ## Tracing
 
 New spans use `cubeloop.*` attributes and `cubeloop.turn` span names.
 `cubeloop trace` still reads 0.13 JSONL that used `cubepi.*`.
 Dashboards you own need their own attribute-name update.
 
-Default JSONL directory is `./cubeloop-traces`.
+Default JSONL directory is `./cubeloop-traces`. There is no automatic
+fallback to `./cubepi-traces`; pass `--dir` (or keep your config path)
+to read leftover files.
 
 ## Environment variables
 


### PR DESCRIPTION
## Summary

The 0.14 from-cubepi page told hosts to add `upgrade_v5_to_v6_op()` but
not how their **existing** Alembic history interacts with the renamed
helpers. CubePlex's cutover review hit three of these:

1. **Historical `create_message_partitions_op()`** now emits
   `PARTITION OF cubeloop_messages`. A v1 revision that created
   `cubepi_messages` then called that helper fails on greenfield
   `alembic upgrade head`. Inline the original `cubepi_messages_pXX`
   SQL instead.
2. **Autogenerate** after pointing `target_metadata` at
   `cubeloop_metadata` proposes `DROP cubepi_threads` (often never
   excluded) on a still-v5 database.
3. **Downgrade** copied from an older bump (`DROP TABLE … CASCADE`)
   deletes conversation history. Parent `RENAME` does not rename the
   128 Postgres partitions.

Also: ship the package bump and the v6 revision together;
`write_schema_version_op()` writing 6 from a v1 replay is the existing
contract.

## Docs

- `website/docs/migration/from-cubepi.md` + zh-Hans current
- `website/versioned_docs/version-0.14/…` (0.14 is the migrate release)
- Short pointers from the Postgres/MySQL checkpointing guides and the
  postgres checkpointer README